### PR TITLE
fix(feeds): set cache TTL to poll interval so segments stay fresh

### DIFF
--- a/internal/feeds/feeds_test.go
+++ b/internal/feeds/feeds_test.go
@@ -1579,3 +1579,148 @@ func TestDaemon_SocketBindReleasedOnStop(t *testing.T) {
 	require.NoError(t, d2.Start(), "second daemon should start after first stopped")
 	require.NoError(t, d2.Stop())
 }
+
+// ---------------------------------------------------------------------------
+// feedCacheTTLSeconds unit tests (issue #88)
+// ---------------------------------------------------------------------------
+
+func TestFeedCacheTTLSeconds_Table(t *testing.T) {
+	tests := []struct {
+		interval time.Duration
+		wantTTL  int
+	}{
+		{1800 * time.Second, 1920}, // news: 1800 + 120
+		{900 * time.Second, 1020},  // weather: 900 + 120
+		{300 * time.Second, 420},   // 300 + 120 = 420 > floor(300)
+		{60 * time.Second, 300},    // 60 + 120 = 180 < floor(300) → 300
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.interval.String(), func(t *testing.T) {
+			got := feedCacheTTLSeconds(tt.interval)
+			assert.Equal(t, tt.wantTTL, got,
+				"feedCacheTTLSeconds(%v) = %d, want %d", tt.interval, got, tt.wantTTL)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runProducer TTL injection tests (issue #88)
+// ---------------------------------------------------------------------------
+
+// canonicalEnvelopeProducer returns a canonical NewEnvelope for runProducer tests.
+type canonicalEnvelopeProducer struct {
+	name string
+	data map[string]interface{}
+}
+
+func (c *canonicalEnvelopeProducer) Name() string { return c.name }
+func (c *canonicalEnvelopeProducer) Produce(_ context.Context) (interface{}, error) {
+	// Deep-copy data so mutations in runProducer don't affect the original map.
+	dataCopy := make(map[string]interface{}, len(c.data))
+	for k, v := range c.data {
+		dataCopy[k] = v
+	}
+	return NewEnvelope(c.name, dataCopy), nil
+}
+
+// readCacheJSON reads and unmarshals a JSON cache file written by runProducer.
+func readCacheJSON(t *testing.T, cacheDir, name string) map[string]interface{} {
+	t.Helper()
+	path := filepath.Join(cacheDir, name+".json")
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err, "cache file %s should exist", path)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}
+
+// TestRunProducer_InjectsTTLForLongInterval verifies that runProducer injects
+// ttl_seconds = interval + grace (1800 + 120 = 1920) when the producer does not
+// set ttl_seconds (the common case for news/weather producers).
+func TestRunProducer_InjectsTTLForLongInterval(t *testing.T) {
+	r := NewRegistry()
+	p := &canonicalEnvelopeProducer{
+		name: "news",
+		data: map[string]interface{}{"headline": "test"},
+	}
+	r.Register(p)
+
+	d, tmpDir := newTestDaemon(t, r)
+	cacheDir := filepath.Join(tmpDir, "cache")
+	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
+	d.SetCacheDir(cacheDir)
+
+	interval := 1800 * time.Second
+	ctx := context.Background()
+	d.runProducer(ctx, p, interval)
+
+	m := readCacheJSON(t, cacheDir, "news")
+	data, ok := m["data"].(map[string]interface{})
+	require.True(t, ok, "envelope should have a 'data' map")
+
+	ttl, ok := data["ttl_seconds"].(float64) // JSON numbers unmarshal as float64
+	require.True(t, ok, "data.ttl_seconds should be a number after JSON round-trip")
+	assert.Equal(t, float64(1920), ttl, "ttl_seconds should be 1800 + 120 grace")
+}
+
+// TestRunProducer_FloorForShortInterval verifies that a sub-floor interval (60s)
+// yields bridge.DefaultTTLSeconds (300) rather than 60+120=180.
+func TestRunProducer_FloorForShortInterval(t *testing.T) {
+	r := NewRegistry()
+	p := &canonicalEnvelopeProducer{
+		name: "project",
+		data: map[string]interface{}{"branch": "main"},
+	}
+	r.Register(p)
+
+	d, tmpDir := newTestDaemon(t, r)
+	cacheDir := filepath.Join(tmpDir, "cache")
+	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
+	d.SetCacheDir(cacheDir)
+
+	interval := 60 * time.Second
+	ctx := context.Background()
+	d.runProducer(ctx, p, interval)
+
+	m := readCacheJSON(t, cacheDir, "project")
+	data, ok := m["data"].(map[string]interface{})
+	require.True(t, ok, "envelope should have a 'data' map")
+
+	ttl, ok := data["ttl_seconds"].(float64)
+	require.True(t, ok, "data.ttl_seconds should be a number")
+	assert.Equal(t, float64(300), ttl,
+		"short-interval TTL should be floored at bridge.DefaultTTLSeconds (300)")
+}
+
+// TestRunProducer_DoesNotOverwriteProducerSetTTL verifies that if the producer
+// already sets ttl_seconds, runProducer leaves it unchanged.
+func TestRunProducer_DoesNotOverwriteProducerSetTTL(t *testing.T) {
+	r := NewRegistry()
+	p := &canonicalEnvelopeProducer{
+		name: "weather",
+		data: map[string]interface{}{
+			"temperature": 72,
+			"ttl_seconds": 9999, // producer explicitly sets its own TTL
+		},
+	}
+	r.Register(p)
+
+	d, tmpDir := newTestDaemon(t, r)
+	cacheDir := filepath.Join(tmpDir, "cache")
+	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
+	d.SetCacheDir(cacheDir)
+
+	interval := 900 * time.Second
+	ctx := context.Background()
+	d.runProducer(ctx, p, interval)
+
+	m := readCacheJSON(t, cacheDir, "weather")
+	data, ok := m["data"].(map[string]interface{})
+	require.True(t, ok, "envelope should have a 'data' map")
+
+	ttl, ok := data["ttl_seconds"].(float64)
+	require.True(t, ok, "data.ttl_seconds should be a number")
+	assert.Equal(t, float64(9999), ttl,
+		"runProducer must not overwrite a ttl_seconds already set by the producer")
+}

--- a/internal/feeds/polling.go
+++ b/internal/feeds/polling.go
@@ -9,6 +9,26 @@ import (
 	"github.com/vishnujayvel/hookwise/internal/core"
 )
 
+// ttlGraceSeconds keeps a cache entry "fresh" a bit past its poll interval so
+// one slow/missed poll doesn't blank the segment; a truly stopped daemon still
+// ages it out.
+const ttlGraceSeconds = 120
+
+// feedTTLFloorSeconds mirrors bridge.DefaultTTLSeconds (kept local to avoid a
+// feeds→bridge import, which cycles with bridge_test → feeds). Fast feeds never
+// get a TTL shorter than this floor.
+const feedTTLFloorSeconds = 300
+
+// feedCacheTTLSeconds computes the TTL to inject into a cache envelope for a
+// given poll interval: interval + grace, floored at feedTTLFloorSeconds.
+func feedCacheTTLSeconds(interval time.Duration) int {
+	ttl := int(interval.Seconds()) + ttlGraceSeconds
+	if ttl < feedTTLFloorSeconds {
+		ttl = feedTTLFloorSeconds
+	}
+	return ttl
+}
+
 // ConfigAware is an optional interface that producers can implement to receive
 // the feed configuration before producing data.
 type ConfigAware interface {
@@ -33,7 +53,7 @@ func (d *Daemon) pollFeed(ctx context.Context, p Producer, interval time.Duratio
 	defer ticker.Stop()
 
 	// Run once immediately on start.
-	d.runProducer(ctx, p)
+	d.runProducer(ctx, p, interval)
 
 	for {
 		select {
@@ -42,7 +62,7 @@ func (d *Daemon) pollFeed(ctx context.Context, p Producer, interval time.Duratio
 		case <-d.stopCh:
 			return
 		case <-ticker.C:
-			d.runProducer(ctx, p)
+			d.runProducer(ctx, p, interval)
 		}
 	}
 }
@@ -50,7 +70,12 @@ func (d *Daemon) pollFeed(ctx context.Context, p Producer, interval time.Duratio
 // runProducer executes a single producer and writes the result to the JSON cache.
 // Panics in Produce() are recovered so that a failing producer cannot crash
 // the daemon goroutine (ARCH-1 fail-open guarantee).
-func (d *Daemon) runProducer(ctx context.Context, p Producer) {
+//
+// interval is the poll interval for this producer; it is used to compute and
+// inject a ttl_seconds value into the envelope's data map so the status-line
+// segment stays visible until the next poll (+ grace). Producers that already
+// set ttl_seconds are left unchanged.
+func (d *Daemon) runProducer(ctx context.Context, p Producer, interval time.Duration) {
 	// IDLE-1: Reset idle timer on producer poll completion, including
 	// error/panic paths — any activity counts.
 	defer d.resetIdleTimer()
@@ -64,6 +89,18 @@ func (d *Daemon) runProducer(ctx context.Context, p Producer) {
 	if err != nil {
 		core.Logger().Error("feeds: producer error", "producer", p.Name(), "error", err)
 		return
+	}
+
+	// Inject ttl_seconds into the envelope's data map so the bridge freshness
+	// check keeps the segment visible until the next poll + grace period.
+	// Producers that already set ttl_seconds are left unchanged (ok guards are
+	// fail-safe for non-canonical shapes).
+	if env, ok := data.(map[string]interface{}); ok {
+		if dataMap, ok := env["data"].(map[string]interface{}); ok {
+			if _, exists := dataMap["ttl_seconds"]; !exists {
+				dataMap["ttl_seconds"] = feedCacheTTLSeconds(interval)
+			}
+		}
 	}
 
 	// ARCH-3: Write to JSON cache only, NOT the analytics DB.


### PR DESCRIPTION
Closes #88.

## Bug
Feed cache freshness used `bridge.DefaultTTLSeconds = 300`, but no producer set `ttl_seconds`, and poll intervals are longer (news 1800s, weather 900s). So `IsEnvelopeFresh` marked the cache stale and the status-line segment was **hidden ~25 of every 30 min** — the real reason news doesn't stay on the bar (the renderer in #86 was necessary but not sufficient).

## Fix
`runProducer` injects `ttl_seconds = interval + 120s grace` (floored at 300) into the envelope `data` at the single cache-write chokepoint, unless the producer already set one. Uses the interval the daemon already computes per feed; non-canonical producer outputs are left untouched (fail-safe). Local floor const avoids a `feeds→bridge` import cycle (bridge_test imports feeds).

## Tests (internal/feeds)
- `feedCacheTTLSeconds` table: 1800→1920, 900→1020, 300→420, 60→300 (floor).
- `runProducer` writes `ttl_seconds=1920` for a 1800s interval; floor at 300 for 60s; does not overwrite a producer-set value.

## Verification
- Guarded gate green: `task test:go:unit` (race, internal/feeds), 0 zombies.
- Live: install + restart daemon; confirm `news.json` now carries `ttl_seconds` and the `news` segment stays rendered past 5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)