### PR TITLE
fix(stats): resolve analytics DB path from config (closes #105)

### DIFF
--- a/cmd/hookwise/cmd_snapshot.go
+++ b/cmd/hookwise/cmd_snapshot.go
@@ -44,10 +44,7 @@ func runSnapshot(cmd *cobra.Command, dataDir, snapshotsDir string, retention int
 	}
 
 	// Resolve the DB path: explicit flag wins, then config, then default.
-	dbPath := dataDir
-	if dbPath == "" {
-		dbPath = config.Analytics.DBPath
-	}
+	dbPath := resolveAnalyticsDBPath(dataDir, config)
 
 	// Resolve the snapshots dir: explicit flag wins, else the default.
 	if snapshotsDir == "" {

--- a/cmd/hookwise/cmd_stats.go
+++ b/cmd/hookwise/cmd_stats.go
@@ -3,12 +3,27 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/vishnujayvel/hookwise/internal/analytics"
+	"github.com/vishnujayvel/hookwise/internal/core"
 )
+
+// resolveAnalyticsDBPath picks the analytics DB path the way reader commands
+// must agree with the writer (dispatch): an explicit --data-dir flag wins,
+// otherwise the loaded config's Analytics.DBPath is used. The returned value
+// may be empty, in which case analytics.Open falls back to DefaultDBPath().
+// See #105: stats previously ignored config and read the default DB, showing
+// $0 whenever a custom analytics.db_path was set.
+func resolveAnalyticsDBPath(flagDataDir string, config core.HooksConfig) string {
+	if flagDataDir != "" {
+		return flagDataDir
+	}
+	return config.Analytics.DBPath
+}
 
 func newStatsCmd() *cobra.Command {
 	var dataDir string
@@ -22,12 +37,20 @@ func newStatsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&dataDir, "data-dir", "", "Path to the analytics SQLite DB file (defaults to ~/.hookwise/analytics.db)")
+	cmd.Flags().StringVar(&dataDir, "data-dir", "", "Path to the analytics SQLite DB file (defaults to config analytics.db_path / ~/.hookwise/analytics.db)")
 	return cmd
 }
 
 func runStats(cmd *cobra.Command, dataDir string) error {
-	db, err := analytics.Open(dataDir)
+	// Load config the same way the writer (dispatch) does so reader and writer
+	// agree on the DB path (ARCH-1: never hard-fail on a missing/broken config).
+	cwd, _ := os.Getwd()
+	config, err := core.LoadConfig(cwd)
+	if err != nil {
+		config = core.GetDefaultConfig()
+	}
+
+	db, err := analytics.Open(resolveAnalyticsDBPath(dataDir, config))
 	if err != nil {
 		return fmt.Errorf("failed to open analytics DB: %w", err)
 	}

--- a/cmd/hookwise/cmd_stats_test.go
+++ b/cmd/hookwise/cmd_stats_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/analytics"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// TestResolveAnalyticsDBPath verifies the reader/writer path-resolution contract:
+// an explicit --data-dir flag wins; otherwise the loaded config's
+// Analytics.DBPath is used (which may be "" → analytics.Open falls back to the
+// default). This is the fix for #105: stats must agree with dispatch.
+func TestResolveAnalyticsDBPath(t *testing.T) {
+	cfg := core.GetDefaultConfig()
+	cfg.Analytics.DBPath = "/custom/from/config.db"
+
+	// Explicit flag wins over config.
+	assert.Equal(t, "/explicit/flag.db",
+		resolveAnalyticsDBPath("/explicit/flag.db", cfg),
+		"non-empty flag must take precedence over config")
+
+	// Empty flag falls back to config.
+	assert.Equal(t, "/custom/from/config.db",
+		resolveAnalyticsDBPath("", cfg),
+		"empty flag must fall back to config Analytics.DBPath")
+
+	// Empty flag + empty config DBPath → empty (analytics.Open resolves default).
+	cfg.Analytics.DBPath = ""
+	assert.Equal(t, "",
+		resolveAnalyticsDBPath("", cfg),
+		"empty flag + empty config must return empty for Open() to default")
+}
+
+// TestRunStats_ReadsConfigDBPath is the #105 regression test: when a project
+// config sets a custom analytics.db_path, `stats` (with no --data-dir flag)
+// must read THAT database — the same one `dispatch` writes to — not the
+// default ~/.hookwise/analytics.db. Before the fix, stats ignored config and
+// printed $0.00.
+func TestRunStats_ReadsConfigDBPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Isolate the default state dir so the "default" DB is empty (and absent).
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+
+	customDB := filepath.Join(tmpDir, "custom-analytics.db")
+
+	// A project dir with a hookwise.yaml pointing analytics at the custom DB.
+	projectDir := filepath.Join(tmpDir, "project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	cfgYAML := "analytics:\n  enabled: true\n  db_path: " + customDB + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "hookwise.yaml"), []byte(cfgYAML), 0o644))
+
+	// Seed $18.00 of cost into the CUSTOM DB via the real writer path.
+	sid := "stats-config-dbpath-001"
+	db := openTestDB(t, customDB)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.StartSession(context.Background(), sid, time.Now()))
+	db.Close()
+
+	transcriptPath := writeSonnetFixture(t)
+	recordAnalytics(context.Background(), core.EventStop, core.HookPayload{
+		SessionID:      sid,
+		TranscriptPath: transcriptPath,
+	}, customDB, core.CostTrackingConfig{Enabled: true})
+
+	// Run `stats` from the project dir with NO --data-dir flag.
+	t.Chdir(projectDir)
+	cmd := newStatsCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "$18.00",
+		"stats must read the config's db_path and show seeded cost, not $0.00 from the default DB")
+}


