### PR TITLE
feat(init): add hookwise init --wire for safe settings.json wiring

### DIFF
--- a/cmd/hookwise/cmd_init.go
+++ b/cmd/hookwise/cmd_init.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vishnujayvel/hookwise/internal/core"
+	"github.com/vishnujayvel/hookwise/internal/hooks"
 )
 
 // defaultYAMLTemplate is the minimal hookwise.yaml created by `hookwise init`.
@@ -36,12 +38,146 @@ tui:
 `
 
 func newInitCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		wire         bool
+		unwire       bool
+		dryRun       bool
+		events       []string
+		noStatusLine bool
+		settingsPath string
+		force        bool
+	)
+
+	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize hookwise configuration",
-		Long:  "Creates a default hookwise.yaml in the current directory and ensures the ~/.hookwise/ state directory exists.",
-		RunE:  runInit,
+		Long: `Creates a default hookwise.yaml in the current directory and ensures the
+~/.hookwise/ state directory exists.
+
+With --wire: wires hookwise dispatch and status-line into Claude Code
+settings.json idempotently and safely. With --unwire: removes hookwise's
+own hooks from settings.json without touching other hooks.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if wire || unwire {
+				return runWire(cmd, wire, unwire, dryRun, events, noStatusLine, settingsPath, force)
+			}
+			return runInit(cmd, args)
+		},
 	}
