### PR TITLE
feeds: real news (HackerNews) + memories producers

### DIFF
--- a/internal/feeds/producer_memories.go
+++ b/internal/feeds/producer_memories.go
@@ -1,15 +1,161 @@
 package feeds
 
-import "context"
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
 
-// MemoriesProducer returns placeholder memories.
-type MemoriesProducer struct{}
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+const memoriesCap = 5
+
+// MemoriesProducer surfaces recently-modified memory markdown files from the
+// Claude projects directory (~/.claude/projects/*/memory/*.md).
+type MemoriesProducer struct {
+	// dir is the base directory to scan (<dir>/*/memory/*.md).
+	// When empty, defaults to filepath.Join(core.HomeDir(), ".claude", "projects").
+	// Tests set this field to a temp directory.
+	dir string
+}
 
 func (p *MemoriesProducer) Name() string { return "memories" }
+
+// memoryEntry holds metadata for one memory markdown file.
+type memoryEntry struct {
+	title    string
+	modified time.Time
+	basename string
+}
+
 func (p *MemoriesProducer) Produce(_ context.Context) (interface{}, error) {
+	baseDir := p.dir
+	if baseDir == "" {
+		baseDir = filepath.Join(core.HomeDir(), ".claude", "projects")
+	}
+
+	pattern := filepath.Join(baseDir, "*", "memory", "*.md")
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return p.emptyEnvelope(), nil
+	}
+
+	totalCount := len(matches)
+
+	entries := make([]memoryEntry, 0, len(matches))
+	for _, path := range matches {
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		title := extractTitle(path)
+		entries = append(entries, memoryEntry{
+			title:    title,
+			modified: info.ModTime(),
+			basename: filepath.Base(path),
+		})
+	}
+
+	// Sort newest first.
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].modified.After(entries[j].modified)
+	})
+
+	// Cap at memoriesCap.
+	if len(entries) > memoriesCap {
+		entries = entries[:memoriesCap]
+	}
+
+	recent := make([]interface{}, 0, len(entries))
+	for _, e := range entries {
+		recent = append(recent, map[string]interface{}{
+			"title":    e.title,
+			"modified": e.modified.UTC().Format(time.RFC3339),
+		})
+	}
+
+	return NewEnvelope("memories", map[string]interface{}{
+		"recent_memories": recent,
+		"total_count":     totalCount,
+		"source":          "claude-memory",
+	}), nil
+}
+
+// emptyEnvelope returns a zero-state envelope. Source is "claude-memory", never "placeholder".
+func (p *MemoriesProducer) emptyEnvelope() map[string]interface{} {
 	return NewEnvelope("memories", map[string]interface{}{
 		"recent_memories": []interface{}{},
 		"total_count":     0,
-		"source":          "placeholder",
-	}), nil
+		"source":          "claude-memory",
+	})
+}
+
+// extractTitle reads the title from a markdown file using the following precedence:
+//  1. YAML frontmatter `name:` field
+//  2. First `# ` heading line
+//  3. Filename without extension
+func extractTitle(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return filenameTitle(path)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+
+	// Check for frontmatter (file starts with "---").
+	if !scanner.Scan() {
+		return filenameTitle(path)
+	}
+	firstLine := scanner.Text()
+
+	if strings.TrimSpace(firstLine) == "---" {
+		// Parse frontmatter lines until closing "---".
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.TrimSpace(line) == "---" {
+				break
+			}
+			if strings.HasPrefix(line, "name:") {
+				value := strings.TrimSpace(strings.TrimPrefix(line, "name:"))
+				if value != "" {
+					return value
+				}
+			}
+		}
+		// Frontmatter ended; continue scanning for H1.
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "# ") {
+				return strings.TrimSpace(strings.TrimPrefix(line, "# "))
+			}
+		}
+		return filenameTitle(path)
+	}
+
+	// No frontmatter — check first line for H1.
+	if strings.HasPrefix(firstLine, "# ") {
+		return strings.TrimSpace(strings.TrimPrefix(firstLine, "# "))
+	}
+
+	// Scan remaining lines for first H1.
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "# "))
+		}
+	}
+
+	return filenameTitle(path)
+}
+
+// filenameTitle returns the filename without its extension.
+func filenameTitle(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	return strings.TrimSuffix(base, ext)
 }

