### PR TITLE
feat(status-line): add news segment renderer

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -777,6 +777,109 @@ func TestStatusLineCalendarSegmentStringEvent(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// 17c. News segment renders from cache
+// ---------------------------------------------------------------------------
+
+func TestStatusLineNewsSegment(t *testing.T) {
+	feedCache := map[string]interface{}{
+		"news": map[string]interface{}{
+			"type":      "news",
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+			"data": map[string]interface{}{
+				"source": "hackernews",
+				"stories": []interface{}{
+					map[string]interface{}{
+						"title": "Go 1.24 Released With New Features",
+						"url":   "https://go.dev/blog/go1.24",
+						"score": float64(500),
+					},
+					map[string]interface{}{
+						"title": "Second Story",
+						"url":   "https://example.com",
+						"score": float64(200),
+					},
+				},
+			},
+		},
+	}
+
+	result := renderBuiltinSegment("news", feedCache, nil)
+	stripped := stripANSI(result)
+
+	if !strings.Contains(stripped, "\U0001f4f0") {
+		t.Errorf("news should show 📰 emoji, got: %s", stripped)
+	}
+	if !strings.Contains(stripped, "Go 1.24 Released With New Features") {
+		t.Errorf("news should show top story title, got: %s", stripped)
+	}
+	// Should show top story, not second
+	if strings.Contains(stripped, "Second Story") {
+		t.Errorf("news should show only top story, got: %s", stripped)
+	}
+}
+
+func TestStatusLineNewsSegmentEmpty(t *testing.T) {
+	// Empty stories list should return "".
+	feedCache := map[string]interface{}{
+		"news": map[string]interface{}{
+			"type":      "news",
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+			"data": map[string]interface{}{
+				"source":  "unavailable",
+				"stories": []interface{}{},
+			},
+		},
+	}
+
+	result := renderBuiltinSegment("news", feedCache, nil)
+	if result != "" {
+		t.Errorf("news with empty stories should return empty, got: %s", stripANSI(result))
+	}
+}
+
+func TestStatusLineNewsSegmentMissingFeed(t *testing.T) {
+	// No news key at all should return "".
+	result := renderBuiltinSegment("news", map[string]interface{}{}, nil)
+	if result != "" {
+		t.Errorf("news with no feed data should return empty, got: %s", stripANSI(result))
+	}
+}
+
+func TestStatusLineNewsSegmentTruncation(t *testing.T) {
+	// Title longer than 40 runes should be truncated with ellipsis.
+	longTitle := "This Is A Very Long Headline That Exceeds Forty Runes And Should Be Truncated By The Renderer"
+	feedCache := map[string]interface{}{
+		"news": map[string]interface{}{
+			"type":      "news",
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+			"data": map[string]interface{}{
+				"source": "hackernews",
+				"stories": []interface{}{
+					map[string]interface{}{
+						"title": longTitle,
+						"url":   "https://example.com",
+						"score": float64(100),
+					},
+				},
+			},
+		},
+	}
+
+	result := renderBuiltinSegment("news", feedCache, nil)
+	stripped := stripANSI(result)
+
+	if !strings.Contains(stripped, "…") {
+		t.Errorf("long title should be truncated with '…', got: %s", stripped)
+	}
+	// Rune-count of the title portion (after emoji+space) must not exceed 40+1 (for "…")
+	// Strip the emoji prefix and check length bound.
+	titlePart := strings.TrimPrefix(stripped, "\U0001f4f0 ")
+	if len([]rune(titlePart)) > 41 {
+		t.Errorf("truncated title should be ≤41 runes (40 + ellipsis), got %d runes: %s", len([]rune(titlePart)), titlePart)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // 18. Placeholder fallback renders "--" not "0"
 // ---------------------------------------------------------------------------
 

--- a/cmd/hookwise/cmd_status_line.go
+++ b/cmd/hookwise/cmd_status_line.go
@@ -223,6 +223,8 @@ func renderBuiltinSegment(name string, feedCache map[string]interface{}, summary
 		return renderCalendarSegment(feedCache)
 	case "weather":
 		return renderWeatherSegment(feedCache)
+	case "news":
+		return renderNewsSegment(feedCache)
 	case "insights":
 		return renderInsightsSegment(feedCache)
 	case "insights_friction":
@@ -314,6 +316,45 @@ func renderWeatherSegment(feedCache map[string]interface{}) string {
 	}
 
 	return ansiCyan + emoji + tempStr + "\u00b0" + unit + desc + ansiReset
+}
+
+// truncateRunes returns s truncated to maxRunes runes, appending "…" if it was longer.
+func truncateRunes(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	return string(runes[:maxRunes]) + "…"
+}
+
+// renderNewsSegment renders the news segment from feed cache data.
+// It displays the top story title prefixed with a 📰 emoji, truncated to 40 runes.
+func renderNewsSegment(feedCache map[string]interface{}) string {
+	data := feedData(feedCache, "news")
+	if data == nil {
+		return ""
+	}
+
+	storiesRaw, ok := data["stories"]
+	if !ok {
+		return ""
+	}
+	stories, ok := storiesRaw.([]interface{})
+	if !ok || len(stories) == 0 {
+		return ""
+	}
+
+	topStory, ok := stories[0].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	title, _ := topStory["title"].(string)
+	if title == "" {
+		return ""
+	}
+
+	return ansiCyan + "\U0001f4f0 " + truncateRunes(title, 40) + ansiReset
 }
 
 // renderProjectSegment renders the project segment from feed cache data.


### PR DESCRIPTION
## What
Adds a `news` status-line segment. `renderBuiltinSegment` had no `case "news"`, so a configured `news` segment fell through to the dim default label instead of rendering a headline.

- New `renderNewsSegment(feedCache)` reads `feedData(news).data.stories[0].title`, rune-safe truncation to 40, 📰 prefix — mirrors the existing weather/calendar renderers.
- Unit tests: top-headline render, empty/missing → "", long-title truncation.

## Why
First of three fixes needed for "see news in the status bar" (found via first-principles live debugging):
1. **this PR** — the renderer (was missing entirely).
2. calendar OAuth context-cancel bug (separate PR).
3. feed-cache TTL (300s) < poll interval (news 1800s) so segments are marked stale and hidden most of each cycle (separate issue).

## Verification
- `go build ./...` + `go vet` clean; `go test -race -p 1 ./cmd/hookwise/` (news tests) green, 0 zombies.
- Live: built the branch binary and rendered against the real `~/.hookwise/state/news.json` (5 HN stories). Renderer works; note the segment is only visible while the cache is within TTL — fix #3 addresses that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a news segment to the status line displaying the top story with a newspaper emoji.
  * Automatically truncates long story titles to maintain display formatting.

* **Tests**
  * Added comprehensive unit tests validating the news segment behavior across various data scenarios, including empty feeds and missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->