### PR TITLE
doctor: make hook sprawl + duplicate checks matcher-aware

### DIFF
--- a/internal/hooks/analyze.go
+++ b/internal/hooks/analyze.go
@@ -88,18 +88,56 @@ func sprawlThreshold(event string) (warn, fail int) {
 	return 3, 8
 }
 
-// SprawlFindings flags events whose hook count exceeds the WARN/FAIL threshold
-// (issue #34 F1.2).
+// firesEveryCall reports whether a matcher causes its hook to run on every event
+// of that type. An empty or "*" matcher is unconditional; a specific tool
+// matcher (e.g. "mcp__cal__create") only fires when that tool is used.
+func firesEveryCall(matcher string) bool {
+	m := strings.TrimSpace(matcher)
+	return m == "" || m == "*"
+}
+
+// alwaysFireByEvent counts, per event, the hooks that fire on every call
+// (unconditional matcher). Matcher-scoped hooks are excluded — they are the
+// real per-call process cost, so they drive the sprawl alarm.
+func alwaysFireByEvent(inv *Inventory) map[string]int {
+	counts := map[string]int{}
+	for _, e := range inv.Entries {
+		if firesEveryCall(e.Matcher) {
+			counts[e.Event]++
+		}
+	}
+	return counts
+}
+
+// SprawlFindings flags events with too many ALWAYS-FIRE hooks (issue #34 F1.2).
+// Severity is driven by hooks that run on every call (unconditional matcher),
+// not by matcher-scoped hooks: a hook bound to one specific tool does not fork a
+// process on unrelated calls, so counting it toward per-call sprawl is wrong.
 func SprawlFindings(inv *Inventory) []Finding {
+	alwaysFire := alwaysFireByEvent(inv)
+
+	// Deterministic order: by count desc, then event name.
+	events := make([]string, 0, len(alwaysFire))
+	for ev := range alwaysFire {
+		events = append(events, ev)
+	}
+	sort.Slice(events, func(i, j int) bool {
+		if alwaysFire[events[i]] != alwaysFire[events[j]] {
+			return alwaysFire[events[i]] > alwaysFire[events[j]]
+		}
+		return events[i] < events[j]
+	})
+
 	var out []Finding
-	for _, ec := range sortedEventCounts(inv) {
-		warn, fail := sprawlThreshold(ec.Event)
+	for _, ev := range events {
+		count := alwaysFire[ev]
+		warn, fail := sprawlThreshold(ev)
 		level := ""
 		threshold := warn
 		switch {
-		case ec.Count > fail:
+		case count > fail:
 			level, threshold = LevelFail, fail
-		case ec.Count > warn:
+		case count > warn:
 			level, threshold = LevelWarn, warn
 		}
 		if level == "" {
@@ -108,8 +146,8 @@ func SprawlFindings(inv *Inventory) []Finding {
 		out = append(out, Finding{
 			Level:   level,
 			Code:    "hook-sprawl",
-			Message: fmt.Sprintf("%s has %d hooks (threshold: %d)", ec.Event, ec.Count, threshold),
-			Details: []string{"Every matching event spawns these processes. Consider consolidating."},
+			Message: fmt.Sprintf("%s has %d always-on hooks (threshold: %d)", ev, count, threshold),
+			Details: []string{"These hooks fork a process on every call. Consider consolidating."},
 		})
 	}
 	return out
@@ -261,21 +299,26 @@ func DuplicateFindings(inv *Inventory) []Finding {
 	for _, event := range eventOrder {
 		entries := byEvent[event]
 
-		// Exact duplicates: same command string appearing >1 times.
-		cmdCount := map[string]int{}
-		cmdOrder := []string{}
+		// Exact duplicates: same (matcher, command) appearing >1 times. The same
+		// command under DIFFERENT matchers is intentional per-tool protection,
+		// not a duplicate, so the matcher is part of the dedup key.
+		type key struct{ matcher, command string }
+		cmdCount := map[key]int{}
+		cmdOrder := []key{}
 		for _, e := range entries {
-			if _, ok := cmdCount[e.Command]; !ok {
-				cmdOrder = append(cmdOrder, e.Command)
+			k := key{e.Matcher, e.Command}
+			if _, ok := cmdCount[k]; !ok {
+				cmdOrder = append(cmdOrder, k)
 			}
-			cmdCount[e.Command]++
+			cmdCount[k]++
 		}
-		for _, cmd := range cmdOrder {
-			if cmdCount[cmd] > 1 {
+		for _, k := range cmdOrder {
+			cmd := k.command
+			if cmdCount[k] > 1 {
 				out = append(out, Finding{
 					Level:   LevelWarn,
 					Code:    "hook-duplicate",
-					Message: fmt.Sprintf("%q appears %d times on %s", cmd, cmdCount[cmd], event),
+					Message: fmt.Sprintf("%q appears %d times on %s", cmd, cmdCount[k], event),
 					Details: []string{"Identical hooks waste resources. Remove the duplicates."},
 				})
 			}

--- a/internal/hooks/analyze_test.go
+++ b/internal/hooks/analyze_test.go
@@ -20,6 +20,74 @@ func inv(pairs ...[2]string) *Inventory {
 	return i
 }
 
+// invM builds an Inventory from {event, matcher, command} triples so tests can
+// distinguish always-fire ("" / "*") from matcher-scoped hooks.
+func invM(triples ...[3]string) *Inventory {
+	i := &Inventory{}
+	for _, t := range triples {
+		i.Entries = append(i.Entries, HookEntry{
+			Event: t[0], Matcher: t[1], Command: t[2], Type: "command", SourceFile: "settings.json",
+		})
+	}
+	return i
+}
+
+// --- matcher-awareness (real-config false positives) ---
+
+// TestSprawlFindings_MatcherScopedDoNotAlarm: many hooks on an event, but each
+// is scoped to a distinct tool matcher → none fire on a generic call → no alarm.
+func TestSprawlFindings_MatcherScopedDoNotAlarm(t *testing.T) {
+	var triples [][3]string
+	for i := 0; i < 12; i++ { // 12 PreToolUse hooks, each a different specific matcher
+		triples = append(triples, [3]string{"PreToolUse", "mcp__tool__op" + string(rune('a'+i)), "guard.py"})
+	}
+	assert.Empty(t, SprawlFindings(invM(triples...)),
+		"matcher-scoped hooks must not trigger sprawl — only one fires per matching call")
+}
+
+// TestSprawlFindings_AlwaysFireAlarms: hooks with empty/'*' matcher fire on every
+// call, so they count toward the threshold.
+func TestSprawlFindings_AlwaysFireAlarms(t *testing.T) {
+	var triples [][3]string
+	for i := 0; i < 6; i++ { // 6 always-fire PreToolUse hooks → WARN (>5)
+		triples = append(triples, [3]string{"PreToolUse", "", "guard.py"})
+	}
+	fs := SprawlFindings(invM(triples...))
+	require.Len(t, fs, 1)
+	assert.Equal(t, LevelWarn, fs[0].Level)
+}
+
+// TestDuplicateFindings_DifferentMatchersNotDuplicate: the same command under
+// different matchers is intentional per-tool protection, NOT a duplicate.
+func TestDuplicateFindings_DifferentMatchersNotDuplicate(t *testing.T) {
+	i := invM(
+		[3]string{"PreToolUse", "mcp__cal__create", "calendar_guard.py"},
+		[3]string{"PreToolUse", "mcp__cal__delete", "calendar_guard.py"},
+		[3]string{"PreToolUse", "mcp__cal__update", "calendar_guard.py"},
+	)
+	for _, f := range DuplicateFindings(i) {
+		assert.NotEqual(t, "hook-duplicate", f.Code,
+			"same command under different matchers is not a duplicate")
+	}
+}
+
+// TestDuplicateFindings_SameMatcherIsDuplicate: same command AND same matcher
+// repeated is a true copy-paste duplicate.
+func TestDuplicateFindings_SameMatcherIsDuplicate(t *testing.T) {
+	i := invM(
+		[3]string{"PreToolUse", "Bash", "guard.py"},
+		[3]string{"PreToolUse", "Bash", "guard.py"},
+	)
+	var dup *Finding
+	for idx := range DuplicateFindings(i) {
+		if DuplicateFindings(i)[idx].Code == "hook-duplicate" {
+			dup = &DuplicateFindings(i)[idx]
+		}
+	}
+	require.NotNil(t, dup)
+	assert.Contains(t, dup.Message, "2 times")
+}
+
 // --- #34 inventory + sprawl ---
 
 func TestInventoryFinding_TotalsAndPerEvent(t *testing.T) {
@@ -48,7 +116,7 @@ func TestSprawlFindings_HotPathThresholds(t *testing.T) {
 	require.Len(t, fs, 1)
 	assert.Equal(t, LevelWarn, fs[0].Level)
 	assert.Equal(t, "hook-sprawl", fs[0].Code)
-	assert.Contains(t, fs[0].Message, "PreToolUse has 6 hooks")
+	assert.Contains(t, fs[0].Message, "PreToolUse has 6 always-on hooks")
 }
 
 func TestSprawlFindings_HotPathFail(t *testing.T) {


### PR DESCRIPTION
## Summary

Dogfooding the Stream-B hook-safety suite (#33-36) on a **real** `~/.claude/settings.json` immediately exposed two false positives — fixing them here.

**The bug:** on a config where guards are scoped to specific tool matchers (e.g. `calendar_guard.py` under `gcal_create_event`, `gcal_delete_event`, …), doctor reported a spurious `FAIL: PreToolUse has 12 hooks` and four `hook-duplicate` warnings. But:
- A matcher-scoped hook **does not fire** on unrelated calls — on a `Bash` call, 0 of those 12 fire. Counting them toward per-call sprawl is wrong.
- The same script under **different matchers** is intentional per-tool protection, not a copy-paste duplicate.

**The fix:**
- **Sprawl** severity now keys on *always-fire* hooks (matcher `""`/`"*"`) — the real per-call process cost. The inventory SCAN line still shows totals.
- **Duplicate** detection keys on `(matcher, command)`; only true copy-paste (same matcher + command) flags.

Result: a clean-but-matcher-heavy config now reports **"All critical checks passed"** instead of a false FAIL.

## Verification
- TDD: matcher-discriminating tests (scoped ≠ sprawl alarm; different-matcher ≠ duplicate; always-fire still alarms; same-matcher still flags).
- Guarded `task test:go:unit` + contract + arch green.
- Confirmed against the maintainer's real settings.json: doctor went from FAIL → "All critical checks passed".

Follow-up fix to the doctor suite shipped in #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined hook sprawl detection to identify only unconditional "always-on" hooks that trigger on every event.
  * Enhanced duplicate hook detection to recognize duplicates based on both the matcher and command, treating same commands under different matchers as distinct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->