--- a/internal/feeds/producer_memories_test.go
+++ b/internal/feeds/producer_memories_test.go
@@ -1,0 +1,207 @@
+package feeds
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeMemoryFile creates a memory markdown file under <base>/projName/memory/filename.
+func makeMemoryFile(t *testing.T, baseDir, projName, filename, content string) string {
+	t.Helper()
+	dir := filepath.Join(baseDir, projName, "memory")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	path := filepath.Join(dir, filename)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+// ---------------------------------------------------------------------------
+// Test A: Returns both memories, newest first, correct titles, total_count
+// ---------------------------------------------------------------------------
+
+func TestMemoriesProducer_ReturnsBothMemoriesNewestFirst(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write projA/memory/a.md with frontmatter name.
+	pathA := makeMemoryFile(t, tmpDir, "projA", "a.md", "---\nname: alpha\n---\nSome content.\n")
+	// Write projB/memory/b.md with H1 title.
+	pathB := makeMemoryFile(t, tmpDir, "projB", "b.md", "# Beta Title\n\nMore content.\n")
+
+	// Set distinct mod times so sort order is deterministic.
+	older := time.Now().Add(-2 * time.Hour)
+	newer := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(pathA, older, older))
+	require.NoError(t, os.Chtimes(pathB, newer, newer))
+
+	p := &MemoriesProducer{dir: tmpDir}
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err, "ARCH-1: must not return error")
+
+	envelope, ok := result.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "memories", envelope["type"])
+	assert.NotEmpty(t, envelope["timestamp"])
+
+	data, ok := envelope["data"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "claude-memory", data["source"])
+	assert.Equal(t, 2, toInt(data["total_count"]))
+
+	recent, ok := data["recent_memories"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, recent, 2, "both memories should appear")
+
+	// Newest first: b.md (Beta Title) should come before a.md (alpha).
+	first := recent[0].(map[string]interface{})
+	assert.Equal(t, "Beta Title", first["title"])
+	assert.NotEmpty(t, first["modified"])
+
+	second := recent[1].(map[string]interface{})
+	assert.Equal(t, "alpha", second["title"])
+	assert.NotEmpty(t, second["modified"])
+}
+
+// ---------------------------------------------------------------------------
+// Test B: Missing/nonexistent dir → empty result, no error
+// ---------------------------------------------------------------------------
+
+func TestMemoriesProducer_MissingDir_ReturnsEmpty(t *testing.T) {
+	nonexistent := filepath.Join(t.TempDir(), "does-not-exist")
+
+	p := &MemoriesProducer{dir: nonexistent}
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err, "missing dir must not return an error (ARCH-1)")
+
+	envelope, ok := result.(map[string]interface{})
+	require.True(t, ok)
+
+	data, ok := envelope["data"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "claude-memory", data["source"])
+	assert.Equal(t, 0, toInt(data["total_count"]))
+
+	recent, ok := data["recent_memories"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, recent)
+}
+
+// ---------------------------------------------------------------------------
+// Test C: .md with neither frontmatter nor H1 → title falls back to filename
+// ---------------------------------------------------------------------------
+
+func TestMemoriesProducer_NoTitleFallsBackToFilename(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a file with neither frontmatter nor H1.
+	makeMemoryFile(t, tmpDir, "projX", "my-notes.md", "Just some plain text.\nNo heading here.\n")
+
+	p := &MemoriesProducer{dir: tmpDir}
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	recent := data["recent_memories"].([]interface{})
+	require.Len(t, recent, 1)
+
+	mem := recent[0].(map[string]interface{})
+	assert.Equal(t, "my-notes", mem["title"], "filename without extension should be the fallback title")
+}
+
+// ---------------------------------------------------------------------------
+// Test D: source is never "placeholder"
+// ---------------------------------------------------------------------------
+
+func TestMemoriesProducer_NeverPlaceholder(t *testing.T) {
+	p := &MemoriesProducer{dir: filepath.Join(t.TempDir(), "nonexistent")}
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	src, _ := data["source"].(string)
+	assert.NotEqual(t, "placeholder", src, "source must never be 'placeholder'")
+}
+
+// ---------------------------------------------------------------------------
+// Test E: Cap at memoriesCap (5) entries
+// ---------------------------------------------------------------------------
+
+func TestMemoriesProducer_CapsAtMemoriesCap(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write 8 files across 8 projects.
+	for i := 0; i < 8; i++ {
+		makeMemoryFile(t, tmpDir, fmt.Sprintf("proj%d", i), "mem.md",
+			fmt.Sprintf("# Memory %d\n", i))
+	}
+
+	p := &MemoriesProducer{dir: tmpDir}
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	assert.Equal(t, 8, toInt(data["total_count"]), "total_count reflects all found files")
+
+	recent := data["recent_memories"].([]interface{})
+	assert.LessOrEqual(t, len(recent), memoriesCap, "recent_memories should be capped at memoriesCap")
+}
+
+// ---------------------------------------------------------------------------
+// Test F: Frontmatter name takes precedence over H1
+// ---------------------------------------------------------------------------
+
+func TestMemoriesProducer_FrontmatterNameTakesPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// File has both frontmatter name AND an H1 — name wins.
+	makeMemoryFile(t, tmpDir, "projP", "priority.md",
+		"---\nname: Frontmatter Name\n---\n# H1 Heading\n\nContent.\n")
+
+	p := &MemoriesProducer{dir: tmpDir}
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	recent := data["recent_memories"].([]interface{})
+	require.Len(t, recent, 1)
+
+	mem := recent[0].(map[string]interface{})
+	assert.Equal(t, "Frontmatter Name", mem["title"])
+}
+
+// ---------------------------------------------------------------------------
+// Test G: modified timestamp is valid RFC3339
+// ---------------------------------------------------------------------------
+
+func TestMemoriesProducer_ModifiedIsRFC3339(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	makeMemoryFile(t, tmpDir, "projT", "ts.md", "# Timestamp Test\n")
+
+	p := &MemoriesProducer{dir: tmpDir}
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	recent := data["recent_memories"].([]interface{})
+	require.Len(t, recent, 1)
+
+	mem := recent[0].(map[string]interface{})
+	modStr, ok := mem["modified"].(string)
+	require.True(t, ok, "modified should be a string")
+	_, err = time.Parse(time.RFC3339, modStr)
+	assert.NoError(t, err, "modified should be a valid RFC3339 timestamp")
+}

