### PR TITLE
fix(daemon): never auto-spawn daemon from a go test binary (#84)

### DIFF
--- a/internal/feeds/client.go
+++ b/internal/feeds/client.go
@@ -3,17 +3,38 @@ package feeds
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/vishnujayvel/hookwise/internal/core"
 )
+
+// errDaemonAutostartDisabled is returned by spawnDaemon when daemon auto-start
+// is refused — either because we are running under a `go test` binary or
+// because HOOKWISE_DISABLE_DAEMON_AUTOSTART is set. Callers fail-open (ARCH-1).
+var errDaemonAutostartDisabled = errors.New("feeds: daemon auto-start disabled (test binary or HOOKWISE_DISABLE_DAEMON_AUTOSTART)")
+
+// isTestBinary reports whether path looks like a `go test` binary. Such a
+// binary must NEVER be re-exec'd as a daemon: under `go test`, os.Executable()
+// is the package's compiled <pkg>.test binary, and re-running it as
+// `<pkg>.test daemon run` re-executes the ENTIRE test suite. Because the
+// status-line command auto-starts the daemon, that re-execution calls back
+// into spawnDaemon and forks an unbounded chain of test processes — the
+// runaway that caused the retro-009 kernel panic (see also #84). The ".test"
+// suffix is how the Go toolchain names test binaries.
+func isTestBinary(path string) bool {
+	base := filepath.Base(path)
+	return strings.HasSuffix(base, ".test") || strings.HasSuffix(base, ".test.exe")
+}
 
 // DaemonClient provides daemon connectivity from CLI commands.
 type DaemonClient struct {
@@ -97,6 +118,15 @@ func (c *DaemonClient) spawnDaemon(configPath string) error {
 	self, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("find executable: %w", err)
+	}
+
+	// FORK-SAFETY (retro-009 / #84): never re-exec the daemon from a `go test`
+	// binary or when explicitly disabled. Under `go test`, self is the
+	// <pkg>.test binary; re-running it re-executes the whole suite, which (via
+	// status-line auto-start) recurses back here and fork-bombs the machine.
+	// Bail out fail-open — the caller renders from the existing JSON cache.
+	if isTestBinary(self) || os.Getenv("HOOKWISE_DISABLE_DAEMON_AUTOSTART") == "1" {
+		return errDaemonAutostartDisabled
 	}
 
 	args := []string{"daemon", "run"}

--- a/internal/feeds/client_test.go
+++ b/internal/feeds/client_test.go
@@ -107,6 +107,38 @@ func TestDaemonClient_EnsureDaemon_AlreadyRunning(t *testing.T) {
 	assert.NoError(t, err, "EnsureDaemon should succeed without spawning when daemon is already running")
 }
 
+// TestIsTestBinary checks the heuristic that prevents the retro-009 / #84
+// fork bomb: a `go test` binary must be recognised so the daemon is never
+// re-exec'd from it.
+func TestIsTestBinary(t *testing.T) {
+	assert.True(t, isTestBinary("/tmp/go-build123/b001/hookwise.test"), "go-build test binary")
+	assert.True(t, isTestBinary("hookwise.test"), "bare test binary name")
+	assert.True(t, isTestBinary("C:/tmp/feeds.test.exe"), "windows test binary")
+	assert.False(t, isTestBinary("/usr/local/bin/hookwise"), "installed binary is not a test binary")
+	assert.False(t, isTestBinary("hookwise"), "bare binary name is not a test binary")
+}
+
+// TestSpawnDaemon_RefusedUnderTestBinary is the regression guard for the
+// retro-009 kernel-panic fork bomb (#84). Because this test itself runs inside
+// the package's <pkg>.test binary, os.Executable() ends in ".test", so
+// spawnDaemon MUST refuse to re-exec and return errDaemonAutostartDisabled
+// instead of forking an unbounded chain of daemon processes.
+func TestSpawnDaemon_RefusedUnderTestBinary(t *testing.T) {
+	client := NewDaemonClient(filepath.Join(t.TempDir(), "nope.sock"))
+	err := client.spawnDaemon("")
+	require.ErrorIs(t, err, errDaemonAutostartDisabled,
+		"spawnDaemon must refuse to re-exec from a *.test binary (fork-bomb guard)")
+}
+
+// TestSpawnDaemon_RefusedWhenDisabledEnv verifies the operator escape hatch:
+// HOOKWISE_DISABLE_DAEMON_AUTOSTART=1 also blocks auto-spawn.
+func TestSpawnDaemon_RefusedWhenDisabledEnv(t *testing.T) {
+	t.Setenv("HOOKWISE_DISABLE_DAEMON_AUTOSTART", "1")
+	client := NewDaemonClient(filepath.Join(t.TempDir(), "nope.sock"))
+	err := client.spawnDaemon("")
+	require.ErrorIs(t, err, errDaemonAutostartDisabled)
+}
+
 func TestDaemonClient_HealthResponseFormat(t *testing.T) {
 	// Verify that the Health response contains the expected keys with correct types.
 	socketPath := filepath.Join(socketTempDir(t), "d.sock")


### PR DESCRIPTION
## Severity: high (kernel-panic class / retro-009)

While verifying the cost-tracking port I found **~1900 live `hookwise.test … daemon run` processes** on the machine — 2/3 of all processes — in a self-spawning fork chain, growing ~5/sec.

### Root cause
`DaemonClient.spawnDaemon` re-execs `os.Executable()`. Under `go test`, that's the package's `<pkg>.test` binary. The `status-line` command auto-starts the daemon (`ensureDaemonWithCache` → `EnsureDaemon` → `spawnDaemon`). So running `cmd/hookwise` tests does:

```
hookwise.test  →  TestStatusLineEnabled  →  spawnDaemon
   →  exec "hookwise.test daemon run"   (no TestMain to intercept)
   →  re-runs the ENTIRE suite  →  TestStatusLineEnabled  →  spawnDaemon  →  …
```

An unbounded fork chain. This is the retro-009 kernel-panic mechanism and the true root cause of **#84** (the "phantom test process" guard discrepancy was *real* leaked daemons).

### Fix
`spawnDaemon` now refuses to re-exec when the executable is a test binary (`.test` / `.test.exe` suffix) or when `HOOKWISE_DISABLE_DAEMON_AUTOSTART=1`. Returns a sentinel error; callers already fail-open per ARCH-1, so `status-line` renders from the JSON cache as normal. **Production behavior with the real `hookwise` binary is unchanged.**

### Tests
- `TestSpawnDaemon_RefusedUnderTestBinary` — the regression guard: because the test itself runs in `feeds.test`, `spawnDaemon` must return `errDaemonAutostartDisabled` and spawn nothing. This makes the fork bomb structurally impossible.
- `TestSpawnDaemon_RefusedWhenDisabledEnv` — env escape hatch.
- `TestIsTestBinary` — suffix heuristic.

Guarded gate green: `GOMEMLIMIT=4GiB go test -race -p 2 ./internal/feeds/` → `ok` (14s), **0 `hookwise.test` processes before and after**.

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)