### PR TITLE
fix(doctor): warn on fresh-cache feeds with empty data (doctor honesty, refs #99)

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -1453,6 +1453,40 @@ feeds:
 	assert.Contains(t, output, "WARN  feed:weather: stale data", "doctor should warn about stale weather feed")
 }
 
+// A feed whose cache is fresh but whose data payload is empty ({}) is a real
+// problem — the producer ran but emitted nothing, so the status-line segment
+// renders blank. doctor must be honest about this rather than reporting "OK"
+// (issue #99 — doctor honesty: distinguish "cache fresh" from "data absent").
+func TestDoctorFeedHealthEmptyData(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer os.Chdir(origDir)
+
+	stateDir := filepath.Join(tmpDir, ".hookwise")
+	t.Setenv("HOOKWISE_STATE_DIR", stateDir)
+	cacheDir := filepath.Join(stateDir, "state")
+	os.MkdirAll(cacheDir, 0o700)
+
+	// Fresh timestamp, but an empty data object.
+	now := time.Now().UTC().Format(time.RFC3339)
+	writeJSONFile(t, filepath.Join(cacheDir, "weather.json"), map[string]interface{}{
+		"type":      "weather",
+		"timestamp": now,
+		"data":      map[string]interface{}{},
+	})
+
+	output, err := executeCommand("doctor")
+	require.NoError(t, err, "doctor failed\noutput: %s", output)
+
+	assert.Contains(t, output, "WARN  feed:weather: cache fresh but no data",
+		"doctor should warn that a fresh-cache feed carries no data")
+	assert.NotContains(t, output, "feed:weather: OK",
+		"an empty-data feed must NOT be reported as OK")
+}
+
 // ---------------------------------------------------------------------------
 // 29. Doctor feed health: segment coverage
 // ---------------------------------------------------------------------------

--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -267,6 +267,16 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 			continue
 		}
 
+		// Honesty check: a fresh cache with an empty data object means the
+		// producer ran but emitted nothing — the segment renders blank. Report
+		// it distinctly rather than as "OK" (issue #99: cache-fresh != data-present).
+		if len(dataMap) == 0 {
+			fmt.Fprintf(w, "WARN  feed:%s: cache fresh but no data\n", feedName)
+			warnings++
+			feedStatuses[feedName] = "empty"
+			continue
+		}
+
 		// Parse timestamp once for staleness and reporting.
 		tsStr := envelope["timestamp"].(string)
 		ts, parseErr := core.ParseTimeFlex(tsStr)


### PR DESCRIPTION
## Problem

`doctor`'s feed-health check conflated **cache freshness** with **data presence**. A feed whose cache has a fresh timestamp but an empty data object (`data: {}`) — i.e. the producer ran but emitted nothing, so the status-line segment renders blank — was reported as:

```
INFO  feed:weather: OK (last updated 0s ago)
```

That's dishonest: the segment is effectively dead, but doctor says OK.

## Fix

In `checkFeedHealth`, after the placeholder check, treat an empty `data` map distinctly:

```
WARN  feed:weather: cache fresh but no data
```

and count it toward the warning total. Placeholder feeds (which carry a `source` key) and feeds with real data are unaffected. This is the #99 "doctor honesty" follow-up theme — it does **not** close the broader writer-audit issue.

## Tests (TDD red→green)

- `TestDoctorFeedHealthEmptyData` — seeds a fresh-timestamp feed with `data: {}`, asserts the new WARN line appears and the feed is NOT reported as `OK`. Failed before the change (reported `OK`), passes after.
- The existing `TestDoctorFeedHealth{Placeholder,Stale,SegmentCoverage,NoStateFiles,AllHealthy}` family still passes — no regression, and doctor output is not contract-locked (no fixtures in `testdata/contracts/`).

Guarded gate: full `cmd/hookwise` package passes under `-race -p 2` (0 zombies); `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)