--- a/internal/feeds/producer_news.go
+++ b/internal/feeds/producer_news.go
@@ -1,20 +1,148 @@
 package feeds
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
 
-// NewsProducer returns placeholder news items.
-type NewsProducer struct{}
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+const (
+	hnTopStoriesURL = "https://hacker-news.firebaseio.com/v0/topstories.json"
+	hnItemURLFmt    = "https://hacker-news.firebaseio.com/v0/item/%d.json"
+	hnDefaultMax    = 5
+)
+
+// NewsProducer fetches live stories from the HackerNews Firebase API.
+// It implements ConfigAware to receive MaxStories and Source from feed config.
+type NewsProducer struct {
+	mu       sync.Mutex
+	feedsCfg core.FeedsConfig
+	client   *http.Client
+}
 
 func (p *NewsProducer) Name() string { return "news" }
-func (p *NewsProducer) Produce(_ context.Context) (interface{}, error) {
+
+// SetFeedsConfig receives the feed configuration (ConfigAware interface).
+func (p *NewsProducer) SetFeedsConfig(cfg core.FeedsConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.feedsCfg = cfg
+}
+
+// hnItem is the subset of fields we read from each HackerNews item.
+type hnItem struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+	Score int    `json:"score"`
+}
+
+func (p *NewsProducer) Produce(ctx context.Context) (interface{}, error) {
+	p.mu.Lock()
+	cfg := p.feedsCfg.News
+	p.mu.Unlock()
+
+	// Only "hackernews" is implemented. Any other non-empty Source → fallback.
+	if cfg.Source != "" && cfg.Source != "hackernews" {
+		return p.fallback(), nil
+	}
+
+	maxStories := cfg.MaxStories
+	if maxStories <= 0 {
+		maxStories = hnDefaultMax
+	}
+
+	if p.client == nil {
+		p.client = &http.Client{Timeout: 5 * time.Second}
+	}
+
+	// Fetch top story IDs.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hnTopStoriesURL, nil)
+	if err != nil {
+		core.Logger().Warn("news: failed to build top-stories request", "error", err)
+		return p.fallback(), nil
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		core.Logger().Warn("news: top-stories request failed", "error", err)
+		return p.fallback(), nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		core.Logger().Warn("news: top-stories non-200", "status", resp.StatusCode)
+		return p.fallback(), nil
+	}
+
+	var ids []int
+	if err := json.NewDecoder(resp.Body).Decode(&ids); err != nil {
+		core.Logger().Warn("news: failed to decode top-stories IDs", "error", err)
+		return p.fallback(), nil
+	}
+
+	if len(ids) > maxStories {
+		ids = ids[:maxStories]
+	}
+
+	stories := make([]interface{}, 0, len(ids))
+	for _, id := range ids {
+		item, ok := p.fetchItem(ctx, id)
+		if !ok {
+			continue
+		}
+		stories = append(stories, map[string]interface{}{
+			"title": item.Title,
+			"url":   item.URL,
+			"score": item.Score,
+		})
+	}
+
 	return NewEnvelope("news", map[string]interface{}{
-		"stories": []interface{}{
-			map[string]interface{}{
-				"title": "Placeholder story",
-				"url":   "https://example.com",
-				"score": 0,
-			},
-		},
-		"source": "placeholder",
+		"stories": stories,
+		"source":  "hackernews",
 	}), nil
+}
+
+// fetchItem fetches a single HackerNews item by ID.
+// Returns the item and true on success; false on any error (fail-soft).
+func (p *NewsProducer) fetchItem(ctx context.Context, id int) (hnItem, bool) {
+	url := fmt.Sprintf(hnItemURLFmt, id)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		core.Logger().Warn("news: failed to build item request", "id", id, "error", err)
+		return hnItem{}, false
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		core.Logger().Warn("news: item request failed", "id", id, "error", err)
+		return hnItem{}, false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		core.Logger().Warn("news: item non-200", "id", id, "status", resp.StatusCode)
+		return hnItem{}, false
+	}
+
+	var item hnItem
+	if err := json.NewDecoder(resp.Body).Decode(&item); err != nil {
+		core.Logger().Warn("news: failed to decode item", "id", id, "error", err)
+		return hnItem{}, false
+	}
+
+	return item, true
+}
+
+// fallback returns an empty-stories envelope. Source is "unavailable", never "placeholder".
+func (p *NewsProducer) fallback() map[string]interface{} {
+	return NewEnvelope("news", map[string]interface{}{
+		"stories": []interface{}{},
+		"source":  "unavailable",
+	})
 }

