### PR TITLE
feat(transcript): per-model token usage reader for .jsonl

### DIFF
--- a/internal/transcript/testdata/missing_usage.jsonl
+++ b/internal/transcript/testdata/missing_usage.jsonl
@@ -1,0 +1,2 @@
+{"type":"assistant","message":{"id":"msg_01","model":"claude-opus-4-8","role":"assistant"},"timestamp":"2026-06-07T00:00:00Z"}
+{"type":"assistant","message":{"id":"msg_02","model":"claude-opus-4-8","role":"assistant","usage":{"input_tokens":500,"output_tokens":100,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-06-07T00:00:01Z"}

--- a/internal/transcript/testdata/multi_model.jsonl
+++ b/internal/transcript/testdata/multi_model.jsonl
@@ -1,0 +1,6 @@
+{"type":"assistant","message":{"id":"msg_01","model":"claude-opus-4-8","role":"assistant","usage":{"input_tokens":1000,"output_tokens":200,"cache_read_input_tokens":50,"cache_creation_input_tokens":5}},"timestamp":"2026-06-07T00:00:00Z"}
+{"type":"user","message":{"role":"user","content":"hello"},"timestamp":"2026-06-07T00:00:01Z"}
+{"type":"assistant","message":{"id":"msg_02","model":"claude-sonnet-4-6","role":"assistant","usage":{"input_tokens":800,"output_tokens":300,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-06-07T00:00:02Z"}
+{"type":"assistant","message":{"id":"msg_03","model":"claude-opus-4-8","role":"assistant","usage":{"input_tokens":500,"output_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":3}},"timestamp":"2026-06-07T00:00:03Z"}
+{"type":"system","message":{"content":"system prompt"},"timestamp":"2026-06-07T00:00:04Z"}
+{"type":"assistant","message":{"id":"msg_04","model":"claude-sonnet-4-6","role":"assistant","usage":{"input_tokens":200,"output_tokens":50,"cache_read_input_tokens":10,"cache_creation_input_tokens":1}},"timestamp":"2026-06-07T00:00:05Z"}

--- a/internal/transcript/testdata/non_assistant_only.jsonl
+++ b/internal/transcript/testdata/non_assistant_only.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","message":{"role":"user","content":"hello"},"timestamp":"2026-06-07T00:00:00Z"}
+{"type":"system","message":{"content":"system"},"timestamp":"2026-06-07T00:00:01Z"}
+{"type":"summary","summary":"some summary","timestamp":"2026-06-07T00:00:02Z"}

--- a/internal/transcript/testdata/single.jsonl
+++ b/internal/transcript/testdata/single.jsonl
@@ -1,0 +1,1 @@
+{"type":"assistant","message":{"id":"msg_01","model":"claude-opus-4-8","role":"assistant","usage":{"input_tokens":1234,"output_tokens":567,"cache_read_input_tokens":89,"cache_creation_input_tokens":10}},"timestamp":"2026-06-07T00:00:00Z"}

--- a/internal/transcript/testdata/with_malformed_lines.jsonl
+++ b/internal/transcript/testdata/with_malformed_lines.jsonl
@@ -1,0 +1,5 @@
+{"type":"assistant","message":{"id":"msg_01","model":"claude-haiku-3-5","role":"assistant","usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":5,"cache_creation_input_tokens":2}},"timestamp":"2026-06-07T00:00:00Z"}
+this is not json at all
+{"type":"assistant","message":{"id":"msg_02","model":"claude-haiku-3-5","role":"assistant","usage":{"input_tokens":200,"output_tokens":75,"cache_read_input_tokens":10,"cache_creation_input_tokens":3}},"timestamp":"2026-06-07T00:00:01Z"}
+{broken json
+{"type":"user","message":{"role":"user","content":"hi"},"timestamp":"2026-06-07T00:00:02Z"}

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -1,0 +1,105 @@
+// Package transcript parses Claude Code .jsonl transcript files and aggregates
+// token usage per model.
+package transcript
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+
+	"github.com/vishnujayvel/hookwise/internal/pricing"
+)
+
+// transcriptLine is the top-level shape of each JSONL line.
+// Only the fields we care about are decoded; everything else is silently ignored.
+type transcriptLine struct {
+	Type    string          `json:"type"`
+	Message transcriptMsg   `json:"message"`
+}
+
+// transcriptMsg holds the assistant message fields we need.
+type transcriptMsg struct {
+	Model string         `json:"model"`
+	Usage *transcriptUsage `json:"usage"` // pointer so we can detect absent usage (nil)
+}
+
+// transcriptUsage maps directly to Anthropic's reported usage block.
+type transcriptUsage struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+}
+
+// scannerBufSize is the initial Scanner buffer size (10 MiB).
+// Transcript lines can easily exceed the default 64 KiB limit when assistant
+// messages embed large tool-result payloads.
+const scannerBufSize = 10 * 1024 * 1024 // 10 MiB
+
+// SumUsage opens the .jsonl transcript at path, scans it line by line, and
+// returns a map from model ID to the total token usage accumulated across all
+// assistant messages that model produced.
+//
+// Parsing is lenient:
+//   - Non-JSON and malformed lines are skipped (not fatal).
+//   - Lines where type != "assistant" are skipped.
+//   - Assistant lines with no usage block are skipped.
+//   - All other lines contribute their token counts to the per-model accumulator.
+//
+// A missing file returns a non-nil error.
+// An empty file (or a file with no parseable assistant+usage lines) returns an
+// empty (non-nil) map and a nil error.
+func SumUsage(path string) (map[string]pricing.Usage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	result := make(map[string]pricing.Usage)
+
+	sc := bufio.NewScanner(f)
+	// Allocate a 10 MiB initial buffer; allow it to grow up to 10 MiB max.
+	buf := make([]byte, scannerBufSize)
+	sc.Buffer(buf, scannerBufSize)
+
+	for sc.Scan() {
+		raw := sc.Bytes()
+		if len(raw) == 0 {
+			continue
+		}
+
+		var line transcriptLine
+		if err := json.Unmarshal(raw, &line); err != nil {
+			// Malformed line — skip, not fatal.
+			continue
+		}
+
+		if line.Type != "assistant" {
+			continue
+		}
+		if line.Message.Usage == nil {
+			continue
+		}
+		if line.Message.Model == "" {
+			continue
+		}
+
+		u := line.Message.Usage
+		existing := result[line.Message.Model]
+		result[line.Message.Model] = pricing.Usage{
+			InputTokens:         existing.InputTokens + u.InputTokens,
+			OutputTokens:        existing.OutputTokens + u.OutputTokens,
+			CacheReadTokens:     existing.CacheReadTokens + u.CacheReadInputTokens,
+			CacheCreationTokens: existing.CacheCreationTokens + u.CacheCreationInputTokens,
+		}
+	}
+
+	// sc.Err() returns nil on normal EOF; any scanner error (e.g., token too
+	// long even after our large buffer) would surface here — treat as fatal.
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -1,0 +1,226 @@
+package transcript_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/pricing"
+	"github.com/vishnujayvel/hookwise/internal/transcript"
+)
+
+// testdataPath returns the absolute path to a fixture file.
+func testdataPath(name string) string {
+	return filepath.Join("testdata", name)
+}
+
+// assistantLine builds a minimal assistant JSONL line as a string.
+func assistantLine(model string, input, output, cacheRead, cacheWrite int64) string {
+	type usageJSON struct {
+		InputTokens              int64 `json:"input_tokens"`
+		OutputTokens             int64 `json:"output_tokens"`
+		CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+		CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	}
+	type msgJSON struct {
+		ID    string    `json:"id"`
+		Model string    `json:"model"`
+		Role  string    `json:"role"`
+		Usage usageJSON `json:"usage"`
+	}
+	type lineJSON struct {
+		Type      string  `json:"type"`
+		Message   msgJSON `json:"message"`
+		Timestamp string  `json:"timestamp"`
+	}
+	line := lineJSON{
+		Type: "assistant",
+		Message: msgJSON{
+			ID:    "msg_test",
+			Model: model,
+			Role:  "assistant",
+			Usage: usageJSON{
+				InputTokens:              input,
+				OutputTokens:             output,
+				CacheReadInputTokens:     cacheRead,
+				CacheCreationInputTokens: cacheWrite,
+			},
+		},
+		Timestamp: "2026-06-07T00:00:00Z",
+	}
+	b, _ := json.Marshal(line)
+	return string(b)
+}
+
+// TestSingleAssistantMessage verifies a single assistant message is parsed into the correct per-model usage.
+func TestSingleAssistantMessage(t *testing.T) {
+	result, err := transcript.SumUsage(testdataPath("single.jsonl"))
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	u, ok := result["claude-opus-4-8"]
+	require.True(t, ok, "expected key 'claude-opus-4-8' in result")
+	assert.Equal(t, int64(1234), u.InputTokens)
+	assert.Equal(t, int64(567), u.OutputTokens)
+	assert.Equal(t, int64(89), u.CacheReadTokens)
+	assert.Equal(t, int64(10), u.CacheCreationTokens)
+}
+
+// TestMultipleMessagesSameModel verifies usage is accumulated when the same model appears multiple times.
+func TestMultipleMessagesSameModel(t *testing.T) {
+	// Use multi_model fixture but filter to just opus entries: 1000+500=1500 input, 200+100=300 output, etc.
+	result, err := transcript.SumUsage(testdataPath("multi_model.jsonl"))
+	require.NoError(t, err)
+
+	u, ok := result["claude-opus-4-8"]
+	require.True(t, ok, "expected key 'claude-opus-4-8'")
+	assert.Equal(t, int64(1000+500), u.InputTokens)
+	assert.Equal(t, int64(200+100), u.OutputTokens)
+	assert.Equal(t, int64(50+20), u.CacheReadTokens)
+	assert.Equal(t, int64(5+3), u.CacheCreationTokens)
+}
+
+// TestMultipleModels verifies that different models produce separate map entries each summed correctly.
+func TestMultipleModels(t *testing.T) {
+	result, err := transcript.SumUsage(testdataPath("multi_model.jsonl"))
+	require.NoError(t, err)
+	require.Len(t, result, 2, "expected exactly 2 model entries")
+
+	opus, ok := result["claude-opus-4-8"]
+	require.True(t, ok, "expected key 'claude-opus-4-8'")
+	assert.Equal(t, int64(1500), opus.InputTokens)
+	assert.Equal(t, int64(300), opus.OutputTokens)
+	assert.Equal(t, int64(70), opus.CacheReadTokens)
+	assert.Equal(t, int64(8), opus.CacheCreationTokens)
+
+	sonnet, ok := result["claude-sonnet-4-6"]
+	require.True(t, ok, "expected key 'claude-sonnet-4-6'")
+	assert.Equal(t, int64(1000), sonnet.InputTokens)
+	assert.Equal(t, int64(350), sonnet.OutputTokens)
+	assert.Equal(t, int64(10), sonnet.CacheReadTokens)
+	assert.Equal(t, int64(1), sonnet.CacheCreationTokens)
+}
+
+// TestNonAssistantLinesIgnored verifies user/system/summary lines with no usage are skipped.
+func TestNonAssistantLinesIgnored(t *testing.T) {
+	result, err := transcript.SumUsage(testdataPath("non_assistant_only.jsonl"))
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// TestMalformedLinesSkipped verifies garbled/non-JSON lines are skipped and valid lines still counted.
+func TestMalformedLinesSkipped(t *testing.T) {
+	result, err := transcript.SumUsage(testdataPath("with_malformed_lines.jsonl"))
+	require.NoError(t, err)
+	require.Len(t, result, 1, "expected exactly 1 model")
+
+	u, ok := result["claude-haiku-3-5"]
+	require.True(t, ok)
+	// 100+200=300, 50+75=125, 5+10=15, 2+3=5
+	assert.Equal(t, int64(300), u.InputTokens)
+	assert.Equal(t, int64(125), u.OutputTokens)
+	assert.Equal(t, int64(15), u.CacheReadTokens)
+	assert.Equal(t, int64(5), u.CacheCreationTokens)
+}
+
+// TestAssistantLineMissingUsageSkipped verifies that assistant lines without a usage block are skipped without panic.
+func TestAssistantLineMissingUsageSkipped(t *testing.T) {
+	result, err := transcript.SumUsage(testdataPath("missing_usage.jsonl"))
+	require.NoError(t, err)
+	// Only the second message (with usage) should be counted.
+	u, ok := result["claude-opus-4-8"]
+	require.True(t, ok)
+	assert.Equal(t, int64(500), u.InputTokens)
+	assert.Equal(t, int64(100), u.OutputTokens)
+}
+
+// TestMissingFile verifies that a missing file path returns an error.
+func TestMissingFile(t *testing.T) {
+	_, err := transcript.SumUsage(testdataPath("does_not_exist.jsonl"))
+	assert.Error(t, err)
+}
+
+// TestEmptyFile verifies an empty file returns an empty map and nil error.
+func TestEmptyFile(t *testing.T) {
+	result, err := transcript.SumUsage(testdataPath("empty.jsonl"))
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+// TestVeryLongLine verifies that a line exceeding the default 64KB Scanner buffer is parsed correctly.
+// The large token count is embedded in a JSON object whose total serialized size exceeds 64KB.
+func TestVeryLongLine(t *testing.T) {
+	// Build a line that exceeds 64 KB by stuffing a large dummy field into the message.
+	// We embed a "junk" field with a 100KB string value to force a line > 64KB.
+	pad := strings.Repeat("x", 100*1024) // 100 KB of padding
+
+	type usageJSON struct {
+		InputTokens              int64 `json:"input_tokens"`
+		OutputTokens             int64 `json:"output_tokens"`
+		CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+		CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	}
+	type msgJSON struct {
+		ID    string    `json:"id"`
+		Model string    `json:"model"`
+		Role  string    `json:"role"`
+		Usage usageJSON `json:"usage"`
+		Junk  string    `json:"junk"` // large padding field
+	}
+	type lineJSON struct {
+		Type      string  `json:"type"`
+		Message   msgJSON `json:"message"`
+		Timestamp string  `json:"timestamp"`
+	}
+
+	line := lineJSON{
+		Type: "assistant",
+		Message: msgJSON{
+			ID:    "msg_large",
+			Model: "claude-opus-4-8",
+			Role:  "assistant",
+			Usage: usageJSON{
+				InputTokens:              42,
+				OutputTokens:             7,
+				CacheReadInputTokens:     3,
+				CacheCreationInputTokens: 1,
+			},
+			Junk: pad,
+		},
+		Timestamp: "2026-06-07T00:00:00Z",
+	}
+	b, err := json.Marshal(line)
+	require.NoError(t, err)
+	require.Greater(t, len(b), 64*1024, "test fixture must exceed 64KB")
+
+	// Write to a temp file
+	f, err := os.CreateTemp(t.TempDir(), "large_line_*.jsonl")
+	require.NoError(t, err)
+	_, err = fmt.Fprintf(f, "%s\n", b)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	result, err := transcript.SumUsage(f.Name())
+	require.NoError(t, err)
+
+	u, ok := result["claude-opus-4-8"]
+	require.True(t, ok, "expected key 'claude-opus-4-8' for large line")
+	assert.Equal(t, int64(42), u.InputTokens)
+	assert.Equal(t, int64(7), u.OutputTokens)
+	assert.Equal(t, int64(3), u.CacheReadTokens)
+	assert.Equal(t, int64(1), u.CacheCreationTokens)
+}
+
+// TestResultTypeIsPricingUsage is a compile-time assertion that SumUsage returns map[string]pricing.Usage.
+// If the return type ever changes, this assignment will fail to compile.
+func TestResultTypeIsPricingUsage(t *testing.T) {
+	result, err := transcript.SumUsage(testdataPath("single.jsonl"))
+	require.NoError(t, err)
+	var _ map[string]pricing.Usage = result
+	_ = result
+}


### PR DESCRIPTION
## What

PR-B of the **cost-tracking writer port**. Adds `internal/transcript.SumUsage(path) (map[string]pricing.Usage, error)` — parses a Claude Code transcript `.jsonl` and sums assistant `usage` blocks **per model**.

## Why

Hook payloads carry no token counts; the transcript `.jsonl` is the only source of truth. This is the reader PR-C wires into the **Stop** dispatch seam to compute real cost.

## Details

- Maps `input_tokens` / `output_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens` → `pricing.Usage`.
- Aggregates per `message.model` (sessions can switch models).
- Tolerant: malformed/blank/partial lines skipped; missing file → error; empty → empty map.
- 10 MiB `bufio.Scanner` buffer so long transcript lines (>64 KB) parse.

## Tests

10 unit tests + 6 `testdata/` fixtures (single, multi-model, malformed, empty, missing-usage, non-assistant-only). Guarded gate green locally: `GOMEMLIMIT=4GiB go test -race -p 2 ./internal/transcript/` → `ok`. 0 zombies.

Stacks on #100 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)