### PR TITLE
fix(notifications): generate notifications during dispatch

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -987,7 +987,7 @@ func TestRecordAnalytics_SessionStart(t *testing.T) {
 	dbPath := filepath.Join(tmpDir, "analytics.db")
 
 	payload := core.HookPayload{SessionID: "test-session-001"}
-	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath)
+	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, 0)
 
 	// Verify session was recorded.
 	db, err := analytics.Open(dbPath)
@@ -1013,11 +1013,11 @@ func TestRecordAnalytics_PostToolUse(t *testing.T) {
 
 	// First create a session.
 	payload := core.HookPayload{SessionID: "test-session-002"}
-	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath)
+	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, 0)
 
 	// Record a tool use event.
 	payload.ToolName = "Bash"
-	recordAnalytics(context.Background(), core.EventPostToolUse, payload, dbPath)
+	recordAnalytics(context.Background(), core.EventPostToolUse, payload, dbPath, 0)
 
 	db, err := analytics.Open(dbPath)
 	if err != nil {

--- a/cmd/hookwise/cmd_dispatch.go
+++ b/cmd/hookwise/cmd_dispatch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/vishnujayvel/hookwise/internal/analytics"
 	"github.com/vishnujayvel/hookwise/internal/core"
+	"github.com/vishnujayvel/hookwise/internal/notifications"
 )
 
 // newDispatchCmd handles "hookwise dispatch <EventType>".