--- a/internal/feeds/producer_news_test.go
+++ b/internal/feeds/producer_news_test.go
@@ -1,0 +1,263 @@
+package feeds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// fakeHNTransport routes HackerNews API requests to in-memory responses.
+type fakeHNTransport struct {
+	topStoriesIDs    []int
+	items            map[int]map[string]interface{}
+	failTopStories   bool
+	topStoriesStatus int // 0 means 200
+}
+
+func (f *fakeHNTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if f.failTopStories && strings.Contains(req.URL.Path, "topstories") {
+		return nil, fmt.Errorf("simulated transport error")
+	}
+
+	status := http.StatusOK
+	var body string
+
+	switch {
+	case strings.HasSuffix(req.URL.Path, "topstories.json"):
+		if f.topStoriesStatus != 0 {
+			status = f.topStoriesStatus
+		}
+		data, _ := json.Marshal(f.topStoriesIDs)
+		body = string(data)
+
+	default:
+		// Parse item ID from path like /v0/item/123.json
+		var id int
+		_, err := fmt.Sscanf(req.URL.Path, "/v0/item/%d.json", &id)
+		if err != nil || f.items == nil {
+			status = http.StatusNotFound
+			body = `{}`
+		} else if item, ok := f.items[id]; ok {
+			data, _ := json.Marshal(item)
+			body = string(data)
+		} else {
+			status = http.StatusNotFound
+			body = `{}`
+		}
+	}
+
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// newNewsProducerWithTransport builds a NewsProducer with an injected HTTP transport.
+func newNewsProducerWithTransport(t *testing.T, transport http.RoundTripper, cfg core.FeedsConfig) *NewsProducer {
+	t.Helper()
+	p := &NewsProducer{
+		client: &http.Client{Transport: transport},
+	}
+	p.SetFeedsConfig(cfg)
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// Test A: Real stories returned, source=="hackernews", MaxStories respected
+// ---------------------------------------------------------------------------
+
+func TestNewsProducer_RealStories(t *testing.T) {
+	transport := &fakeHNTransport{
+		topStoriesIDs: []int{1, 2, 3, 4, 5, 6},
+		items: map[int]map[string]interface{}{
+			1: {"title": "Go 1.24 Released", "url": "https://go.dev/blog/go1.24", "score": 300},
+			2: {"title": "SQLite is underrated", "url": "https://sqlite.org", "score": 250},
+			3: {"title": "Claude Code ships agents", "url": "https://claude.ai", "score": 200},
+		},
+	}
+
+	cfg := core.FeedsConfig{
+		News: core.NewsFeedConfig{Source: "hackernews", MaxStories: 3},
+	}
+	p := newNewsProducerWithTransport(t, transport, cfg)
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	envelope, ok := result.(map[string]interface{})
+	require.True(t, ok, "result must be a map")
+	assert.Equal(t, "news", envelope["type"])
+
+	data, ok := envelope["data"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "hackernews", data["source"])
+
+	stories, ok := data["stories"].([]interface{})
+	require.True(t, ok)
+	// MaxStories=3, but only items 1/2/3 have entries; item IDs 4/5/6 are missing → skipped.
+	assert.LessOrEqual(t, len(stories), 3, "should not exceed MaxStories")
+	assert.GreaterOrEqual(t, len(stories), 1, "should return at least the known items")
+
+	// Verify field names.
+	first := stories[0].(map[string]interface{})
+	assert.Contains(t, first, "title")
+	assert.Contains(t, first, "url")
+	assert.Contains(t, first, "score")
+}
+
+func TestNewsProducer_MaxStoriesLimit(t *testing.T) {
+	// 10 IDs in top-stories, MaxStories=2 → only 2 items fetched.
+	ids := make([]int, 10)
+	items := make(map[int]map[string]interface{}, 10)
+	for i := 1; i <= 10; i++ {
+		ids[i-1] = i
+		items[i] = map[string]interface{}{
+			"title": fmt.Sprintf("Story %d", i),
+			"url":   fmt.Sprintf("https://example.com/%d", i),
+			"score": i * 10,
+		}
+	}
+
+	transport := &fakeHNTransport{topStoriesIDs: ids, items: items}
+	cfg := core.FeedsConfig{
+		News: core.NewsFeedConfig{Source: "hackernews", MaxStories: 2},
+	}
+	p := newNewsProducerWithTransport(t, transport, cfg)
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	stories := data["stories"].([]interface{})
+	assert.Len(t, stories, 2, "MaxStories=2 must cap the result at 2")
+}
+
+func TestNewsProducer_DefaultMaxStoriesWhenZero(t *testing.T) {
+	ids := make([]int, 10)
+	items := make(map[int]map[string]interface{}, 10)
+	for i := 1; i <= 10; i++ {
+		ids[i-1] = i
+		items[i] = map[string]interface{}{
+			"title": fmt.Sprintf("Story %d", i),
+			"url":   fmt.Sprintf("https://example.com/%d", i),
+			"score": i,
+		}
+	}
+
+	transport := &fakeHNTransport{topStoriesIDs: ids, items: items}
+	// MaxStories=0 → default (hnDefaultMax=5)
+	cfg := core.FeedsConfig{
+		News: core.NewsFeedConfig{Source: "hackernews", MaxStories: 0},
+	}
+	p := newNewsProducerWithTransport(t, transport, cfg)
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	stories := data["stories"].([]interface{})
+	assert.LessOrEqual(t, len(stories), hnDefaultMax, "zero MaxStories should apply default cap")
+}
+
+// ---------------------------------------------------------------------------
+// Test B: Transport error → fallback (empty stories, source=="unavailable", no error)
+// ---------------------------------------------------------------------------
+
+func TestNewsProducer_TransportError_ReturnsFallback(t *testing.T) {
+	transport := &fakeHNTransport{failTopStories: true}
+	cfg := core.FeedsConfig{
+		News: core.NewsFeedConfig{Source: "hackernews", MaxStories: 5},
+	}
+	p := newNewsProducerWithTransport(t, transport, cfg)
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err, "ARCH-1: must not return error on transport failure")
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	assert.Equal(t, "unavailable", data["source"])
+
+	stories, ok := data["stories"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, stories, "fallback must return empty stories slice")
+}
+
+// ---------------------------------------------------------------------------
+// Test C: Non-200 HTTP status → fallback
+// ---------------------------------------------------------------------------
+
+func TestNewsProducer_Non200Response_ReturnsFallback(t *testing.T) {
+	transport := &fakeHNTransport{
+		topStoriesIDs:    []int{1},
+		topStoriesStatus: http.StatusInternalServerError,
+	}
+	cfg := core.FeedsConfig{
+		News: core.NewsFeedConfig{Source: "hackernews", MaxStories: 5},
+	}
+	p := newNewsProducerWithTransport(t, transport, cfg)
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err, "ARCH-1: must not return error on non-200 response")
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	assert.Equal(t, "unavailable", data["source"])
+
+	stories := data["stories"].([]interface{})
+	assert.Empty(t, stories)
+}
+
+// ---------------------------------------------------------------------------
+// Test D: Source != "hackernews" → fallback without hitting the network
+// ---------------------------------------------------------------------------
+
+func TestNewsProducer_UnknownSource_ReturnsFallbackWithoutNetwork(t *testing.T) {
+	// Transport panics if called — verifies the network is never hit.
+	transport := &panicTransport{}
+	cfg := core.FeedsConfig{
+		News: core.NewsFeedConfig{Source: "rss", MaxStories: 5},
+	}
+	p := newNewsProducerWithTransport(t, transport, cfg)
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	assert.Equal(t, "unavailable", data["source"])
+
+	stories := data["stories"].([]interface{})
+	assert.Empty(t, stories)
+}
+
+// panicTransport panics if the network is accidentally called.
+type panicTransport struct{}
+
+func (p *panicTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	panic("network should not be called for unknown Source")
+}
+
+// ---------------------------------------------------------------------------
+// Test E: Fallback envelope never contains source:"placeholder"
+// ---------------------------------------------------------------------------
+
+func TestNewsProducer_FallbackNeverPlaceholder(t *testing.T) {
+	transport := &fakeHNTransport{failTopStories: true}
+	cfg := core.FeedsConfig{
+		News: core.NewsFeedConfig{Source: "hackernews"},
+	}
+	p := newNewsProducerWithTransport(t, transport, cfg)
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	data := result.(map[string]interface{})["data"].(map[string]interface{})
+	src, _ := data["source"].(string)
+	assert.NotEqual(t, "placeholder", src, "source must never be 'placeholder'")
+}

