### PR TITLE
test(feeds): isolate tests from real ~/.hookwise via TestMain

### DIFF
--- a/internal/feeds/main_test.go
+++ b/internal/feeds/main_test.go
@@ -1,0 +1,27 @@
+package feeds
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain redirects HOOKWISE_STATE_DIR to a throwaway temp directory before any
+// test in this package runs. core.Logger() resolves its log path from
+// GetStateDir() inside a sync.Once, so without this the feed/producer tests
+// (e.g. the calendar fail-open and httptest cases) write to the user's REAL
+// ~/.hookwise/logs/hookwise.log — polluting the live log and muddying debugging.
+// See issue #91. The env var must be set before the first Logger() call, which
+// is exactly what TestMain guarantees (it runs before m.Run()).
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "hookwise-feeds-test-")
+	if err == nil {
+		_ = os.Setenv("HOOKWISE_STATE_DIR", tmp)
+	}
+
+	code := m.Run()
+
+	if tmp != "" {
+		_ = os.RemoveAll(tmp)
+	}
+	os.Exit(code)
+}


### PR DESCRIPTION
Closes #91.

## Bug
`internal/feeds` tests call `core.Logger()`, which builds its log path from `GetStateDir()` inside a `sync.Once` and writes to the **real** `~/.hookwise/logs/hookwise.log`. During live calendar debugging, the real log showed test-only lines (an httptest 500, the `/nonexistent/path/calendar-token.json` fixture) — which initially looked like a live daemon failure.

## Fix (test-only)
Add `internal/feeds/main_test.go` with a `TestMain` that points `HOOKWISE_STATE_DIR` at a throwaway temp dir before `m.Run()` (so it's set before the first `Logger()` call), and cleans it up after. No production code changes.

## Verification
- `go build ./...` + `go vet ./internal/feeds/...` clean.
- Guarded single-package run green, 0 zombies.
- **Live proof:** `~/.hookwise/logs/hookwise.log` is byte-identical (134,380,367 bytes) before and after running the feeds tests — no more pollution.

Note: other packages whose tests call `core.Logger()` may want the same TestMain; this PR covers the observed offender (feeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)