### PR TITLE
fix(dispatch): persist analytics before exit (os.Exit race)

### DIFF
--- a/cmd/hookwise/cmd_dispatch.go
+++ b/cmd/hookwise/cmd_dispatch.go
@@ -81,9 +81,25 @@ func newDispatchCmd() *cobra.Command {
 					wc.Add("dispatch", fmt.Sprintf("timeout after %dms (limit %dms)", elapsed.Milliseconds(), timeoutMs))
 				}
 
-				// Analytics recording (non-blocking, ARCH-7).
+				// Analytics recording. This MUST complete before the process
+				// exits: dispatch calls os.Exit() shortly after, which kills any
+				// still-running goroutine — so a fire-and-forget
+				// `go recordAnalytics(...)` almost never persists its SQLite write
+				// (the open+insert loses the race with os.Exit). Run it in a
+				// goroutine so a hung DB can't block the hook forever, but WAIT up
+				// to analyticsRecordTimeout for it. Fail-open (ARCH-1) on timeout.
 				if config.Analytics.Enabled && payload.SessionID != "" {
-					go recordAnalytics(ctx, eventType, payload, config.Analytics.DBPath)
+					done := make(chan struct{})
+					go func() {
+						defer close(done)
+						recordAnalytics(ctx, eventType, payload, config.Analytics.DBPath)
+					}()
+					select {
+					case <-done:
+					case <-time.After(analyticsRecordTimeout):
+						core.Logger().Warn("analytics: recording did not finish in time",
+							"timeout", analyticsRecordTimeout)
+					}
 				}
 
 				// Signal TUI launch intent (executed synchronously after SafeDispatch)
@@ -120,7 +136,14 @@ func newDispatchCmd() *cobra.Command {
 	return cmd
 }
 
-// recordAnalytics writes session/event data to the SQLite analytics DB in a background goroutine.
+// analyticsRecordTimeout bounds how long dispatch waits for the analytics write
+// before exiting fail-open. A SQLite WAL insert is single-digit ms; this ceiling
+// only trips if the DB is locked/slow, and prevents a stuck write from hanging
+// the hook (and thus the tool call) indefinitely.
+const analyticsRecordTimeout = 2 * time.Second
+
+// recordAnalytics writes session/event data to the SQLite analytics DB. The
+// caller waits for it (bounded) before os.Exit so the write actually persists.
 // Fail-open: any error is logged but never surfaces to the user (ARCH-1).
 func recordAnalytics(ctx context.Context, eventType string, payload core.HookPayload, dataDir string) {
 	defer func() {


### PR DESCRIPTION
## Summary

**Dogfooding caught a real bug:** `hookwise dispatch` almost never persisted analytics. It launched `go recordAnalytics(...)` then immediately called `os.Exit()`, which terminates all goroutines — so the SQLite open+insert lost the race with process exit every time. The whole analytics half of hookwise was effectively dark in the live hook path.

## Fix

Run `recordAnalytics` in a goroutine (so a locked/slow DB can't hang the hook forever) but **wait** up to `analyticsRecordTimeout` (2s) for it before exiting. Fail-open on timeout (ARCH-1). A WAL insert is single-digit ms, so the wait is invisible in practice.

## Verified live (end-to-end)

After wiring hookwise into `~/.claude/settings.json`, real `PostToolUse` hooks now record events — the events table grew **1330 → 1333** from this session's own tool calls. A manual `PostToolUse` dispatch also persists (`POSTPROOF` row landed). **Before this fix, the identical dispatches recorded nothing.** (`PreToolUse` correctly doesn't create an event row — events are recorded on `PostToolUse` by design.)

## Note on testing

The bug is a process-level race (`os.Exit` vs goroutine), not unit-testable in `package main`. The verification is the live end-to-end proof above. Unit/contract gates green.

Found while bringing hookwise live for daily use (the post-Dolt dogfooding effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)