@@ -92,7 +93,7 @@ func newDispatchCmd() *cobra.Command {
 					done := make(chan struct{})
 					go func() {
 						defer close(done)
-						recordAnalytics(ctx, eventType, payload, config.Analytics.DBPath)
+						recordAnalytics(ctx, eventType, payload, config.Analytics.DBPath, config.CostTracking.DailyBudget)
 					}()
 					select {
 					case <-done:
@@ -145,7 +146,7 @@ const analyticsRecordTimeout = 2 * time.Second
 // recordAnalytics writes session/event data to the SQLite analytics DB. The
 // caller waits for it (bounded) before os.Exit so the write actually persists.
 // Fail-open: any error is logged but never surfaces to the user (ARCH-1).
-func recordAnalytics(ctx context.Context, eventType string, payload core.HookPayload, dataDir string) {
+func recordAnalytics(ctx context.Context, eventType string, payload core.HookPayload, dataDir string, budgetThreshold float64) {
 	defer func() {
 		if r := recover(); r != nil {
 			core.Logger().Error("panic in analytics recording", "recovered", fmt.Sprintf("%v", r))
@@ -180,6 +181,15 @@ func recordAnalytics(ctx context.Context, eventType string, payload core.HookPay
 		}
 		if err := a.RecordEvent(ctx, payload.SessionID, event); err != nil {
 			core.Logger().Error("analytics: record event", "error", err)
+		}
+
+		// Best-effort notification generation (fail-open, ARCH-1). Producers dedup
+		// per day, so repeated calls don't spam.
+		costState, _ := db.ReadCostState(ctx)
+		coachState, _ := db.ReadCoachingState(ctx)
+		ns := notifications.NewNotificationService(db)
+		if err := notifications.RunAll(ctx, ns, db, costState, coachState, budgetThreshold); err != nil {
+			core.Logger().Warn("notifications: generation had errors", "error", err)
 		}
 
 	case core.EventSessionEnd, core.EventStop:

--- a/internal/notifications/notifications_test.go
+++ b/internal/notifications/notifications_test.go
@@ -608,3 +608,83 @@ func TestNotification_ExpiredComputed(t *testing.T) {
 	assert.True(t, expiredNotif.Expired, "notification with TTL=1s and created 10s ago should be expired")
 	assert.False(t, activeNotif.Expired, "notification with TTL=86400s just created should not be expired")
 }
+
+// ---------------------------------------------------------------------------
+// Test 22: RunAll creates a budget notification when cost exceeds threshold
+// ---------------------------------------------------------------------------
+
+func TestRunAll_CreatesBudgetNotification(t *testing.T) {
+	ns, db, cleanup := testService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Write a cost state with TotalToday above the threshold.
+	costState := &analytics.CostState{
+		DailyCosts:   map[string]float64{},
+		SessionCosts: map[string]float64{},
+		Today:        time.Now().Format("2006-01-02"),
+		TotalToday:   15.00,
+	}
+	require.NoError(t, db.WriteCostState(ctx, costState))
+
+	// Read it back (as the dispatch path would).
+	cs, err := db.ReadCostState(ctx)
+	require.NoError(t, err)
+
+	err = RunAll(ctx, ns, db, cs, nil, 10.00)
+	require.NoError(t, err)
+
+	notifs, err := ns.List(ctx, 20)
+	require.NoError(t, err)
+
+	found := false
+	for _, n := range notifs {
+		if n.Producer == ProducerBudget {
+			found = true
+			assert.Equal(t, TypeBudgetThreshold, n.Type)
+			assert.Contains(t, n.Content, "$15.00")
+			assert.Contains(t, n.Content, "$10.00")
+		}
+	}
+	assert.True(t, found, "expected at least one budget notification")
+}
+
+// ---------------------------------------------------------------------------
+// Test 23: RunAll with nil states and zero threshold does not panic
+// ---------------------------------------------------------------------------
+
+func TestRunAll_NilStatesNoPanic(t *testing.T) {
+	ns, db, cleanup := testService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	err := RunAll(ctx, ns, db, nil, nil, 0)
+	require.NoError(t, err)
+
+	notifs, err := ns.List(ctx, 20)
+	require.NoError(t, err)
+	assert.Empty(t, notifs, "nil states + zero threshold should produce no notifications")
+}
+
+// ---------------------------------------------------------------------------
+// Test 24: RunAll continues past a single producer error (fail-soft)
+// ---------------------------------------------------------------------------
+
+func TestRunAll_FailSoft(t *testing.T) {
+	ns, db, cleanup := testService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Close the DB to make all producers that touch it return errors.
+	require.NoError(t, db.Close())
+
+	// RunAll should return a non-nil joined error but must not panic.
+	err := RunAll(ctx, ns, db, nil, nil, 0)
+	// With all nil/zero inputs, producers that check nil first return nil,
+	// so at most guard-effectiveness errors propagate (it queries the DB).
+	// The key invariant: no panic.
+	_ = err // may be nil or non-nil depending on which producers short-circuit
+}

--- a/internal/notifications/producers.go
+++ b/internal/notifications/producers.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -22,6 +23,27 @@ const (
 	TypeGuardEffectiveness  = "guard_effectiveness"
 	TypeCoachingPrompt      = "coaching_prompt"
 )
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+// RunAll runs every notification producer best-effort. A failure in one does
+// NOT stop the others; all errors are joined and returned (callers log + ignore
+// per ARCH-1). costState/coachState may be nil (producers no-op on nil).
+func RunAll(ctx context.Context, ns *NotificationService, db *analytics.DB, costState *analytics.CostState, coachState *analytics.CoachingState, budgetThreshold float64) error {
+	var errs []error
+	if err := CheckBudget(ctx, ns, costState, budgetThreshold); err != nil {
+		errs = append(errs, err)
+	}
+	if err := CheckGuardEffectiveness(ctx, ns, db); err != nil {
+		errs = append(errs, err)
+	}
+	if err := CheckCoaching(ctx, ns, coachState); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
 
 // ---------------------------------------------------------------------------
 // Budget threshold notifications (R12.1)


### PR DESCRIPTION
## Bug (user-reported)
`hookwise notifications` always prints "No notifications" and the TUI notifications view is empty.

## Root cause
The notification **producers** (`CheckBudget`, `CheckGuardEffectiveness`, `CheckCoaching`) and the writer (`NotificationService.Create`) are implemented and unit-tested, but **nothing in the runtime ever calls them** — no caller in `cmd/`, dispatch, or daemon. So the `notifications` table is never populated. Classic implemented-but-unwired.

## Fix
- Add `notifications.RunAll(ctx, ns, db, costState, coachState, budgetThreshold)` — runs all three producers best-effort (`errors.Join`, one failure doesn't stop others; nil states no-op).
- Call it from `recordAnalytics` (dispatch) on `PostToolUse`, after the event is recorded, using `config.CostTracking.DailyBudget` as the threshold. Runs inside the existing bounded + panic-recovered goroutine → **fail-open (ARCH-1)**, never blocks/fails the hook. Producers dedup per day, so no spam.

## Verification
- Guarded gate green (`task test:go:unit`, race), 0 zombies. New tests: `RunAll` creates a budget notification above threshold; nil-states no-op; fail-soft.
- **Live end-to-end:** isolated temp DB, seeded a cost overage, one real `hookwise dispatch PostToolUse` → a budget notification appears in `hookwise notifications` (was empty before). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification generation during analytics recording, including alerts for budget thresholds and coaching state tracking with built-in error resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->