### PR TITLE
ci: add commitlint and PR template

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,32 @@
+extends:
+  - "@commitlint/config-conventional"
+
+rules:
+  type-enum:
+    - 2
+    - always
+    - - feat
+      - fix
+      - docs
+      - chore
+      - refactor
+      - test
+      - perf
+      - ci
+      - build
+      - revert
+  subject-case:
+    - 2
+    - never
+    - - sentence-case
+      - start-case
+      - pascal-case
+      - upper-case
+  header-max-length:
+    - 2
+    - always
+    - 72
+  body-max-line-length:
+    - 1
+    - always
+    - 100

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- 1-3 bullet points describing what this PR does -->
+
+-
+
+## Motivation
+
+<!-- Why is this change needed? Link to issue if applicable: Closes #XX -->
+
+## Test plan
+
+<!-- How was this tested? -->
+
+- [ ] `go test -race ./...` passes
+- [ ] `task check` passes
+- [ ] Manual verification (describe below)
+
+## Checklist
+
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No secrets or credentials included
+- [ ] Breaking changes documented (if any)

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,18 @@
+name: Commitlint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: wagoid/commitlint-github-action@v6


### PR DESCRIPTION
## Summary

- Add `wagoid/commitlint-github-action@v6` to enforce conventional commits on all PRs
- Add `.commitlintrc.yml` with conventional commit type rules (`feat`, `fix`, `docs`, `chore`, etc.)
- Add `.github/pull_request_template.md` with summary, motivation, test plan, and checklist

## Motivation

Closes #46 — standardize commit messages and PR descriptions across the repo. CI-only enforcement (no local npm install needed). The action bundles commitlint internally.

## Test plan

- [x] Commit message on this PR follows conventional format (self-validating)
- [x] PR template renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Established commit message validation standards with linting rules
  * Added standardized pull request template for consistent contributions
  * Configured automated GitHub Actions workflow for commit validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->