### PR TITLE
fix(logging): bound the daemon log — default Info + rotate-on-open at 10MB

### DIFF
--- a/internal/core/errors.go
+++ b/internal/core/errors.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -84,6 +85,33 @@ func NewAnalyticsError(msg string) *AnalyticsError {
 
 // --- Structured Logging via slog ---
 
+// maxLogBytes is the log file size threshold (10 MB) that triggers rotation.
+const maxLogBytes int64 = 10 * 1024 * 1024
+
+// logLevelFromEnv returns slog.LevelDebug if HOOKWISE_LOG_LEVEL == "debug"
+// (case-insensitive), otherwise slog.LevelInfo.
+func logLevelFromEnv() slog.Level {
+	if strings.EqualFold(os.Getenv("HOOKWISE_LOG_LEVEL"), "debug") {
+		return slog.LevelDebug
+	}
+	return slog.LevelInfo
+}
+
+// rotateLogIfNeeded renames logPath to logPath+".1" (overwriting any existing
+// backup) when the file exists and its size exceeds maxBytes. Errors are
+// swallowed — logging setup must never crash dispatch (ARCH-1 fail-open).
+func rotateLogIfNeeded(logPath string, maxBytes int64) {
+	info, err := os.Stat(logPath)
+	if err != nil {
+		// File does not exist or is inaccessible — nothing to rotate.
+		return
+	}
+	if info.Size() > maxBytes {
+		// Best-effort: ignore rename errors.
+		_ = os.Rename(logPath, logPath+".1")
+	}
+}
+
 var (
 	logger     *slog.Logger
 	loggerOnce sync.Once
@@ -99,12 +127,13 @@ func Logger() *slog.Logger {
 			return
 		}
 		logPath := filepath.Join(logDir, "hookwise.log")
+		rotateLogIfNeeded(logPath, maxLogBytes)
 		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 		if err != nil {
 			logger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 			return
 		}
-		logger = slog.New(slog.NewJSONHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		logger = slog.New(slog.NewJSONHandler(f, &slog.HandlerOptions{Level: logLevelFromEnv()}))
 	})
 	return logger
 }

