### PR TITLE
fix(doctor): isolate hook + analytics checks from real home state (closes #104)

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -1548,6 +1548,22 @@ func TestDoctorFeedHealthAllHealthy(t *testing.T) {
 	cacheDir := filepath.Join(stateDir, "state")
 	os.MkdirAll(cacheDir, 0o700)
 
+	// Isolate the hook-safety scan from the real ~/.claude by pointing it at a
+	// temp .claude dir with a clean (hook-free) settings.json. Without this the
+	// scan reads the developer's real settings and any hook sprawl there makes
+	// this test flake (issue #104).
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{}`), 0o644))
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	// Seed an analytics DB under the isolated state dir so doctor's analytics
+	// check finds a real, queryable DB (PASS) instead of WARNing that it is not
+	// yet created — which would itself add a warning to the summary.
+	seedDB, err := analytics.Open(filepath.Join(stateDir, "analytics.db"))
+	require.NoError(t, err)
+	require.NoError(t, seedDB.Close())
+
 	configYAML := `version: 1
 status_line:
   enabled: true

--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -79,7 +79,10 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// Check 3: analytics DB health. Open the SQLite DB and run a trivial query
 	// so a corrupt or unwritable analytics.db surfaces here — ARCH-1 fail-open
 	// hides analytics write failures everywhere else.
-	dbPath := analytics.DefaultDBPath()
+	// Resolve the analytics DB under the active state dir so doctor checks the
+	// SAME DB the dispatch writer uses (and honors HOOKWISE_STATE_DIR), rather
+	// than the home-relative DefaultDBPath which ignores the env override.
+	dbPath := filepath.Join(core.GetStateDir(), "analytics.db")
 	if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {
 		fmt.Fprintf(w, "WARN  analytics: %s not yet created (created on first dispatch)\n", dbPath)
 		warnings++

--- a/internal/hooks/paths.go
+++ b/internal/hooks/paths.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -22,9 +23,16 @@ func SettingsPaths(claudeDir string) []string {
 	return paths
 }
 
-// DefaultSettingsPaths returns SettingsPaths for the real ~/.claude directory.
+// DefaultSettingsPaths returns SettingsPaths for the Claude Code settings
+// directory. It honors the HOOKWISE_CLAUDE_DIR env override (used by tests to
+// isolate the hook scan from the developer's real ~/.claude), falling back to
+// the real ~/.claude directory.
 func DefaultSettingsPaths() []string {
-	return SettingsPaths(filepath.Join(core.HomeDir(), ".claude"))
+	claudeDir := os.Getenv("HOOKWISE_CLAUDE_DIR")
+	if claudeDir == "" {
+		claudeDir = filepath.Join(core.HomeDir(), ".claude")
+	}
+	return SettingsPaths(claudeDir)
 }
 
 // AllFindings runs every hook-safety analysis over the inventory and returns the

--- a/internal/hooks/paths_test.go
+++ b/internal/hooks/paths_test.go
@@ -35,3 +35,12 @@ func TestSettingsPaths_GlobalAlwaysListedEvenIfAbsent(t *testing.T) {
 	require.Len(t, paths, 1)
 	assert.Equal(t, filepath.Join(claude, "settings.json"), paths[0])
 }
+
+func TestDefaultSettingsPaths_HonorsClaudeDirEnv(t *testing.T) {
+	claude := t.TempDir()
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claude)
+	// The override must point the default scan at the temp dir, not real ~/.claude.
+	paths := DefaultSettingsPaths()
+	require.NotEmpty(t, paths)
+	assert.Equal(t, filepath.Join(claude, "settings.json"), paths[0])
+}


### PR DESCRIPTION
## Problem

`doctor` read real machine state instead of the isolated/configured locations, so `TestDoctorFeedHealthAllHealthy` was non-deterministic (found while verifying the cost-tracking writer, #103):

- the **hook-safety scan** read the developer's real `~/.claude/settings.json` → any hook sprawl there triggered a `WARN` and failed the test's `NotContains("warning(s)")` assertion;
- the **analytics check** used the home-relative `analytics.DefaultDBPath()` (`~/.hookwise/analytics.db`), ignoring `HOOKWISE_STATE_DIR`.

CI passed only because the runner's `$HOME` happened to be clean — masking a real source-of-truth gap in the doctor command.

## Fix

- `hooks.DefaultSettingsPaths()` honors a new `HOOKWISE_CLAUDE_DIR` env override (falls back to `~/.claude`), so the scan can be pointed at an isolated dir.
- `doctor` resolves the analytics DB under `core.GetStateDir()` (honors `HOOKWISE_STATE_DIR`), matching where the `dispatch` writer puts it, instead of the home-relative default.
- The test points the scan at a clean temp `.claude`, seeds an analytics DB under the temp state dir (so the analytics check PASSes rather than WARNing "not yet created"), and asserts deterministically.

## Tests (TDD red→green)

- `TestDoctorFeedHealthAllHealthy` rewritten to full isolation — failed before the production fixes (still read real `~/.claude` → 26 hooks, sprawl WARN), passes after.
- `TestDefaultSettingsPaths_HonorsClaudeDirEnv` — new unit test for the env override.

`go vet ./cmd/hookwise/ ./internal/hooks/` clean. Full `cmd/hookwise` + `internal/hooks` packages pass under the guarded gate (`-race -p 2`, 0 zombies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)