--- a/tui/tests/test_terminal_e2e.py
+++ b/tui/tests/test_terminal_e2e.py
@@ -182,29 +182,22 @@ class TestStatusLineE2E:
 
     @skipif_no_claude
     @skipif_no_hookwise
-    @pytest.mark.xfail(
-        reason=(
-            "Some feed producers still return placeholder data. "
-            "Tracked by: #57 (project), #58 (calendar), #59 (session/cost). "
-            "Insights producer is fixed — see test_status_line_has_insights_data."
-        ),
-        strict=True,
-    )
     def test_status_line_has_real_data(self, terminal_session):
-        """E2E: ALL status line segments must show real data, not '--' placeholders.
+        """E2E: the asserted status line segments must show real data, not '--'.
 
         This test validates the feature end-to-end: from feed producers
         through the cache pipeline to the rendered status line inside
         Claude Code. It fails when producers return placeholder data,
         because from the user's perspective the feature is broken.
 
-        Currently xfail because some feed producers are stubs:
-        - #57: ProjectProducer returns placeholder
-        - #58: CalendarProducer returns placeholder
-        - #59: session/cost analytics not wired to SQLite analytics DB
+        The previously-tracked blockers are resolved:
+        - #57: ProjectProducer now reads real git data
+        - #58: CalendarProducer now integrates the calendar
+        - #59: session/cost now wired to the SQLite analytics DB
 