+
+	cmd.Flags().BoolVar(&wire, "wire", false, "Wire hookwise into Claude Code settings.json")
+	cmd.Flags().BoolVar(&unwire, "unwire", false, "Remove hookwise hooks from Claude Code settings.json")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print what would change without writing")
+	cmd.Flags().StringSliceVar(&events, "events", []string{"PreToolUse", "PostToolUse"}, "Hook events to wire (comma-separated)")
+	cmd.Flags().BoolVar(&noStatusLine, "no-status-line", false, "Skip wiring the statusLine entry")
+	cmd.Flags().StringVar(&settingsPath, "settings", "", "Override path to Claude Code settings.json")
+	cmd.Flags().BoolVar(&force, "force", false, "Wire even if pre-flight finds FAIL-level issues")
+
+	return cmd
+}
+
+// runWire handles --wire and --unwire modes.
+func runWire(cmd *cobra.Command, wire, unwire, dryRun bool, events []string, noStatusLine bool, settingsPath string, force bool) error {
+	if wire && unwire {
+		return fmt.Errorf("--wire and --unwire are mutually exclusive")
+	}
+
+	// Resolve the settings path.
+	if settingsPath == "" {
+		paths := hooks.DefaultSettingsPaths()
+		if len(paths) > 0 {
+			settingsPath = paths[0]
+		}
+	}
+	if settingsPath == "" {
+		return fmt.Errorf("could not determine Claude Code settings.json path; use --settings")
+	}
+
+	opts := hooks.WireOptions{
+		SettingsPath: settingsPath,
+		Events:       events,
+		StatusLine:   !noStatusLine,
+		DryRun:       dryRun,
+		Unwire:       unwire,
+		Force:        force,
+	}
+
+	out := cmd.OutOrStdout()
+
+	if dryRun {
+		fmt.Fprintln(out, "DRY RUN — no files will be modified.")
+	}
+
+	result, err := hooks.Wire(opts)
+	if err != nil {
+		// Print any findings before the error.
+		if result != nil && len(result.Findings) > 0 {
+			fmt.Fprintln(out, "\nPre-flight findings:")
+			for _, f := range result.Findings {
+				fmt.Fprintf(out, "  %s  %s: %s\n", f.Level, f.Code, f.Message)
+				for _, d := range f.Details {
+					fmt.Fprintf(out, "         %s\n", d)
+				}
+			}
+		}
+		return err
+	}
+
+	// Print pre-flight findings (informational).
+	if len(result.Findings) > 0 {
+		fmt.Fprintln(out, "Pre-flight:")
+		for _, f := range result.Findings {
+			fmt.Fprintf(out, "  %s  %s: %s\n", f.Level, f.Code, f.Message)
+		}
+		fmt.Fprintln(out)
+	}
+
+	if dryRun {
+		fmt.Fprintln(out, "Changes:")
+		fmt.Fprintln(out, result.Diff)
+		return nil
+	}
+
+	if unwire {
+		if result.Changed {
+			fmt.Fprintf(out, "Unwired hookwise from %s\n", settingsPath)
+			if result.BackupPath != "" {
+				fmt.Fprintf(out, "Backup:  %s\n", result.BackupPath)
+			}
+		} else {
+			fmt.Fprintln(out, "Nothing to unwire (no hookwise entries found).")
+		}
+		return nil
+	}
+
+	// Wire summary.
+	if !result.Changed {
+		fmt.Fprintln(out, "Already wired — nothing changed.")
+		return nil
+	}
+
+	fmt.Fprintf(out, "Wired settings.json: %s\n", settingsPath)
+	if result.BackupPath != "" {
+		fmt.Fprintf(out, "Backup:             %s\n", result.BackupPath)
+	}
+
+	if len(result.WiredEvents) > 0 {
+		fmt.Fprintf(out, "Events wired:       %s\n", strings.Join(result.WiredEvents, ", "))
+	}
+	if len(result.SkippedEvents) > 0 {
+		fmt.Fprintf(out, "Events skipped:     %s (already present)\n", strings.Join(result.SkippedEvents, ", "))
+	}
+	if result.StatusLineWired {
+		fmt.Fprintln(out, "statusLine:         wired")
+	} else if result.StatusLineSkipped {
+		fmt.Fprintln(out, "statusLine:         skipped (already present)")
+	}
+
+	fmt.Fprintln(out, "\nNext steps:")
+	fmt.Fprintln(out, "  hookwise daemon start")
+	fmt.Fprintln(out, "  hookwise doctor")
+
+	return nil
 }
 
 func runInit(cmd *cobra.Command, args []string) error {

--- a/internal/hooks/wire.go
+++ b/internal/hooks/wire.go
@@ -1,0 +1,508 @@
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// backupTimeLayout is the UTC timestamp format used in backup file names.
+// Example: settings.json.bak-20260613T183115Z
+const backupTimeLayout = "20060102T150405Z"
+
+// defaultEvents are the hook events wired when --events is not specified.
+var defaultEvents = []string{"PreToolUse", "PostToolUse"}
+
+// WireOptions configures a Wire or Unwire operation.
+type WireOptions struct {
+	// SettingsPath is the absolute path to the Claude Code settings.json to
+	// modify. Required — callers resolve the default via DefaultSettingsPaths().
+	SettingsPath string
+
+	// Events lists the hook events to wire (default: PreToolUse, PostToolUse).
+	// Empty slice is normalised to the defaults.
+	Events []string
+
+	// StatusLine controls whether a statusLine entry is added/removed.
+	StatusLine bool
+
+	// DryRun computes changes but writes nothing. Diff is populated.
+	DryRun bool
+
+	// Unwire removes hookwise's own entries instead of adding them.
+	Unwire bool
+
+	// Force wires even when pre-flight finds FAIL-level findings.
+	Force bool
+
+	// DispatchCommand is the command prefix for dispatch hooks.
+	// Default: "hookwise dispatch"
+	DispatchCommand string
+
+	// StatusLineCommand is the full command for the statusLine entry.
+	// Default: "hookwise status-line"
+	StatusLineCommand string
+
+	// RollbackNotePath overrides the path for the rollback note. When empty,
+	// defaults to <GetStateDir()>/dogfood-rollback.md. Set to "-" to skip.
+	RollbackNotePath string
+
+	// nowFn is injectable for deterministic backup timestamps in tests.
+	nowFn func() time.Time
+}
+
+// normalise fills in defaults so callers only set what they care about.
+func (o *WireOptions) normalise() {
+	if len(o.Events) == 0 {
+		o.Events = defaultEvents
+	}
+	if o.DispatchCommand == "" {
+		o.DispatchCommand = "hookwise dispatch"
+	}
+	if o.StatusLineCommand == "" {
+		o.StatusLineCommand = "hookwise status-line"
+	}
+	if o.nowFn == nil {
+		o.nowFn = func() time.Time { return time.Now().UTC() }
+	}
+}
+
+// WireResult reports the outcome of a Wire or Unwire operation.
+type WireResult struct {
+	// BackupPath is where the original settings.json was backed up (empty on DryRun).
+	BackupPath string
+
+	// Diff is a human-readable summary of what would change (populated on DryRun).
+	Diff string
+
+	// WiredEvents lists events for which a new dispatch group was added.
+	WiredEvents []string
+
+	// SkippedEvents lists events that already had a matching dispatch entry.
+	SkippedEvents []string
+
+	// StatusLineWired is true when the statusLine entry was added.
+	StatusLineWired bool
+
+	// StatusLineSkipped is true when the statusLine was already set correctly.
+	StatusLineSkipped bool
+
+	// Changed is true when the settings file was actually modified.
+	Changed bool
+
+	// Findings holds the pre-flight analysis results.
+	Findings []Finding
+}
+
+// preflight runs the hook-safety scan and returns a non-nil error when the
+// settings file has FAIL-level findings and Force is false.
+func preflight(opts *WireOptions) ([]Finding, error) {
+	inv, err := Scan([]string{opts.SettingsPath})
+	if err != nil {
+		// Unreadable existing file is still reported, not fatal for wire.
+		return nil, fmt.Errorf("scan settings: %w", err)
+	}
+
+	findings := AllFindings(inv, nil)
+
+	if opts.Force {
+		return findings, nil
+	}
+
+	// Refuse if there are FAIL-level findings from duplicate or sprawl codes.
+	for _, f := range findings {
+		if f.Level == LevelFail && (f.Code == "hook-sprawl" || f.Code == "hook-duplicate") {
+			return findings, fmt.Errorf("pre-flight refused: %s %s: %s (use --force to override)", f.Level, f.Code, f.Message)
+		}
+	}
+
+	return findings, nil
+}
+
+// readSettingsMap reads the settings.json into a raw map so all other keys are
+// preserved. Returns an empty map when the file does not exist.
+func readSettingsMap(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return m, nil
+}
+
+// marshalSettings produces indented JSON bytes for a settings map.
+func marshalSettings(m map[string]any) ([]byte, error) {
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}
+
+// backup copies the current settings file to a timestamped backup path and
+// returns the backup path.
+func backup(settingsPath string, nowFn func() time.Time) (string, error) {
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Nothing to back up.
+			return "", nil
+		}
+		return "", fmt.Errorf("read for backup: %w", err)
+	}
+	ts := nowFn().UTC().Format(backupTimeLayout)
+	backupPath := settingsPath + ".bak-" + ts
+	if err := os.WriteFile(backupPath, data, 0o600); err != nil {
+		return "", fmt.Errorf("write backup: %w", err)
+	}
+	return backupPath, nil
+}
+
+// validateWritten re-reads the written settings file and confirms it parses.
+// On failure it restores the backup bytes and returns the error.
+func validateWritten(settingsPath, backupPath string) error {
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return fmt.Errorf("re-read after write: %w", err)
+	}
+	var tmp any
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		// Restore the backup.
+		if backupPath != "" {
+			bdata, berr := os.ReadFile(backupPath)
+			if berr == nil {
+				_ = os.WriteFile(settingsPath, bdata, 0o600)
+			}
+		}
+		return fmt.Errorf("validate written JSON: %w (backup restored)", err)
+	}
+	return nil
+}
+
+// writeRollbackNote writes a rollback command to the dogfood-rollback.md note.
+// Best-effort: errors are silently ignored per the spec.
+func writeRollbackNote(opts *WireOptions, backupPath string) {
+	if opts.RollbackNotePath == "-" || backupPath == "" {
+		return
+	}
+	notePath := opts.RollbackNotePath
+	if notePath == "" {
+		notePath = filepath.Join(core.GetStateDir(), "dogfood-rollback.md")
+	}
+	content := fmt.Sprintf("# hookwise rollback\n\nTo restore your previous settings:\n\n```sh\ncp %s %s\n```\n",
+		backupPath, opts.SettingsPath)
+	_ = os.MkdirAll(filepath.Dir(notePath), 0o700)
+	_ = os.WriteFile(notePath, []byte(content), 0o600)
+}
+
+// hookGroupForEvent returns the dispatch command for a given event.
+func hookGroupForEvent(dispatchCmd, event string) map[string]any {
+	return map[string]any{
+		"matcher": "",
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": dispatchCmd + " " + event,
+			},
+		},
+	}
+}
+
+// hooksMapFromRaw extracts and type-asserts the "hooks" key as map[string]any.
+func hooksMapFromRaw(m map[string]any) map[string]any {
+	if raw, ok := m["hooks"]; ok {
+		if hm, ok := raw.(map[string]any); ok {
+			return hm
+		}
+	}
+	return map[string]any{}
+}
+
+// groupsForEvent returns the slice of matcher-group maps for a given event.
+func groupsForEvent(hooksMap map[string]any, event string) []any {
+	if raw, ok := hooksMap[event]; ok {
+		if sl, ok := raw.([]any); ok {
+			return sl
+		}
+	}
+	return nil
+}
+
+// dispatchCommandForEvent builds the exact command string expected for an event.
+func dispatchCommandForEvent(dispatchCmd, event string) string {
+	return dispatchCmd + " " + event
+}
+
+// hasDispatchEntry returns true when the groups slice already contains a group
+// with matcher="" and the exact dispatch command for this event.
+func hasDispatchEntry(groups []any, wantCmd string) bool {
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		matcher, _ := gm["matcher"].(string)
+		if matcher != "" {
+			continue
+		}
+		hooks, _ := gm["hooks"].([]any)
+		for _, h := range hooks {
+			hm, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			cmd, _ := hm["command"].(string)
+			if cmd == wantCmd {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// applyWire mutates the raw settings map to add hookwise entries.
+// It returns which events were wired and which were skipped.
+func applyWire(m map[string]any, opts *WireOptions) (wired, skipped []string, statusWired, statusSkipped bool) {
+	hooksMap := hooksMapFromRaw(m)
+
+	for _, event := range opts.Events {
+		wantCmd := dispatchCommandForEvent(opts.DispatchCommand, event)
+		groups := groupsForEvent(hooksMap, event)
+		if hasDispatchEntry(groups, wantCmd) {
+			skipped = append(skipped, event)
+			continue
+		}
+		groups = append(groups, hookGroupForEvent(opts.DispatchCommand, event))
+		hooksMap[event] = groups
+		wired = append(wired, event)
+	}
+
+	m["hooks"] = hooksMap
+
+	if opts.StatusLine {
+		// Check current statusLine value.
+		if sl, ok := m["statusLine"]; ok {
+			slm, ok := sl.(map[string]any)
+			if ok {
+				cmd, _ := slm["command"].(string)
+				if cmd == opts.StatusLineCommand {
+					statusSkipped = true
+				} else {
+					m["statusLine"] = map[string]any{
+						"type":    "command",
+						"command": opts.StatusLineCommand,
+					}
+					statusWired = true
+				}
+			} else {
+				m["statusLine"] = map[string]any{
+					"type":    "command",
+					"command": opts.StatusLineCommand,
+				}
+				statusWired = true
+			}
+		} else {
+			m["statusLine"] = map[string]any{
+				"type":    "command",
+				"command": opts.StatusLineCommand,
+			}
+			statusWired = true
+		}
+	}
+
+	return wired, skipped, statusWired, statusSkipped
+}
+
+// applyUnwire removes hookwise's own entries from the raw settings map.
+// It removes any matcher-group whose command has prefix DispatchCommand and
+// removes the statusLine if it matches StatusLineCommand.
+func applyUnwire(m map[string]any, opts *WireOptions) {
+	hooksMap := hooksMapFromRaw(m)
+
+	for event, raw := range hooksMap {
+		groups, ok := raw.([]any)
+		if !ok {
+			continue
+		}
+		var kept []any
+		for _, g := range groups {
+			gm, ok := g.(map[string]any)
+			if !ok {
+				kept = append(kept, g)
+				continue
+			}
+			hooks, _ := gm["hooks"].([]any)
+			isHookwise := false
+			for _, h := range hooks {
+				hm, ok := h.(map[string]any)
+				if !ok {
+					continue
+				}
+				cmd, _ := hm["command"].(string)
+				if strings.HasPrefix(cmd, opts.DispatchCommand) {
+					isHookwise = true
+					break
+				}
+			}
+			if !isHookwise {
+				kept = append(kept, g)
+			}
+		}
+		if len(kept) == 0 {
+			delete(hooksMap, event)
+		} else {
+			hooksMap[event] = kept
+		}
+	}
+
+	if len(hooksMap) > 0 {
+		m["hooks"] = hooksMap
+	} else {
+		// Keep empty map rather than dropping the key to preserve structure.
+		m["hooks"] = hooksMap
+	}
+
+	// Remove statusLine if it matches.
+	if sl, ok := m["statusLine"]; ok {
+		if slm, ok := sl.(map[string]any); ok {
+			cmd, _ := slm["command"].(string)
+			if cmd == opts.StatusLineCommand {
+				delete(m, "statusLine")
+			}
+		}
+	}
+}
+
+// simpleDiff produces a human-readable diff summary between old and new JSON bytes.
+func simpleDiff(oldBytes, newBytes []byte) string {
+	if bytes.Equal(oldBytes, newBytes) {
+		return "(no changes)"
+	}
+	var buf strings.Builder
+	buf.WriteString("--- current settings.json\n")
+	buf.WriteString("+++ proposed settings.json\n")
+
+	oldLines := strings.Split(strings.TrimRight(string(oldBytes), "\n"), "\n")
+	newLines := strings.Split(strings.TrimRight(string(newBytes), "\n"), "\n")
+
+	// Build sets for quick lookup.
+	oldSet := make(map[string]bool, len(oldLines))
+	for _, l := range oldLines {
+		oldSet[l] = true
+	}
+	newSet := make(map[string]bool, len(newLines))
+	for _, l := range newLines {
+		newSet[l] = true
+	}
+
+	// Lines removed.
+	for _, l := range oldLines {
+		if !newSet[l] {
+			buf.WriteString("- " + l + "\n")
+		}
+	}
+	// Lines added.
+	for _, l := range newLines {
+		if !oldSet[l] {
+			buf.WriteString("+ " + l + "\n")
+		}
+	}
+	return buf.String()
+}
+
+// Wire applies (or dry-runs) the wiring described by opts.
+func Wire(opts WireOptions) (*WireResult, error) {
+	opts.normalise()
+	result := &WireResult{}
+
+	// Pre-flight (skip if unwiring — we're removing, not adding).
+	if !opts.Unwire {
+		findings, err := preflight(&opts)
+		result.Findings = findings
+		if err != nil {
+			return result, err
+		}
+	}
+
+	// Read current settings.
+	currentMap, err := readSettingsMap(opts.SettingsPath)
+	if err != nil {
+		return result, err
+	}
+
+	oldBytes, _ := marshalSettings(currentMap)
+
+	// Apply changes to a working copy.
+	workMap, err := readSettingsMap(opts.SettingsPath)
+	if err != nil {
+		return result, err
+	}
+
+	if opts.Unwire {
+		applyUnwire(workMap, &opts)
+	} else {
+		wired, skipped, slWired, slSkipped := applyWire(workMap, &opts)
+		result.WiredEvents = wired
+		result.SkippedEvents = skipped
+		result.StatusLineWired = slWired
+		result.StatusLineSkipped = slSkipped
+	}
+
+	newBytes, err := marshalSettings(workMap)
+	if err != nil {
+		return result, fmt.Errorf("marshal new settings: %w", err)
+	}
+
+	changed := !bytes.Equal(oldBytes, newBytes)
+
+	if opts.DryRun {
+		// Dry-run writes nothing, so the file is never modified: Changed stays
+		// false. The Diff still reflects what *would* change.
+		result.Changed = false
+		result.Diff = simpleDiff(oldBytes, newBytes)
+		return result, nil
+	}
+
+	result.Changed = changed
+	if !changed {
+		// Nothing to write.
+		return result, nil
+	}
+
+	// Backup before write.
+	backupPath, err := backup(opts.SettingsPath, opts.nowFn)
+	if err != nil {
+		return result, fmt.Errorf("backup: %w", err)
+	}
+	result.BackupPath = backupPath
+
+	// Write the new settings.
+	if err := os.MkdirAll(filepath.Dir(opts.SettingsPath), 0o700); err != nil {
+		return result, fmt.Errorf("ensure dir: %w", err)
+	}
+	if err := os.WriteFile(opts.SettingsPath, newBytes, 0o600); err != nil {
+		return result, fmt.Errorf("write settings: %w", err)
+	}
+
+	// Validate the written file.
+	if err := validateWritten(opts.SettingsPath, backupPath); err != nil {
+		return result, err
+	}
+
+	// Write rollback note (best-effort).
+	writeRollbackNote(&opts, backupPath)
+
+	return result, nil
+}

--- a/internal/hooks/wire_test.go
+++ b/internal/hooks/wire_test.go
@@ -1,0 +1,435 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedNow returns a deterministic time for backup-name assertions.
+func fixedNow() time.Time {
+	return time.Date(2026, 6, 13, 18, 31, 15, 0, time.UTC)
+}
+
+// fixedNowFn is the injectable nowFn that returns fixedNow().
+func fixedNowFn() time.Time { return fixedNow() }
+
+// emptySettings writes an empty JSON object to a temp file and returns its path.
+func emptySettings(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "settings.json")
+	require.NoError(t, os.WriteFile(p, []byte("{}\n"), 0o600))
+	return p
+}
+
+// settingsWithContent writes arbitrary JSON to a temp file and returns its path.
+func settingsWithContent(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "settings.json")
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+	return p
+}
+
+// nonexistentSettings returns a path inside a temp dir that does not yet exist.
+func nonexistentSettings(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	return filepath.Join(dir, "settings.json")
+}
+
+// readJSON reads a file and unmarshals it into a map.
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	return m
+}
+
+// baseOpts returns a WireOptions with a fixed nowFn and rollback note disabled.
+func baseOpts(settingsPath string) WireOptions {
+	return WireOptions{
+		SettingsPath:     settingsPath,
+		StatusLine:       true,
+		nowFn:            fixedNowFn,
+		RollbackNotePath: "-", // skip rollback note in tests
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Happy path: wire from empty
+// ---------------------------------------------------------------------------
+
+func TestWire_AddsHooksAndStatusLine(t *testing.T) {
+	p := emptySettings(t)
+	opts := baseOpts(p)
+
+	result, err := Wire(opts)
+	require.NoError(t, err)
+	assert.True(t, result.Changed)
+	assert.ElementsMatch(t, []string{"PreToolUse", "PostToolUse"}, result.WiredEvents)
+	assert.Empty(t, result.SkippedEvents)
+	assert.True(t, result.StatusLineWired)
+	assert.False(t, result.StatusLineSkipped)
+
+	m := readJSON(t, p)
+	hooksRaw, ok := m["hooks"].(map[string]any)
+	require.True(t, ok, "hooks should be an object")
+
+	for _, event := range []string{"PreToolUse", "PostToolUse"} {
+		groups, ok := hooksRaw[event].([]any)
+		require.True(t, ok, "event %s should have groups", event)
+		found := false
+		for _, g := range groups {
+			gm := g.(map[string]any)
+			matcher, _ := gm["matcher"].(string)
+			if matcher != "" {
+				continue
+			}
+			hooks, _ := gm["hooks"].([]any)
+			for _, h := range hooks {
+				hm := h.(map[string]any)
+				cmd, _ := hm["command"].(string)
+				if cmd == "hookwise dispatch "+event {
+					found = true
+				}
+			}
+		}
+		assert.True(t, found, "should have dispatch entry for %s", event)
+	}
+
+	slRaw, ok := m["statusLine"].(map[string]any)
+	require.True(t, ok, "statusLine should be a map")
+	assert.Equal(t, "hookwise status-line", slRaw["command"])
+	assert.Equal(t, "command", slRaw["type"])
+}
+
+// ---------------------------------------------------------------------------
+// Wire from a nonexistent file (new settings)
+// ---------------------------------------------------------------------------
+
+func TestWire_CreatesFileIfMissing(t *testing.T) {
+	p := nonexistentSettings(t)
+	opts := baseOpts(p)
+
+	result, err := Wire(opts)
+	require.NoError(t, err)
+	assert.True(t, result.Changed)
+
+	_, err = os.Stat(p)
+	assert.NoError(t, err, "settings.json should have been created")
+}
+
+// ---------------------------------------------------------------------------
+// Backup
+// ---------------------------------------------------------------------------
+
+func TestWire_BackupCreatedBeforeWrite(t *testing.T) {
+	p := emptySettings(t)
+	opts := baseOpts(p)
+
+	result, err := Wire(opts)
+	require.NoError(t, err)
+	require.NotEmpty(t, result.BackupPath)
+
+	// Backup path uses the fixed timestamp.
+	expectedBackup := p + ".bak-20260613T183115Z"
+	assert.Equal(t, expectedBackup, result.BackupPath)
+
+	// Backup exists and contains the original content.
+	data, err := os.ReadFile(result.BackupPath)
+	require.NoError(t, err)
+	assert.Equal(t, "{}\n", string(data))
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency: second Wire is a no-op
+// ---------------------------------------------------------------------------
+
+func TestWire_IdempotentRerun(t *testing.T) {
+	p := emptySettings(t)
+	opts := baseOpts(p)
+
+	// First wire.
+	r1, err := Wire(opts)
+	require.NoError(t, err)
+	assert.True(t, r1.Changed)
+
+	// Second wire with a different timestamp so backup names won't clash.
+	opts2 := opts
+	ts2 := fixedNow().Add(time.Minute)
+	opts2.nowFn = func() time.Time { return ts2 }
+
+	r2, err := Wire(opts2)
+	require.NoError(t, err)
+	assert.False(t, r2.Changed, "second wire should be a no-op")
+	assert.ElementsMatch(t, []string{"PreToolUse", "PostToolUse"}, r2.SkippedEvents)
+	assert.True(t, r2.StatusLineSkipped)
+	assert.False(t, r2.StatusLineWired)
+	assert.Empty(t, r2.BackupPath, "no backup when nothing changed")
+}
+
+// ---------------------------------------------------------------------------
+// DryRun: file unchanged, Diff populated
+// ---------------------------------------------------------------------------
+
+func TestWire_DryRun(t *testing.T) {
+	p := emptySettings(t)
+	mtime1, err := os.Stat(p)
+	require.NoError(t, err)
+
+	opts := baseOpts(p)
+	opts.DryRun = true
+
+	result, err := Wire(opts)
+	require.NoError(t, err)
+	assert.False(t, result.Changed)
+	assert.NotEmpty(t, result.Diff)
+	assert.Empty(t, result.BackupPath)
+
+	mtime2, err := os.Stat(p)
+	require.NoError(t, err)
+	assert.Equal(t, mtime1.ModTime(), mtime2.ModTime(), "file mtime must not change on dry-run")
+
+	// File content must still be the original.
+	data, _ := os.ReadFile(p)
+	assert.Equal(t, "{}\n", string(data))
+
+	// Diff should mention the added content.
+	assert.True(t, strings.Contains(result.Diff, "hookwise dispatch"), "diff should mention dispatch command")
+}
+
+// ---------------------------------------------------------------------------
+// --events: only wire specified event
+// ---------------------------------------------------------------------------
+
+func TestWire_CustomEvents(t *testing.T) {
+	p := emptySettings(t)
+	opts := baseOpts(p)
+	opts.Events = []string{"PreToolUse"}
+	opts.StatusLine = false
+
+	result, err := Wire(opts)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"PreToolUse"}, result.WiredEvents)
+	assert.Empty(t, result.SkippedEvents)
+
+	m := readJSON(t, p)
+	hooksRaw := m["hooks"].(map[string]any)
+	assert.Contains(t, hooksRaw, "PreToolUse")
+	assert.NotContains(t, hooksRaw, "PostToolUse")
+}
+
+// ---------------------------------------------------------------------------
+// --no-status-line: statusLine not added
+// ---------------------------------------------------------------------------
+
+func TestWire_NoStatusLine(t *testing.T) {
+	p := emptySettings(t)
+	opts := baseOpts(p)
+	opts.StatusLine = false
+
+	result, err := Wire(opts)
+	require.NoError(t, err)
+	assert.False(t, result.StatusLineWired)
+	assert.False(t, result.StatusLineSkipped)
+
+	m := readJSON(t, p)
+	_, hasStatusLine := m["statusLine"]
+	assert.False(t, hasStatusLine, "statusLine should not be present")
+}
+
+// ---------------------------------------------------------------------------
+// Preserves unrelated keys
+// ---------------------------------------------------------------------------
+
+func TestWire_PreservesOtherKeys(t *testing.T) {
+	content := `{"theme": "dark", "someOtherSetting": true}`
+	p := settingsWithContent(t, content)
+	opts := baseOpts(p)
+
+	_, err := Wire(opts)
+	require.NoError(t, err)
+
+	m := readJSON(t, p)
+	assert.Equal(t, "dark", m["theme"])
+	assert.Equal(t, true, m["someOtherSetting"])
+}
+
+// ---------------------------------------------------------------------------
+// Unwire: removes only hookwise entries, preserves others
+// ---------------------------------------------------------------------------
+
+func TestWire_Unwire_RemovesOnlyHookwiseEntries(t *testing.T) {
+	// Seed a settings.json with both hookwise entries AND an unrelated guard hook.
+	content := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [{"type": "command", "command": "hookwise dispatch PreToolUse"}]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "python3 /usr/local/lib/guard.py"}]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [{"type": "command", "command": "hookwise dispatch PostToolUse"}]
+      }
+    ]
+  },
+  "statusLine": {"type": "command", "command": "hookwise status-line"},
+  "theme": "dark"
+}`
+	p := settingsWithContent(t, content)
+	opts := baseOpts(p)
+	opts.Unwire = true
+
+	result, err := Wire(opts)
+	require.NoError(t, err)
+	assert.True(t, result.Changed)
+
+	m := readJSON(t, p)
+
+	// The unrelated guard hook must still be present.
+	hooksRaw, ok := m["hooks"].(map[string]any)
+	require.True(t, ok)
+	preGroups, ok := hooksRaw["PreToolUse"].([]any)
+	require.True(t, ok, "PreToolUse should still exist (has non-hookwise group)")
+	assert.Len(t, preGroups, 1, "only the guard.py group should remain")
+	gm := preGroups[0].(map[string]any)
+	hooks, _ := gm["hooks"].([]any)
+	hm := hooks[0].(map[string]any)
+	assert.Equal(t, "python3 /usr/local/lib/guard.py", hm["command"])
+
+	// PostToolUse had only hookwise entries; the event key should be removed.
+	_, postExists := hooksRaw["PostToolUse"]
+	assert.False(t, postExists, "PostToolUse should be removed entirely")
+
+	// statusLine should be removed.
+	_, slExists := m["statusLine"]
+	assert.False(t, slExists, "statusLine should be removed on unwire")
+
+	// Unrelated key preserved.
+	assert.Equal(t, "dark", m["theme"])
+}
+
+// ---------------------------------------------------------------------------
+// Unwire is idempotent (second unwire is a no-op)
+// ---------------------------------------------------------------------------
+
+func TestWire_Unwire_Idempotent(t *testing.T) {
+	content := `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "", "hooks": [{"type": "command", "command": "hookwise dispatch PreToolUse"}]}
+    ]
+  },
+  "statusLine": {"type": "command", "command": "hookwise status-line"}
+}`
+	p := settingsWithContent(t, content)
+	opts := baseOpts(p)
+	opts.Unwire = true
+
+	// First unwire.
+	r1, err := Wire(opts)
+	require.NoError(t, err)
+	assert.True(t, r1.Changed)
+
+	// Second unwire — already gone, nothing to change.
+	opts2 := opts
+	ts2 := fixedNow().Add(time.Minute)
+	opts2.nowFn = func() time.Time { return ts2 }
+	r2, err := Wire(opts2)
+	require.NoError(t, err)
+	assert.False(t, r2.Changed)
+}
+
+// ---------------------------------------------------------------------------
+// Validate-after-write: malformed backup restore
+// ---------------------------------------------------------------------------
+
+func TestWire_ValidateWritten_PassesOnHappyPath(t *testing.T) {
+	// Confirm that the written file validates cleanly (no restore needed).
+	p := emptySettings(t)
+	opts := baseOpts(p)
+
+	result, err := Wire(opts)
+	require.NoError(t, err)
+	// Backup exists, written file parses.
+	require.NotEmpty(t, result.BackupPath)
+
+	var tmp any
+	data, _ := os.ReadFile(p)
+	assert.NoError(t, json.Unmarshal(data, &tmp), "written file must be valid JSON")
+}
+
+// ---------------------------------------------------------------------------
+// Pre-flight: malformed existing settings file is recorded (ParseError)
+// ---------------------------------------------------------------------------
+
+func TestWire_PreExistingMalformedFile_HandledGracefully(t *testing.T) {
+	p := settingsWithContent(t, `{ not valid json }`)
+	opts := baseOpts(p)
+
+	// Wire should fail because readSettingsMap will return an error for malformed JSON.
+	_, err := Wire(opts)
+	assert.Error(t, err, "malformed settings.json should yield an error")
+}
+
+// ---------------------------------------------------------------------------
+// Custom DispatchCommand and StatusLineCommand
+// ---------------------------------------------------------------------------
+
+func TestWire_CustomCommands(t *testing.T) {
+	p := emptySettings(t)
+	opts := baseOpts(p)
+	opts.DispatchCommand = "/usr/local/bin/hookwise dispatch"
+	opts.StatusLineCommand = "/usr/local/bin/hookwise status-line"
+
+	result, err := Wire(opts)
+	require.NoError(t, err)
+	assert.True(t, result.Changed)
+
+	m := readJSON(t, p)
+	hooksRaw := m["hooks"].(map[string]any)
+	groups := hooksRaw["PreToolUse"].([]any)
+	gm := groups[0].(map[string]any)
+	hooks := gm["hooks"].([]any)
+	hm := hooks[0].(map[string]any)
+	assert.Equal(t, "/usr/local/bin/hookwise dispatch PreToolUse", hm["command"])
+}
+
+// ---------------------------------------------------------------------------
+// DryRun on already-wired file: reports no changes
+// ---------------------------------------------------------------------------
+
+func TestWire_DryRun_AlreadyWired_ReportsNoChanges(t *testing.T) {
+	p := emptySettings(t)
+	opts := baseOpts(p)
+
+	// Wire first.
+	_, err := Wire(opts)
+	require.NoError(t, err)
+
+	// DryRun second time.
+	opts2 := opts
+	opts2.DryRun = true
+	opts2.nowFn = fixedNowFn
+	result, err := Wire(opts2)
+	require.NoError(t, err)
+	assert.False(t, result.Changed)
+	assert.Contains(t, result.Diff, "(no changes)")
+}


### PR DESCRIPTION
## What
Adds `hookwise init --wire` — productizes the manual dogfood wiring (done by hand on 2026-06-13) into one **safe, reversible, idempotent** command.

Per the design in `openspec/changes/init-wire/proposal.md`:
1. **Locate** settings.json (`--settings` > `$CLAUDE_CONFIG_DIR` > `~/.claude`)
2. **Backup** to `settings.json.bak-<RFC3339Z>` before any write
3. **Matcher-aware pre-flight** (reuses `internal/hooks` Scan + AllFindings); refuses on a true-duplicate / FAIL-level always-fire sprawl unless `--force`
4. **Idempotent wire**: adds `{matcher:"", command:"hookwise dispatch <Event>"}` per event + `statusLine`; skips entries already present (re-run is a no-op)
5. **Validate**: re-parses the written file; restores backup on failure — never leaves a malformed settings.json
6. **Rollback note** at `~/.hookwise/dogfood-rollback.md`

Flags: `--dry-run`, `--unwire`, `--events`, `--no-status-line`, `--settings`, `--force`.

## Where
- `internal/hooks/wire.go` — hermetic wiring engine (whole-doc `map[string]any` round-trip preserves all other settings)
- `internal/hooks/wire_test.go` — temp-path tests (idempotency, dry-run no-write, unwire-preserves-others, events, statusLine)
- `cmd/hookwise/cmd_init.go` — flags wired onto existing `init`; default `hookwise init` unchanged

## Verification
- Guarded gate green: `task test:go:unit` (race, -p 2) across all 8 packages
- End-to-end smoke (temp settings): dry-run writes nothing; real wire → 3 refs + backup, `Read` perm preserved; re-run no-op; `--unwire` removes only hookwise entries
- Caught + fixed during the guarded gate: dry-run was reporting `Changed=true` (should be false — nothing written)

## Known follow-up (non-blocking)
- The `--dry-run` diff renderer (`simpleDiff`) has imperfect brace rendering; the **written** JSON is valid (jq-verified). Cosmetic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)