### PR DESCRIPTION
## Problem

Reader and writer disagreed on the analytics DB path (found while live-verifying the cost writer, #103):

- **`dispatch`** (writer) uses `config.Analytics.DBPath`.
- **`stats`** opened the DB straight from the `--data-dir` flag, which defaults to `""` → `analytics.Open` falls back to `~/.hookwise/analytics.db`. It never consulted config.

So with a custom `analytics.db_path`, dispatch wrote cost into the custom DB but `stats` read the default one and printed **`$0.00`** — silently undermining the brand-new cost feature.

## Fix

- Add a shared `resolveAnalyticsDBPath(flag, config)` helper: explicit `--data-dir` wins, else `config.Analytics.DBPath`, else `""` (so `analytics.Open` applies its own `DefaultDBPath()` fallback).
- `runStats` now loads config the same way `dispatch`/`snapshot` do (ARCH-1: config-load failure falls back to defaults, never errors) and resolves via the helper.
- Refactor `cmd_snapshot.go` to use the same helper — it had the identical inline resolution logic.

## Status-line cost segment — already correct

The issue suspected `renderCostSegment` too, but `cmd_status_line.go` already opens `config.Analytics.DBPath` directly (consistent with dispatch). No change needed there. Confirmed by inspection.

## Tests (TDD red→green)

- `TestResolveAnalyticsDBPath` — unit: flag precedence, config fallback, empty/empty → empty.
- `TestRunStats_ReadsConfigDBPath` — regression: a project `hookwise.yaml` with a custom `analytics.db_path`, $18 seeded into that DB via the real writer path, then `stats` (no `--data-dir`) must print `$18.00`, not `$0.00`. Fails before the fix, passes after.

`go vet ./cmd/hookwise/` clean. Full `cmd/hookwise` package passes except the **pre-existing** `TestDoctorFeedHealthAllHealthy` (#104 test-isolation leak — reads real `~/.hookwise`/`~/.claude`; fails identically on pristine `main`, green in CI).

## Out of scope

- #104 (doctor's own real-state leak) — same class, separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)