-        Note: InsightsProducer is fixed and tested separately via
-        test_status_line_has_insights_data.
+        The strict xfail was removed once those producers became real. This
+        test is gated by skipif_no_claude/skipif_no_hookwise, so it only runs
+        with a live Claude Code session present (never in headless CI).
         """
         session = terminal_session.create_session(
             "claude",


### PR DESCRIPTION
## Summary

Replaces the **last two placeholder feed producers** with real data sources, so the TUI feeds show live data instead of `source:"placeholder"`. Stream D of the post-Dolt backlog.

## Producers

**News** (`producer_news.go`) — real HackerNews fetch:
- `topstories.json` → first N IDs (`News.MaxStories`, default 5) → `item/<id>.json` per story → `{title, url, score}`.
- Injectable `*http.Client` (mirrors the weather producer) for hermetic tests.
- Only `Source: "hackernews"` implemented; other sources fall back without hitting the network.
- **Fail-soft:** network / non-200 / decode errors → empty stories, `source: "unavailable"` — **never** `"placeholder"`. Returns `(envelope, nil)`, never an error.

**Memories** (`producer_memories.go`) — scans the Claude memory dir:
- `~/.claude/projects/*/memory/*.md` (base dir injectable for tests), title from frontmatter `name:` → first `# H1` → filename; newest-first, capped at 5, with `total_count`.
- `source: "claude-memory"`; missing dir → empty, never `"placeholder"`.

## xfail flip

Removes the **stale strict xfail** on `test_status_line_has_real_data`. Its cited blockers — #57 (project), #58 (calendar), #59 (session/cost) — are all **closed/fixed**, so the asserted segments (`session/cost/project/calendar`) now show real data. The test remains gated by `skipif_no_claude`/`skipif_no_hookwise` (E2E — never runs in headless CI), so this is safe.

## Verification

- **TDD:** 12 new tests — news uses a fake `http.RoundTripper` (real stories, MaxStories limit, transport-error/non-200/unknown-source fallbacks, never-placeholder); memories uses a temp dir (newest-first, frontmatter vs H1 vs filename titles, missing-dir, RFC3339, cap).
- Guarded `task test:go:unit` + cross-schema boundary (Go→Python contract, 13 tests) green. Envelope keys unchanged (`stories`/`recent_memories`/`total_count`) so the TUI contract holds.

## Note for reviewer

The producer logic is fully covered by unit tests with injected fakes; a live network smoke wasn't run (HackerNews is external). The xfail's E2E test can't run in CI (no Claude binary) — the flip is justified by its tracked blockers being closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)