--- a/internal/core/logger_test.go
+++ b/internal/core/logger_test.go
@@ -1,0 +1,109 @@
+package core
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogLevelFromEnv(t *testing.T) {
+	// Note: t.Setenv forbids t.Parallel — do not parallelize.
+	tests := []struct {
+		name     string
+		envValue string // empty string means unset
+		unset    bool
+		want     slog.Level
+	}{
+		{name: "unset returns Info", unset: true, want: slog.LevelInfo},
+		{name: "debug lowercase returns Debug", envValue: "debug", want: slog.LevelDebug},
+		{name: "DEBUG uppercase returns Debug", envValue: "DEBUG", want: slog.LevelDebug},
+		{name: "info returns Info", envValue: "info", want: slog.LevelInfo},
+		{name: "garbage returns Info", envValue: "garbage", want: slog.LevelInfo},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				t.Setenv("HOOKWISE_LOG_LEVEL", "")
+			} else {
+				t.Setenv("HOOKWISE_LOG_LEVEL", tc.envValue)
+			}
+			got := logLevelFromEnv()
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRotateLogIfNeeded(t *testing.T) {
+	t.Run("file larger than threshold is rotated", func(t *testing.T) {
+		dir := t.TempDir()
+		logPath := filepath.Join(dir, "hookwise.log")
+
+		// Write 200 bytes — above the 100-byte test threshold.
+		content := make([]byte, 200)
+		for i := range content {
+			content[i] = 'a'
+		}
+		require.NoError(t, os.WriteFile(logPath, content, 0o600))
+
+		rotateLogIfNeeded(logPath, 100)
+
+		assert.NoFileExists(t, logPath, "original log should have been renamed away")
+		backup := logPath + ".1"
+		assert.FileExists(t, backup, "backup .1 should exist")
+
+		got, err := os.ReadFile(backup)
+		require.NoError(t, err)
+		assert.Equal(t, content, got, "backup should contain original content")
+	})
+
+	t.Run("file at or below threshold is not rotated", func(t *testing.T) {
+		dir := t.TempDir()
+		logPath := filepath.Join(dir, "hookwise.log")
+
+		content := make([]byte, 50)
+		require.NoError(t, os.WriteFile(logPath, content, 0o600))
+
+		rotateLogIfNeeded(logPath, 100)
+
+		assert.FileExists(t, logPath, "log file should still exist")
+		assert.NoFileExists(t, logPath+".1", "backup should not have been created")
+	})
+
+	t.Run("missing file is a no-op", func(t *testing.T) {
+		dir := t.TempDir()
+		logPath := filepath.Join(dir, "nonexistent.log")
+
+		// Must not panic.
+		rotateLogIfNeeded(logPath, 100)
+
+		assert.NoFileExists(t, logPath)
+		assert.NoFileExists(t, logPath+".1")
+	})
+
+	t.Run("existing backup is overwritten", func(t *testing.T) {
+		dir := t.TempDir()
+		logPath := filepath.Join(dir, "hookwise.log")
+		backupPath := logPath + ".1"
+
+		newContent := make([]byte, 200)
+		for i := range newContent {
+			newContent[i] = 'n'
+		}
+		oldContent := []byte("old")
+
+		require.NoError(t, os.WriteFile(logPath, newContent, 0o600))
+		require.NoError(t, os.WriteFile(backupPath, oldContent, 0o600))
+
+		rotateLogIfNeeded(logPath, 100)
+
+		assert.NoFileExists(t, logPath, "original log should have been renamed away")
+		got, err := os.ReadFile(backupPath)
+		require.NoError(t, err)
+		assert.Equal(t, newContent, got, "backup should now contain the new (rotated) content, overwriting the old backup")
+	})
+}


### PR DESCRIPTION
## What & why

`core.Logger()` opened `~/.hookwise/logs/hookwise.log` at `slog.LevelDebug` with **no rotation**. Every `hookwise dispatch` is a short-lived process appending to that file, plus one long-lived daemon — so the log grows unbounded (observed ~128MB of debug spam). Fixes #93.

## Change

- **Default level → `slog.LevelInfo`.** `HOOKWISE_LOG_LEVEL=debug` (case-insensitive) re-enables `Debug`.
- **Rotate-on-open at 10MB.** Before opening the log for append, if `hookwise.log` > 10MB it is `os.Rename`d to `hookwise.log.1` (atomic on POSIX, overwrites any prior backup). Exactly 1 backup is kept. No gzip, no new dependencies.

Logic is factored into two pure helpers — `logLevelFromEnv()` and `rotateLogIfNeeded(logPath, maxBytes)` — because `Logger()` is a `sync.Once` singleton that can't be re-initialized across table-test cases. Rotation/stat errors are swallowed (**ARCH-1 fail-open**: logging setup must never crash dispatch). The stderr-fallback branches stay at `Info`.

## Decision (approved by repo owner)

> Info default; `HOOKWISE_LOG_LEVEL=debug` override; rotate-on-open at 10MB keeping 1 backup; no new dependencies.

## Tests

`internal/core/logger_test.go` (helpers tested directly — `Logger()` itself isn't, since the singleton isn't re-runnable):
- `TestLogLevelFromEnv` — 5 cases: unset/`debug`/`DEBUG`/`info`/`garbage`.
- `TestRotateLogIfNeeded` — 4 subtests: large file rotated, small file untouched, missing file no-op, existing backup overwritten.

Guarded gate green locally: `GOMEMLIMIT=4GiB go test -race -p 2 ./internal/core/` → `ok` (0 zombies confirmed first).

## Known limitation

Rotation fires only on process start (rotate-on-open). A long-lived daemon writing >10MB within a single run won't rotate until restart — acceptable at `Info` volume; noted in the dev journal for a future size-interval check if the daemon ever becomes chatty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)