### PR TITLE
test: isolate guarded gate from real ~/.hookwise state dir

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -107,6 +107,11 @@ tasks:
       # -race requires cgo; pin it so a shell with CGO_ENABLED=0 (e.g. mirroring
       # the install target) doesn't break the race detector build.
       CGO_ENABLED: "1"
+      # Isolate the run from the developer's real ~/.hookwise: core.Logger() and
+      # GetStateDir() honor HOOKWISE_STATE_DIR, so a fresh temp dir keeps tests
+      # from writing to the live log/state (issue #91, machine-level pollution).
+      HOOKWISE_STATE_DIR:
+        sh: mktemp -d
     cmds:
       - go test -race -p {{.TEST_PARALLEL}} ./internal/core/... ./internal/feeds/... ./internal/bridge/... ./internal/analytics/... ./internal/notifications/... ./internal/migration/... ./internal/hooks/... ./pkg/...
 


### PR DESCRIPTION
Part of #91.

## Problem
Unit tests across several packages call `core.Logger()` (and other `GetStateDir()` paths), which resolve to the developer's real `~/.hookwise/logs+state`. Running `task test:go:unit` locally pollutes the live log/state. PR #92 fixed `internal/feeds` with a per-package `TestMain`, but the issue is broader.

## Fix
Set `HOOKWISE_STATE_DIR` to a fresh `mktemp -d` in the `test:go:unit` task env. `GetStateDir()` already honors that var, so every unit-test package writes to the throwaway dir instead of `~/.hookwise`. One change covers the whole guarded gate (the CI container is already isolated; this fixes local-dev hygiene).

## Verification
- Guarded gate green across all packages (`task test:go:unit`), 0 zombies.
- **Live proof:** `~/.hookwise/logs/hookwise.log` is byte-identical (134,380,606 bytes) before and after a full gate run — no pollution.

Note: bare `go test ./<pkg>/` outside `task` still writes to real state unless the package has its own `TestMain` (feeds does, via #92); other packages could add one if direct-run isolation is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by ensuring unit tests run with isolated temporary state directories, preventing test runs from interfering with local development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->