### PR TITLE
feat(cost): compute real session cost on Stop and write cost_state

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -987,7 +987,7 @@ func TestRecordAnalytics_SessionStart(t *testing.T) {
 	dbPath := filepath.Join(tmpDir, "analytics.db")
 
 	payload := core.HookPayload{SessionID: "test-session-001"}
-	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, 0)
+	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, core.CostTrackingConfig{})
 
 	// Verify session was recorded.
 	db, err := analytics.Open(dbPath)
@@ -1013,11 +1013,11 @@ func TestRecordAnalytics_PostToolUse(t *testing.T) {
 
 	// First create a session.
 	payload := core.HookPayload{SessionID: "test-session-002"}
-	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, 0)
+	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, core.CostTrackingConfig{})
 
 	// Record a tool use event.
 	payload.ToolName = "Bash"
-	recordAnalytics(context.Background(), core.EventPostToolUse, payload, dbPath, 0)
+	recordAnalytics(context.Background(), core.EventPostToolUse, payload, dbPath, core.CostTrackingConfig{})
 
 	db, err := analytics.Open(dbPath)
 	if err != nil {

--- a/cmd/hookwise/cmd_dispatch.go
+++ b/cmd/hookwise/cmd_dispatch.go
@@ -10,6 +10,8 @@ import (
 	"github.com/vishnujayvel/hookwise/internal/analytics"
 	"github.com/vishnujayvel/hookwise/internal/core"
 	"github.com/vishnujayvel/hookwise/internal/notifications"
+	"github.com/vishnujayvel/hookwise/internal/pricing"
+	"github.com/vishnujayvel/hookwise/internal/transcript"
 )
 
 // newDispatchCmd handles "hookwise dispatch <EventType>".
@@ -93,7 +95,7 @@ func newDispatchCmd() *cobra.Command {
 					done := make(chan struct{})
 					go func() {
 						defer close(done)
-						recordAnalytics(ctx, eventType, payload, config.Analytics.DBPath, config.CostTracking.DailyBudget)
+						recordAnalytics(ctx, eventType, payload, config.Analytics.DBPath, config.CostTracking)
 					}()
 					select {
 					case <-done:
@@ -146,7 +148,7 @@ const analyticsRecordTimeout = 2 * time.Second
 // recordAnalytics writes session/event data to the SQLite analytics DB. The
 // caller waits for it (bounded) before os.Exit so the write actually persists.
 // Fail-open: any error is logged but never surfaces to the user (ARCH-1).
-func recordAnalytics(ctx context.Context, eventType string, payload core.HookPayload, dataDir string, budgetThreshold float64) {
+func recordAnalytics(ctx context.Context, eventType string, payload core.HookPayload, dataDir string, costCfg core.CostTrackingConfig) {
 	defer func() {
 		if r := recover(); r != nil {
 			core.Logger().Error("panic in analytics recording", "recovered", fmt.Sprintf("%v", r))
@@ -188,12 +190,39 @@ func recordAnalytics(ctx context.Context, eventType string, payload core.HookPay
 		costState, _ := db.ReadCostState(ctx)
 		coachState, _ := db.ReadCoachingState(ctx)
 		ns := notifications.NewNotificationService(db)
-		if err := notifications.RunAll(ctx, ns, db, costState, coachState, budgetThreshold); err != nil {
+		if err := notifications.RunAll(ctx, ns, db, costState, coachState, costCfg.DailyBudget); err != nil {
 			core.Logger().Warn("notifications: generation had errors", "error", err)
 		}
 
 	case core.EventSessionEnd, core.EventStop:
-		if err := a.EndSession(ctx, payload.SessionID, now, analytics.SessionStats{}); err != nil {
+		var sessionCost float64
+		if costCfg.Enabled && payload.TranscriptPath != "" {
+			usageByModel, terr := transcript.SumUsage(payload.TranscriptPath)
+			if terr != nil {
+				core.Logger().Warn("cost: read transcript usage", "error", terr)
+			} else {
+				for model, u := range usageByModel {
+					sessionCost += pricing.ComputeWithRates(model, u, costCfg.Rates)
+				}
+				if state, serr := db.ReadCostState(ctx); serr == nil {
+					today := now.Format("2006-01-02")
+					delta := sessionCost - state.SessionCosts[payload.SessionID]
+					state.SessionCosts[payload.SessionID] = sessionCost
+					state.TotalToday += delta
+					if state.TotalToday < 0 {
+						state.TotalToday = 0
+					}
+					state.DailyCosts[today] += delta
+					state.Today = today
+					if werr := db.WriteCostState(ctx, state); werr != nil {
+						core.Logger().Error("cost: write cost_state", "error", werr)
+					}
+				} else {
+					core.Logger().Warn("cost: read cost_state", "error", serr)
+				}
+			}
+		}
+		if err := a.EndSession(ctx, payload.SessionID, now, analytics.SessionStats{EstimatedCostUSD: sessionCost}); err != nil {
 			core.Logger().Error("analytics: end session", "error", err)
 		}
 	}

--- a/cmd/hookwise/cmd_dispatch_cost_test.go
+++ b/cmd/hookwise/cmd_dispatch_cost_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/analytics"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// writeSonnetFixture writes a .jsonl transcript with one assistant line:
+// claude-sonnet-4, input_tokens=1_000_000, output_tokens=1_000_000.
+// At built-in Sonnet rates ($3/MTok input, $15/MTok output) this costs
+// exactly $18.00 USD.
+func writeSonnetFixture(t *testing.T) string {
+	t.Helper()
+	line := `{"type":"assistant","message":{"id":"msg_01","model":"claude-sonnet-4","role":"assistant","usage":{"input_tokens":1000000,"output_tokens":1000000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-06-15T00:00:00Z"}`
+	f, err := os.CreateTemp(t.TempDir(), "transcript-*.jsonl")
+	require.NoError(t, err)
+	_, err = f.WriteString(line + "\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+// openTestDB opens (or creates) the analytics DB in dataDir so the test can
+// assert post-call state without duplicating the open logic in recordAnalytics.
+func openTestDB(t *testing.T, dataDir string) *analytics.DB {
+	t.Helper()
+	db, err := analytics.Open(dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+const expectedSonnetCost = 18.00 // $3*1 + $15*1 (1M tokens each, Sonnet rates)
+
+// TestRecordAnalytics_CostStop verifies that calling recordAnalytics with a
+// Stop event and a real transcript path writes the expected cost into both
+// the cost_state table and the sessions table.
+func TestRecordAnalytics_CostStop(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	transcriptPath := writeSonnetFixture(t)
+	sid := "cost-test-session-001"
+
+	// Pre-create the session so EndSession's UPDATE has a row to touch.
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.StartSession(context.Background(), sid, time.Now()))
+	db.Close()
+
+	costCfg := core.CostTrackingConfig{Enabled: true}
+	payload := core.HookPayload{
+		SessionID:      sid,
+		TranscriptPath: transcriptPath,
+	}
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+
+	// Re-open to assert.
+	db = openTestDB(t, dbPath)
+	defer db.Close()
+
+	// Assert cost_state.TotalToday and SessionCosts[sid].
+	state, err := db.ReadCostState(context.Background())
+	require.NoError(t, err)
+	assert.InDelta(t, expectedSonnetCost, state.TotalToday, 0.001, "TotalToday should equal $18.00")
+	assert.InDelta(t, expectedSonnetCost, state.SessionCosts[sid], 0.001, "SessionCosts[sid] should equal $18.00")
+
+	// Assert the sessions table also holds the cost via DailySummary.
+	a = analytics.NewAnalytics(db)
+	today := time.Now().UTC().Format("2006-01-02")
+	summary, err := a.DailySummary(context.Background(), today)
+	require.NoError(t, err)
+	assert.InDelta(t, expectedSonnetCost, summary.EstimatedCostUSD, 0.001, "DailySummary.EstimatedCostUSD should equal $18.00")
+}
+
+// TestRecordAnalytics_CostStop_Idempotent verifies that re-running a Stop for
+// the same session does NOT double-count cost (delta = 0, TotalToday unchanged).
+func TestRecordAnalytics_CostStop_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	transcriptPath := writeSonnetFixture(t)
+	sid := "cost-test-session-002"
+
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.StartSession(context.Background(), sid, time.Now()))
+	db.Close()
+
+	costCfg := core.CostTrackingConfig{Enabled: true}
+	payload := core.HookPayload{
+		SessionID:      sid,
+		TranscriptPath: transcriptPath,
+	}
+
+	// First Stop.
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+
+	// Second Stop — same transcript, same session.
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+
+	db = openTestDB(t, dbPath)
+	defer db.Close()
+
+	state, err := db.ReadCostState(context.Background())
+	require.NoError(t, err)
+	assert.InDelta(t, expectedSonnetCost, state.TotalToday, 0.001,
+		"TotalToday must NOT be doubled on second Stop (idempotency)")
+}
+
+// TestRecordAnalytics_CostStop_Disabled verifies that when CostTracking.Enabled=false,
+// no cost is written and TotalToday stays 0.
+func TestRecordAnalytics_CostStop_Disabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	transcriptPath := writeSonnetFixture(t)
+	sid := "cost-test-session-003"
+
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.StartSession(context.Background(), sid, time.Now()))
+	db.Close()
+
+	costCfg := core.CostTrackingConfig{Enabled: false}
+	payload := core.HookPayload{
+		SessionID:      sid,
+		TranscriptPath: transcriptPath,
+	}
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+
+	db = openTestDB(t, dbPath)
+	defer db.Close()
+
+	state, err := db.ReadCostState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, state.TotalToday, "TotalToday must remain 0 when cost tracking disabled")
+	assert.Empty(t, state.SessionCosts, "SessionCosts must be empty when cost tracking disabled")
+}
+
+// TestRecordAnalytics_CostStop_NoTranscript verifies that an empty TranscriptPath
+// does not panic, EndSession is still called (session ends cleanly), and cost is 0.
+func TestRecordAnalytics_CostStop_NoTranscript(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	sid := "cost-test-session-004"
+
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.StartSession(context.Background(), sid, time.Now()))
+	db.Close()
+
+	costCfg := core.CostTrackingConfig{Enabled: true}
+	payload := core.HookPayload{
+		SessionID:      sid,
+		TranscriptPath: "", // no transcript path
+	}
+
+	// Must not panic.
+	require.NotPanics(t, func() {
+		recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+	})
+
+	db = openTestDB(t, dbPath)
+	defer db.Close()
+
+	state, err := db.ReadCostState(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, state.TotalToday, "TotalToday must be 0 with no transcript")
+
+	// Session should still have been ended with cost=0.
+	a = analytics.NewAnalytics(db)
+	today := time.Now().UTC().Format("2006-01-02")
+	summary, err := a.DailySummary(context.Background(), today)
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, summary.EstimatedCostUSD, "EstimatedCostUSD must be 0 with no transcript")
+}

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -47,10 +47,11 @@ func IsEventType(value string) bool {
 
 // HookPayload is the JSON payload piped to stdin by Claude Code for each hook invocation.
 type HookPayload struct {
-	SessionID string                 `json:"session_id"`
-	ToolName  string                 `json:"tool_name,omitempty"`
-	ToolInput map[string]interface{} `json:"tool_input,omitempty"`
-	Extra     map[string]interface{} `json:"-"` // captures unknown fields
+	SessionID      string                 `json:"session_id"`
+	ToolName       string                 `json:"tool_name,omitempty"`
+	ToolInput      map[string]interface{} `json:"tool_input,omitempty"`
+	TranscriptPath string                 `json:"transcript_path,omitempty"`
+	Extra          map[string]interface{} `json:"-"` // captures unknown fields
 }
 
 // IsValidPayload checks that the payload has the required session_id field.


### PR DESCRIPTION
## What — PR-C (final) of the cost-tracking writer port

Wires the cost **writer** into dispatch so `hookwise stats`, the cost status-line segment, and the **#97 budget notification** stop being permanently `$0`/dead.

Builds on #100 (`internal/pricing`) and #101 (`internal/transcript`).

## How
- **`HookPayload.TranscriptPath`** — additive field; Claude Code sends `transcript_path` but the struct dropped it (`Extra` is `json:"-"`).
- **Stop/SessionEnd seam only** (`cmd_dispatch.go`, fires once per turn — the per-tool PostToolUse hot path is untouched): read the full session transcript → `transcript.SumUsage` → `pricing.ComputeWithRates(model, usage, cfg.Rates)` summed across models → **idempotent** accumulate into `cost_state` (`delta = sessionCost − SessionCosts[sid]`; re-running Stop yields delta 0, no double count) → `WriteCostState` + pass `EstimatedCostUSD` into `EndSession`.
- `recordAnalytics` now receives the full `core.CostTrackingConfig` (Rates + DailyBudget).

## Why idempotent recompute-from-full-file
Stop can fire repeatedly and `SessionEnd` also fires; recomputing the whole transcript and storing a delta keyed by session makes repeated calls safe without offset bookkeeping.

## Tests (`cmd_dispatch_cost_test.go`)
- `TestRecordAnalytics_CostStop` — sonnet fixture, 1M in + 1M out → exactly **$18.00**; asserts `cost_state.TotalToday`, `SessionCosts[sid]`, and `DailySummary.EstimatedCostUSD`.
- `TestRecordAnalytics_CostStop_Idempotent` — second Stop does **not** double to $36.
- `_Disabled` (cfg off → $0), `_NoTranscript` (empty path → no panic, $0, session still ends).

Guarded gate green: `GOMEMLIMIT=4GiB go test -race -p 2 -run TestRecordAnalytics_Cost ./cmd/hookwise/` → `ok`, **0 zombie processes**.

> Note: full-package run flags a pre-existing **environmental** failure in `TestDoctorFeedHealthAllHealthy` (the `doctor` command reads the real `~/.claude/settings.json` + `~/.hookwise/analytics.db` rather than the isolated `HOOKWISE_STATE_DIR`). Unrelated to this change; filed separately. CI's clean `$HOME` is unaffected.

Depends on the now-merged fork-safety fix (#102) so this package can be tested at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)