### PR TITLE
fix: update feed health tests for dynamic discovery

### DIFF
--- a/tui/tests/test_data.py
+++ b/tui/tests/test_data.py
@@ -290,11 +290,23 @@ class TestReadFeedHealth:
         assert project.healthy is True  # Disabled = healthy
 
     def test_empty_feeds_config(self):
-        # With no feeds key, defaults apply for the 5 builtin feed names
+        # No feeds in config → no feed health entries (dynamic discovery)
         feeds = read_feed_health({}, {})
-        # Empty feeds dict → empty defaults for each feed → still 5 entries
-        # because the code iterates the 5 builtin names
-        assert isinstance(feeds, list)
+        assert feeds == []
+
+    def test_discovers_unknown_feed_dynamically(self):
+        """Any key under feeds: is discovered — no hardcoded list."""
+        config = {
+            "feeds": {
+                "brand_new_feed": {"enabled": True, "interval_seconds": 42},
+            }
+        }
+        cache = {}
+        feeds = read_feed_health(config, cache)
+        assert len(feeds) == 1
+        assert feeds[0].name == "brand_new_feed"
+        assert feeds[0].interval_seconds == 42
+        assert feeds[0].healthy is False  # Enabled but no cache entry
 
 
 # --- read_insights ---


### PR DESCRIPTION
## Summary

- Fix stale test comments that referenced old hardcoded feed list
- Add `test_discovers_unknown_feed_dynamically` proving any arbitrary feed name is discovered from config without hardcoding

## Motivation

Closes #23 — the core fix (deriving builtins dynamically from config keys in `data.py:read_feed_health`) was already applied in a previous session. This PR updates tests to match and adds a regression test.

## Test plan

- [x] `cd tui && .venv/bin/python -m pytest tests/test_data.py::TestReadFeedHealth -v` — 3/3 pass
- [x] New test uses `brand_new_feed` (not a real feed) to prove dynamic discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feed discovery now dynamically detects all configured feeds instead of relying on hardcoded defaults.
  * Feed health reporting correctly handles configurations with no feeds.

* **Tests**
  * Added test coverage for dynamic feed discovery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->