### PR TITLE
test: isolate remaining test tasks from real ~/.hookwise

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -123,6 +123,9 @@ tasks:
       # -race requires cgo; pin it so a shell with CGO_ENABLED=0 (e.g. mirroring
       # the install target) doesn't break the race detector build.
       CGO_ENABLED: "1"
+      # Isolate from the developer's real ~/.hookwise state/log (#91).
+      HOOKWISE_STATE_DIR:
+        sh: mktemp -d
     cmds:
       - go test -race -p {{.TEST_PARALLEL}} ./internal/contract/...
 
@@ -134,6 +137,9 @@ tasks:
       # -race requires cgo; pin it so a shell with CGO_ENABLED=0 (e.g. mirroring
       # the install target) doesn't break the race detector build.
       CGO_ENABLED: "1"
+      # Isolate from the developer's real ~/.hookwise state/log (#91).
+      HOOKWISE_STATE_DIR:
+        sh: mktemp -d
     cmds:
       - go test -race -p {{.TEST_PARALLEL}} ./internal/arch/...
 
@@ -145,6 +151,9 @@ tasks:
       # -race requires cgo; pin it so a shell with CGO_ENABLED=0 (e.g. mirroring
       # the install target) doesn't break the race detector build.
       CGO_ENABLED: "1"
+      # Isolate from the developer's real ~/.hookwise state/log (#91).
+      HOOKWISE_STATE_DIR:
+        sh: mktemp -d
     cmds:
       - go test -race -p {{.TEST_PARALLEL}} ./internal/proptest/...
 
@@ -182,6 +191,9 @@ tasks:
       # -race requires cgo; pin it so a shell with CGO_ENABLED=0 (e.g. mirroring
       # the install target) doesn't break the race detector build.
       CGO_ENABLED: "1"
+      # Isolate from the developer's real ~/.hookwise state/log (#91).
+      HOOKWISE_STATE_DIR:
+        sh: mktemp -d
     cmds:
       - go test -race -p {{.TEST_PARALLEL}} -tags integration ./...
 
@@ -193,6 +205,9 @@ tasks:
       # -race requires cgo; pin it so a shell with CGO_ENABLED=0 (e.g. mirroring
       # the install target) doesn't break the race detector build.
       CGO_ENABLED: "1"
+      # Isolate from the developer's real ~/.hookwise state/log (#91).
+      HOOKWISE_STATE_DIR:
+        sh: mktemp -d
     cmds:
       - go test -race -p {{.TEST_PARALLEL}} -tags mutation ./internal/mutation/...
 


### PR DESCRIPTION
Finishes #91.

## What
#95 isolated `test:go:unit`. This extends the same `HOOKWISE_STATE_DIR: {sh: mktemp -d}` env to the other state-writing Go test tasks: `test:go:contract`, `test:go:arch`, `test:go:pbt`, `test:go:integration`, `test:go:mutation`. Now no local test run via `task` writes to the developer's real `~/.hookwise/logs+state`.

## Verification
- `task --list` parses; `HOOKWISE_STATE_DIR` present on all 6 Go test tasks.
- `task test:go:contract` green; **real `~/.hookwise/logs/hookwise.log` byte-identical (134,380,770) before/after** — confirmed isolated.
- 0 zombies (retro-009 guard held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)