### PR TITLE
doctor: hook-safety suite (sprawl, binaries, network, duplicates)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -98,7 +98,7 @@ tasks:
       # the install target) doesn't break the race detector build.
       CGO_ENABLED: "1"
     cmds:
-      - go test -race -p {{.TEST_PARALLEL}} ./internal/core/... ./internal/feeds/... ./internal/bridge/... ./internal/analytics/... ./internal/notifications/... ./internal/migration/... ./pkg/...
+      - go test -race -p {{.TEST_PARALLEL}} ./internal/core/... ./internal/feeds/... ./internal/bridge/... ./internal/analytics/... ./internal/notifications/... ./internal/migration/... ./internal/hooks/... ./pkg/...
 
   test:go:contract:
     desc: "Contract parity tests (33 JSON fixtures)"

--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -166,7 +166,18 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 // guards) and renders the findings. Returns (warnings, fails) so the caller can
 // fold them into the doctor summary.
 func checkHookSafety(w io.Writer) (warnings, fails int) {
-	inv, _ := hooks.Scan(hooks.DefaultSettingsPaths())
+	inv, err := hooks.Scan(hooks.DefaultSettingsPaths())
+	if err != nil {
+		// Scan currently never returns a non-nil error (malformed files are
+		// recorded in inv.ParseErrors), but handle it defensively.
+		fmt.Fprintf(w, "WARN  hooks: settings scan failed: %v\n", err)
+		warnings++
+	}
+	// Surface any settings files that could not be parsed.
+	for _, pe := range inv.ParseErrors {
+		fmt.Fprintf(w, "WARN  hook-settings: %s could not be parsed: %v\n", pe.File, pe.Err)
+		warnings++
+	}
 	for _, f := range hooks.AllFindings(inv, nil) {
 		renderHookFinding(w, f)
 		switch f.Level {

--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vishnujayvel/hookwise/internal/analytics"
 	"github.com/vishnujayvel/hookwise/internal/core"
 	"github.com/vishnujayvel/hookwise/internal/feeds"
+	"github.com/vishnujayvel/hookwise/internal/hooks"
 	"gopkg.in/yaml.v3"
 )
 
@@ -125,6 +126,15 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 	warnings += checkFeedHealth(w, filepath.Join(stateDir, "state"), feedCfg)
 
+	// Check 7: Hook safety — scan Claude Code settings for hook sprawl, missing
+	// binaries, network-dependent hot-path hooks, and duplicate/overlapping
+	// guards (issues #33-36).
+	hookWarnings, hookFails := checkHookSafety(w)
+	warnings += hookWarnings
+	if hookFails > 0 {
+		allOK = false
+	}
+
 	// Check 6: Recent warnings.
 	recentWarnings := core.ReadWarnings(stateDir)
 	if len(recentWarnings) == 0 {
@@ -149,6 +159,44 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// checkHookSafety scans Claude Code settings for hook-safety issues (sprawl,
+// missing binaries, network-dependent hot-path hooks, duplicate/overlapping
+// guards) and renders the findings. Returns (warnings, fails) so the caller can
+// fold them into the doctor summary.
+func checkHookSafety(w io.Writer) (warnings, fails int) {
+	inv, _ := hooks.Scan(hooks.DefaultSettingsPaths())
+	for _, f := range hooks.AllFindings(inv, nil) {
+		renderHookFinding(w, f)
+		switch f.Level {
+		case hooks.LevelWarn, hooks.LevelInfo:
+			warnings++
+		case hooks.LevelFail:
+			fails++
+		}
+	}
+	return warnings, fails
+}
+
+// renderHookFinding prints a finding in the doctor's house style:
+//
+//	LEVEL  code: message
+//	        <8-space breakdown for SCAN>
+//	       → <remediation for WARN/FAIL/INFO>
+//	       • <bullet detail>
+func renderHookFinding(w io.Writer, f hooks.Finding) {
+	fmt.Fprintf(w, "%-5s %s: %s\n", f.Level, f.Code, f.Message)
+	for _, d := range f.Details {
+		switch {
+		case f.Level == hooks.LevelScan:
+			fmt.Fprintf(w, "        %s\n", d)
+		case strings.HasPrefix(d, "• "):
+			fmt.Fprintf(w, "       %s\n", d)
+		default:
+			fmt.Fprintf(w, "       → %s\n", d)
+		}
+	}
 }
 
 // checkFeedHealth reads feed cache files and reports placeholder/stale feeds.

--- a/internal/hooks/analyze.go
+++ b/internal/hooks/analyze.go
@@ -1,0 +1,310 @@
+package hooks
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Severity levels for doctor findings, rendered as the leading column.
+const (
+	LevelScan = "SCAN"
+	LevelPass = "PASS"
+	LevelInfo = "INFO"
+	LevelWarn = "WARN"
+	LevelFail = "FAIL"
+)
+
+// Finding is one doctor result line plus optional indented detail lines.
+type Finding struct {
+	Level   string   // LevelScan/Info/Warn/Fail
+	Code    string   // short tag, e.g. "hook-sprawl"
+	Message string   // the headline after "LEVEL  code: "
+	Details []string // indented follow-up lines (remediation, breakdown)
+}
+
+// pluralHooks renders a hook count with correct singular/plural ("1 hook",
+// "2 hooks").
+func pluralHooks(n int) string {
+	if n == 1 {
+		return "1 hook"
+	}
+	return fmt.Sprintf("%d hooks", n)
+}
+
+// hotPathEvents are the high-frequency events where per-call cost matters most.
+var hotPathEvents = map[string]bool{
+	"PreToolUse":  true,
+	"PostToolUse": true,
+}
+
+// ---------------------------------------------------------------------------
+// #34 — inventory + sprawl
+// ---------------------------------------------------------------------------
+
+// eventCount pairs an event with its hook count for stable sorting.
+type eventCount struct {
+	Event string
+	Count int
+}
+
+// sortedEventCounts returns per-event counts ordered by count desc, then name asc.
+func sortedEventCounts(inv *Inventory) []eventCount {
+	counts := inv.CountByEvent()
+	out := make([]eventCount, 0, len(counts))
+	for ev, c := range counts {
+		out = append(out, eventCount{ev, c})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Event < out[j].Event
+	})
+	return out
+}
+
+// InventoryFinding produces the SCAN line summarizing total hooks + per-event
+// breakdown (issue #34 F1.1).
+func InventoryFinding(inv *Inventory) Finding {
+	ecs := sortedEventCounts(inv)
+	var details []string
+	for _, ec := range ecs {
+		details = append(details, fmt.Sprintf("%-14s %s", ec.Event+":", pluralHooks(ec.Count)))
+	}
+	return Finding{
+		Level:   LevelScan,
+		Code:    "hooks",
+		Message: fmt.Sprintf("%d hooks across %d events", len(inv.Entries), len(ecs)),
+		Details: details,
+	}
+}
+
+// sprawlThreshold returns (warn, fail) hook-count thresholds for an event.
+func sprawlThreshold(event string) (warn, fail int) {
+	if hotPathEvents[event] {
+		return 5, 10
+	}
+	return 3, 8
+}
+
+// SprawlFindings flags events whose hook count exceeds the WARN/FAIL threshold
+// (issue #34 F1.2).
+func SprawlFindings(inv *Inventory) []Finding {
+	var out []Finding
+	for _, ec := range sortedEventCounts(inv) {
+		warn, fail := sprawlThreshold(ec.Event)
+		level := ""
+		threshold := warn
+		switch {
+		case ec.Count > fail:
+			level, threshold = LevelFail, fail
+		case ec.Count > warn:
+			level, threshold = LevelWarn, warn
+		}
+		if level == "" {
+			continue
+		}
+		out = append(out, Finding{
+			Level:   level,
+			Code:    "hook-sprawl",
+			Message: fmt.Sprintf("%s has %d hooks (threshold: %d)", ec.Event, ec.Count, threshold),
+			Details: []string{"Every matching event spawns these processes. Consider consolidating."},
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// #33 — missing binary
+// ---------------------------------------------------------------------------
+
+// commandBinary returns the executable name from a hook command string (the
+// first whitespace-delimited token). Returns "" for an empty command.
+func commandBinary(command string) string {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// MissingBinaryFindings flags hook binaries not resolvable on PATH (issue #33
+// F1.3). lookPath is injected so tests are hermetic; production passes
+// exec.LookPath. Each absent binary yields one FAIL with the count of hooks
+// depending on it.
+func MissingBinaryFindings(inv *Inventory, lookPath func(string) (string, error)) []Finding {
+	type stat struct {
+		count   int
+		present bool
+		checked bool
+	}
+	seen := map[string]*stat{}
+	order := []string{}
+	for _, e := range inv.Entries {
+		bin := commandBinary(e.Command)
+		if bin == "" {
+			continue
+		}
+		s, ok := seen[bin]
+		if !ok {
+			s = &stat{}
+			seen[bin] = s
+			order = append(order, bin)
+		}
+		s.count++
+		if !s.checked {
+			_, err := lookPath(bin)
+			s.present = err == nil
+			s.checked = true
+		}
+	}
+
+	var out []Finding
+	for _, bin := range order {
+		s := seen[bin]
+		if s.present {
+			continue
+		}
+		out = append(out, Finding{
+			Level:   LevelFail,
+			Code:    "hook-binary",
+			Message: fmt.Sprintf("%q not found on PATH (used by %d hooks)", bin, s.count),
+			Details: []string{
+				"These hooks will fail silently on every matching event.",
+				fmt.Sprintf("Fix: install %s and put it on PATH, or remove these hooks.", bin),
+			},
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// #35 — network-dependent hooks on hot paths
+// ---------------------------------------------------------------------------
+
+// networkPattern is a substring whose presence in a command implies a
+// network-dependent runner.
+type networkPattern struct {
+	match string
+	why   string
+}
+
+var networkPatterns = []networkPattern{
+	{"uvx ", "uvx resolves Python packages over the network on each invocation."},
+	{"uv run ", "uv run may resolve packages over the network."},
+	{"npx ", "npx resolves Node packages over the network on each invocation."},
+	{"pip install", "pip install fetches packages over the network."},
+	{"curl ", "curl makes a direct network call."},
+	{"wget ", "wget makes a direct network call."},
+	{"docker run ", "docker run may pull an image over the network."},
+}
+
+// NetworkHookFindings flags network-dependent runners used on hot-path events
+// (issue #35 F1.4). Non-hot-path events are not flagged.
+func NetworkHookFindings(inv *Inventory) []Finding {
+	var out []Finding
+	for _, e := range inv.Entries {
+		if !hotPathEvents[e.Event] {
+			continue
+		}
+		// "docker run --pull=never" never pulls — treat as safe.
+		if strings.Contains(e.Command, "docker run") && strings.Contains(e.Command, "--pull=never") {
+			continue
+		}
+		cmd := e.Command + " " // trailing space so a bare "uvx" at end still matches "uvx "
+		for _, p := range networkPatterns {
+			if strings.Contains(cmd, p.match) {
+				out = append(out, Finding{
+					Level:   LevelWarn,
+					Code:    "hook-network",
+					Message: fmt.Sprintf("%s hook uses %q", e.Event, e.Command),
+					Details: []string{
+						p.why,
+						"On hot-path events, this adds latency to every tool call.",
+						"Consider: install the package locally or replace with a compiled binary.",
+					},
+				})
+				break
+			}
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// #36 — duplicates + overlap
+// ---------------------------------------------------------------------------
+
+// knownGuards maps a command substring to a human label for overlap detection.
+var knownGuards = []struct{ match, label string }{
+	{"hookwise dispatch", "hookwise dispatch (hookwise guards)"},
+	{"claude-code-guardian", "claude-code-guardian"},
+	{"skill-routing-guard", "skill-routing-guard"},
+}
+
+// DuplicateFindings flags exact duplicate hooks (same command on the same event)
+// and functional overlap of known guard systems on a single event (issue #36).
+func DuplicateFindings(inv *Inventory) []Finding {
+	// Group entries by event.
+	byEvent := map[string][]HookEntry{}
+	eventOrder := []string{}
+	for _, e := range inv.Entries {
+		if _, ok := byEvent[e.Event]; !ok {
+			eventOrder = append(eventOrder, e.Event)
+		}
+		byEvent[e.Event] = append(byEvent[e.Event], e)
+	}
+	sort.Strings(eventOrder)
+
+	var out []Finding
+	for _, event := range eventOrder {
+		entries := byEvent[event]
+
+		// Exact duplicates: same command string appearing >1 times.
+		cmdCount := map[string]int{}
+		cmdOrder := []string{}
+		for _, e := range entries {
+			if _, ok := cmdCount[e.Command]; !ok {
+				cmdOrder = append(cmdOrder, e.Command)
+			}
+			cmdCount[e.Command]++
+		}
+		for _, cmd := range cmdOrder {
+			if cmdCount[cmd] > 1 {
+				out = append(out, Finding{
+					Level:   LevelWarn,
+					Code:    "hook-duplicate",
+					Message: fmt.Sprintf("%q appears %d times on %s", cmd, cmdCount[cmd], event),
+					Details: []string{"Identical hooks waste resources. Remove the duplicates."},
+				})
+			}
+		}
+
+		// Functional overlap: distinct known guard systems on this event.
+		var labels []string
+		seenLabel := map[string]bool{}
+		for _, e := range entries {
+			for _, g := range knownGuards {
+				if strings.Contains(e.Command, g.match) && !seenLabel[g.label] {
+					seenLabel[g.label] = true
+					labels = append(labels, g.label)
+				}
+			}
+		}
+		if len(labels) > 1 {
+			details := make([]string, 0, len(labels)+1)
+			for _, l := range labels {
+				details = append(details, "• "+l)
+			}
+			details = append(details, "Consider consolidating into a single guard framework.")
+			out = append(out, Finding{
+				Level:   LevelInfo,
+				Code:    "hook-overlap",
+				Message: fmt.Sprintf("%d guard systems detected on %s", len(labels), event),
+				Details: details,
+			})
+		}
+	}
+	return out
+}

--- a/internal/hooks/analyze_test.go
+++ b/internal/hooks/analyze_test.go
@@ -1,0 +1,184 @@
+package hooks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// inv is a tiny builder for an Inventory from (event, command) pairs, all from
+// the same fake source file.
+func inv(pairs ...[2]string) *Inventory {
+	i := &Inventory{}
+	for _, p := range pairs {
+		i.Entries = append(i.Entries, HookEntry{
+			Event: p[0], Command: p[1], Type: "command", SourceFile: "settings.json",
+		})
+	}
+	return i
+}
+
+// --- #34 inventory + sprawl ---
+
+func TestInventoryFinding_TotalsAndPerEvent(t *testing.T) {
+	f := InventoryFinding(inv(
+		[2]string{"PreToolUse", "a"}, [2]string{"PreToolUse", "b"},
+		[2]string{"SessionStart", "c"},
+	))
+	assert.Equal(t, LevelScan, f.Level)
+	assert.Equal(t, "hooks", f.Code)
+	assert.Equal(t, "3 hooks across 2 events", f.Message)
+	// Per-event details sorted by count desc.
+	require.Len(t, f.Details, 2)
+	assert.Contains(t, f.Details[0], "PreToolUse")
+	assert.Contains(t, f.Details[0], "2 hooks")
+	assert.Contains(t, f.Details[1], "SessionStart")
+	assert.Contains(t, f.Details[1], "1 hook")     // singular
+	assert.NotContains(t, f.Details[1], "1 hooks") // not "1 hooks"
+}
+
+func TestSprawlFindings_HotPathThresholds(t *testing.T) {
+	var pairs [][2]string
+	for i := 0; i < 6; i++ { // 6 > 5 WARN, <= 10
+		pairs = append(pairs, [2]string{"PreToolUse", "cmd"})
+	}
+	fs := SprawlFindings(inv(pairs...))
+	require.Len(t, fs, 1)
+	assert.Equal(t, LevelWarn, fs[0].Level)
+	assert.Equal(t, "hook-sprawl", fs[0].Code)
+	assert.Contains(t, fs[0].Message, "PreToolUse has 6 hooks")
+}
+
+func TestSprawlFindings_HotPathFail(t *testing.T) {
+	var pairs [][2]string
+	for i := 0; i < 11; i++ { // 11 > 10 FAIL
+		pairs = append(pairs, [2]string{"PostToolUse", "cmd"})
+	}
+	fs := SprawlFindings(inv(pairs...))
+	require.Len(t, fs, 1)
+	assert.Equal(t, LevelFail, fs[0].Level)
+}
+
+func TestSprawlFindings_OtherEventThresholds(t *testing.T) {
+	var pairs [][2]string
+	for i := 0; i < 4; i++ { // 4 > 3 WARN for non-hot-path
+		pairs = append(pairs, [2]string{"SessionStart", "cmd"})
+	}
+	fs := SprawlFindings(inv(pairs...))
+	require.Len(t, fs, 1)
+	assert.Equal(t, LevelWarn, fs[0].Level)
+}
+
+func TestSprawlFindings_UnderThresholdQuiet(t *testing.T) {
+	fs := SprawlFindings(inv(
+		[2]string{"PreToolUse", "a"}, [2]string{"PreToolUse", "b"},
+		[2]string{"SessionStart", "c"},
+	))
+	assert.Empty(t, fs)
+}
+
+// --- #33 missing binary ---
+
+func TestMissingBinaryFindings_FlagsAbsentBinary(t *testing.T) {
+	i := inv(
+		[2]string{"PreToolUse", "hookwise dispatch PreToolUse"},
+		[2]string{"PreToolUse", "hookwise dispatch PreToolUse"},
+		[2]string{"SessionStart", "python3 /x/quote.py"},
+	)
+	// Fake PATH: python3 present, hookwise absent.
+	look := func(name string) (string, error) {
+		if name == "python3" {
+			return "/usr/bin/python3", nil
+		}
+		return "", errors.New("not found")
+	}
+	fs := MissingBinaryFindings(i, look)
+	require.Len(t, fs, 1)
+	assert.Equal(t, LevelFail, fs[0].Level)
+	assert.Equal(t, "hook-binary", fs[0].Code)
+	assert.Contains(t, fs[0].Message, "hookwise")
+	assert.Contains(t, fs[0].Message, "2 hooks") // dependent-hook count
+}
+
+func TestMissingBinaryFindings_AllPresentQuiet(t *testing.T) {
+	i := inv([2]string{"PreToolUse", "python3 /x/quote.py"})
+	look := func(string) (string, error) { return "/usr/bin/python3", nil }
+	assert.Empty(t, MissingBinaryFindings(i, look))
+}
+
+// --- #35 network on hot path ---
+
+func TestNetworkHookFindings_HotPathOnly(t *testing.T) {
+	i := inv(
+		[2]string{"PreToolUse", "uvx claude-code-guardian"},
+		[2]string{"SessionStart", "uvx some-tool"}, // not hot-path → ignored
+		[2]string{"PostToolUse", "npx foo"},
+		[2]string{"PreToolUse", "python3 local.py"}, // safe
+	)
+	fs := NetworkHookFindings(i)
+	require.Len(t, fs, 2)
+	for _, f := range fs {
+		assert.Equal(t, LevelWarn, f.Level)
+		assert.Equal(t, "hook-network", f.Code)
+	}
+}
+
+func TestNetworkHookFindings_DetectsPatterns(t *testing.T) {
+	cases := []string{"uvx t", "uv run t", "npx t", "pip install t", "curl http://x", "wget x", "docker run img"}
+	for _, c := range cases {
+		fs := NetworkHookFindings(inv([2]string{"PreToolUse", c}))
+		assert.Len(t, fs, 1, "should flag %q", c)
+	}
+	// docker run with --pull=never is acceptable.
+	assert.Empty(t, NetworkHookFindings(inv([2]string{"PreToolUse", "docker run --pull=never img"})))
+}
+
+// --- #36 duplicates + overlap ---
+
+func TestDuplicateFindings_ExactDuplicates(t *testing.T) {
+	i := inv(
+		[2]string{"PreToolUse", "skill-routing-guard"},
+		[2]string{"PreToolUse", "skill-routing-guard"},
+		[2]string{"PreToolUse", "skill-routing-guard"},
+	)
+	fs := DuplicateFindings(i)
+	// Expect a duplicate WARN (3 times) — and overlap is only for >1 distinct guard.
+	var dup *Finding
+	for idx := range fs {
+		if fs[idx].Code == "hook-duplicate" {
+			dup = &fs[idx]
+		}
+	}
+	require.NotNil(t, dup)
+	assert.Equal(t, LevelWarn, dup.Level)
+	assert.Contains(t, dup.Message, "3 times")
+	assert.Contains(t, dup.Message, "PreToolUse")
+}
+
+func TestDuplicateFindings_GuardOverlap(t *testing.T) {
+	i := inv(
+		[2]string{"PreToolUse", "hookwise dispatch PreToolUse"},
+		[2]string{"PreToolUse", "uvx claude-code-guardian"},
+		[2]string{"PreToolUse", "skill-routing-guard"},
+	)
+	fs := DuplicateFindings(i)
+	var overlap *Finding
+	for idx := range fs {
+		if fs[idx].Code == "hook-overlap" {
+			overlap = &fs[idx]
+		}
+	}
+	require.NotNil(t, overlap)
+	assert.Equal(t, LevelInfo, overlap.Level)
+	assert.Contains(t, overlap.Message, "3 guard systems")
+}
+
+func TestDuplicateFindings_NoFalsePositives(t *testing.T) {
+	i := inv(
+		[2]string{"PreToolUse", "hookwise dispatch PreToolUse"},
+		[2]string{"PostToolUse", "python3 fmt.py"},
+	)
+	assert.Empty(t, DuplicateFindings(i))
+}

--- a/internal/hooks/paths.go
+++ b/internal/hooks/paths.go
@@ -1,0 +1,44 @@
+package hooks
+
+import (
+	"os/exec"
+	"path/filepath"
+	"sort"
+
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// SettingsPaths returns the Claude Code settings files to scan for hooks, given
+// the .claude directory: the global settings.json (always listed, even if
+// absent — Scan tolerates missing files) plus every
+// projects/*/settings.local.json. Project paths are sorted for deterministic
+// output.
+func SettingsPaths(claudeDir string) []string {
+	paths := []string{filepath.Join(claudeDir, "settings.json")}
+
+	matches, _ := filepath.Glob(filepath.Join(claudeDir, "projects", "*", "settings.local.json"))
+	sort.Strings(matches)
+	paths = append(paths, matches...)
+	return paths
+}
+
+// DefaultSettingsPaths returns SettingsPaths for the real ~/.claude directory.
+func DefaultSettingsPaths() []string {
+	return SettingsPaths(filepath.Join(core.HomeDir(), ".claude"))
+}
+
+// AllFindings runs every hook-safety analysis over the inventory and returns the
+// findings in a stable order: inventory (SCAN) → sprawl → missing binary →
+// network → duplicates/overlap. lookPath is injected for the binary check
+// (production passes exec.LookPath).
+func AllFindings(inv *Inventory, lookPath func(string) (string, error)) []Finding {
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	out := []Finding{InventoryFinding(inv)}
+	out = append(out, SprawlFindings(inv)...)
+	out = append(out, MissingBinaryFindings(inv, lookPath)...)
+	out = append(out, NetworkHookFindings(inv)...)
+	out = append(out, DuplicateFindings(inv)...)
+	return out
+}

--- a/internal/hooks/paths_test.go
+++ b/internal/hooks/paths_test.go
@@ -16,7 +16,7 @@ func TestSettingsPaths_GlobalAndProjects(t *testing.T) {
 	// Two project settings.local.json files.
 	for _, proj := range []string{"projA", "projB"} {
 		dir := filepath.Join(claude, "projects", proj)
-		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.MkdirAll(dir, 0o750))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "settings.local.json"), []byte("{}"), 0o600))
 	}
 

--- a/internal/hooks/paths_test.go
+++ b/internal/hooks/paths_test.go
@@ -1,0 +1,37 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingsPaths_GlobalAndProjects(t *testing.T) {
+	claude := t.TempDir()
+	// Global settings.
+	require.NoError(t, os.WriteFile(filepath.Join(claude, "settings.json"), []byte("{}"), 0o600))
+	// Two project settings.local.json files.
+	for _, proj := range []string{"projA", "projB"} {
+		dir := filepath.Join(claude, "projects", proj)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "settings.local.json"), []byte("{}"), 0o600))
+	}
+
+	paths := SettingsPaths(claude)
+
+	assert.Contains(t, paths, filepath.Join(claude, "settings.json"))
+	assert.Contains(t, paths, filepath.Join(claude, "projects", "projA", "settings.local.json"))
+	assert.Contains(t, paths, filepath.Join(claude, "projects", "projB", "settings.local.json"))
+	assert.Len(t, paths, 3)
+}
+
+func TestSettingsPaths_GlobalAlwaysListedEvenIfAbsent(t *testing.T) {
+	claude := t.TempDir() // empty: no files
+	paths := SettingsPaths(claude)
+	// Global path is always returned (Scan tolerates it being missing).
+	require.Len(t, paths, 1)
+	assert.Equal(t, filepath.Join(claude, "settings.json"), paths[0])
+}

--- a/internal/hooks/scan.go
+++ b/internal/hooks/scan.go
@@ -1,0 +1,104 @@
+// Package hooks reads and analyzes the hook configuration that Claude Code
+// stores in settings.json files. It powers `hookwise doctor`'s hook-safety
+// checks: inventory/sprawl, missing binaries, network-dependent hooks on hot
+// paths, and duplicate/overlapping hooks.
+//
+// The scanner is hermetic — it only reads files and never makes network calls —
+// so every analysis is fully unit-testable.
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// HookEntry is a single command hook attached to one event type.
+type HookEntry struct {
+	Event      string // e.g. "PreToolUse"
+	Matcher    string // tool-name matcher ("" means all)
+	Type       string // hook type, usually "command"
+	Command    string // the shell command string
+	SourceFile string // settings file this entry came from
+}
+
+// Inventory is the flattened result of scanning one or more settings files.
+type Inventory struct {
+	Entries     []HookEntry
+	ParseErrors []ParseError // non-fatal: malformed files are recorded, not raised
+}
+
+// ParseError records a settings file that could not be parsed.
+type ParseError struct {
+	File string
+	Err  error
+}
+
+// settingsFile mirrors the relevant shape of a Claude Code settings.json.
+//
+//	{ "hooks": { "<Event>": [ { "matcher": "...", "hooks": [ {"type","command"} ] } ] } }
+type settingsFile struct {
+	Hooks map[string][]matcherGroup `json:"hooks"`
+}
+
+type matcherGroup struct {
+	Matcher string        `json:"matcher"`
+	Hooks   []commandHook `json:"hooks"`
+}
+
+type commandHook struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+// Scan reads each settings file path in order and returns the combined hook
+// inventory. Missing files are silently skipped; malformed files are recorded
+// in Inventory.ParseErrors and do not abort the scan. The only error Scan
+// returns is for an unreadable (but existing) file's non-IsNotExist failure —
+// callers can otherwise treat the inventory as best-effort.
+func Scan(paths []string) (*Inventory, error) {
+	inv := &Inventory{}
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue // a missing settings file is normal
+			}
+			inv.ParseErrors = append(inv.ParseErrors, ParseError{File: p, Err: err})
+			continue
+		}
+
+		var sf settingsFile
+		if err := json.Unmarshal(data, &sf); err != nil {
+			inv.ParseErrors = append(inv.ParseErrors, ParseError{
+				File: p,
+				Err:  fmt.Errorf("parse %s: %w", p, err),
+			})
+			continue
+		}
+
+		for event, groups := range sf.Hooks {
+			for _, g := range groups {
+				for _, h := range g.Hooks {
+					inv.Entries = append(inv.Entries, HookEntry{
+						Event:      event,
+						Matcher:    g.Matcher,
+						Type:       h.Type,
+						Command:    h.Command,
+						SourceFile: p,
+					})
+				}
+			}
+		}
+	}
+	return inv, nil
+}
+
+// CountByEvent returns the number of hook entries attached to each event type.
+func (inv *Inventory) CountByEvent() map[string]int {
+	counts := make(map[string]int)
+	for _, e := range inv.Entries {
+		counts[e.Event]++
+	}
+	return counts
+}

--- a/internal/hooks/scan_test.go
+++ b/internal/hooks/scan_test.go
@@ -1,0 +1,78 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeSettings writes a settings.json with the given hooks block to a temp
+// file and returns its path.
+func writeSettings(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "settings.json")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+	return p
+}
+
+func TestScan_ParsesHooksAcrossEvents(t *testing.T) {
+	path := writeSettings(t, `{
+      "hooks": {
+        "PreToolUse": [
+          {"matcher": "Bash", "hooks": [
+            {"type": "command", "command": "hookwise dispatch PreToolUse"},
+            {"type": "command", "command": "uvx claude-code-guardian"}
+          ]},
+          {"matcher": "", "hooks": [
+            {"type": "command", "command": "hookwise dispatch PreToolUse"}
+          ]}
+        ],
+        "SessionStart": [
+          {"matcher": "", "hooks": [
+            {"type": "command", "command": "python3 /x/quote.py"}
+          ]}
+        ]
+      }
+    }`)
+
+	inv, err := Scan([]string{path})
+	require.NoError(t, err)
+
+	// 4 total hook entries across 2 events.
+	assert.Len(t, inv.Entries, 4)
+	assert.Equal(t, 3, inv.CountByEvent()["PreToolUse"])
+	assert.Equal(t, 1, inv.CountByEvent()["SessionStart"])
+
+	// Source file is recorded on each entry.
+	for _, e := range inv.Entries {
+		assert.Equal(t, path, e.SourceFile)
+	}
+}
+
+func TestScan_MissingFileIsSkipped(t *testing.T) {
+	inv, err := Scan([]string{"/nonexistent/settings.json"})
+	require.NoError(t, err, "a missing settings file is not an error")
+	assert.Empty(t, inv.Entries)
+}
+
+func TestScan_MalformedJSONRecordedNotFatal(t *testing.T) {
+	bad := writeSettings(t, `{ this is not json `)
+	good := writeSettings(t, `{"hooks":{"Stop":[{"matcher":"","hooks":[{"type":"command","command":"echo hi"}]}]}}`)
+
+	inv, err := Scan([]string{bad, good})
+	require.NoError(t, err, "one malformed file must not fail the whole scan")
+	assert.Len(t, inv.Entries, 1, "the good file's hook is still parsed")
+	assert.Len(t, inv.ParseErrors, 1, "the malformed file is recorded as a parse error")
+}
+
+func TestScan_LaterFilesAppend(t *testing.T) {
+	a := writeSettings(t, `{"hooks":{"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"a"}]}]}}`)
+	b := writeSettings(t, `{"hooks":{"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"b"}]}]}}`)
+	inv, err := Scan([]string{a, b})
+	require.NoError(t, err)
+	assert.Equal(t, 2, inv.CountByEvent()["PreToolUse"])
+}


### PR DESCRIPTION
## Summary

Adds a **hook-safety suite** to `hookwise doctor` — the highest-leverage defense against the hook-overload incident class (37 hooks / 12 events caused a 2-hour outage). Closes **#33, #34, #35, #36**.

New `internal/hooks` package: a hermetic Claude Code settings scanner + four pure analyses, all TDD'd. Wired into `doctor` as "Check 7".

## Checks (each matches its issue's exact output format)

| Issue | Check | Behavior |
|---|---|---|
| **#34** | inventory + sprawl | `SCAN hooks: N across M events` + per-event breakdown; WARN/FAIL when a hot-path event (PreToolUse/PostToolUse) exceeds 5/10 or other events exceed 3/8 |
| **#33** | missing binary | extracts the executable from each hook command, checks PATH via `exec.LookPath`; FAIL with the count of dependent hooks |
| **#35** | network on hot path | flags `uvx`/`uv run`/`npx`/`pip install`/`curl`/`wget`/`docker run` **only** on PreToolUse/PostToolUse; `docker run --pull=never` is exempt |
| **#36** | duplicates + overlap | exact-duplicate WARN (same command+event); functional-overlap INFO when multiple known guard systems (`hookwise dispatch`, `claude-code-guardian`, `skill-routing-guard`) share an event |

## Real-world smoke (on the maintainer's own settings)

```
SCAN  hooks: 23 hooks across 5 events
        PreToolUse:    12 hooks
        ...
FAIL  hook-sprawl: PreToolUse has 12 hooks (threshold: 10)
WARN  hook-duplicate: "...calendar_guard.py" appears 4 times on PreToolUse
```

It immediately surfaced genuine sprawl + a 4× duplicated guard — the feature works.

## Design notes

- **Scanner is hermetic** (reads files, no network) → fully unit-testable. Missing/malformed settings files are tolerated (recorded, not fatal).
- **`exec.LookPath` is injected** so the binary check is testable without touching the real PATH.
- Scans `~/.claude/settings.json` + `~/.claude/projects/*/settings.local.json`.
- `internal/hooks` added to the guarded `task test:go:unit` target (retro-009: no bare `go test`).

## Verification

- TDD red→green for every analysis; `task test:go:unit` + `test:go:contract` + `test:go:arch` all green.
- Contract parity (ARCH-6) preserved — dispatch fixtures untouched.
- `task install` + `hookwise doctor` smoked on real data.

Stream B of the post-Dolt backlog (B→C→D). Out of scope: the untracked working-tree files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `hookwise doctor` command now performs comprehensive hook safety checks, including inventory analysis, sprawl detection, missing binary detection, network dependency scanning, and duplicate identification.

* **Tests**
  * Added unit tests for hook analysis functionality.

* **Chores**
  * Updated build task configuration to include hook analysis tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->