### PR TITLE
fix(notifications): resolve analytics DB path from config, not $HOME default

### DIFF
--- a/cmd/hookwise/cmd_notifications.go
+++ b/cmd/hookwise/cmd_notifications.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/vishnujayvel/hookwise/internal/analytics"
+	"github.com/vishnujayvel/hookwise/internal/core"
 	"github.com/vishnujayvel/hookwise/internal/notifications"
 )
 
@@ -27,14 +29,22 @@ surfaced via the status line or this command.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&dataDir, "data-dir", "", "Path to the analytics SQLite DB file (defaults to ~/.hookwise/analytics.db)")
+	cmd.Flags().StringVar(&dataDir, "data-dir", "", "Path to the analytics SQLite DB file (defaults to config analytics.db_path / ~/.hookwise/analytics.db)")
 	cmd.Flags().IntVar(&limit, "limit", 20, "Maximum number of notifications to show")
 
 	return cmd
 }
 
 func runNotifications(cmd *cobra.Command, dataDir string, limit int) error {
-	db, err := analytics.Open(dataDir)
+	// Load config the same way the writer (dispatch) does so reader and writer
+	// agree on the DB path (ARCH-1: never hard-fail on a missing/broken config).
+	cwd, _ := os.Getwd()
+	config, err := core.LoadConfig(cwd)
+	if err != nil {
+		config = core.GetDefaultConfig()
+	}
+
+	db, err := analytics.Open(resolveAnalyticsDBPath(dataDir, config))
 	if err != nil {
 		return fmt.Errorf("failed to open analytics DB: %w", err)
 	}

--- a/cmd/hookwise/cmd_notifications_test.go
+++ b/cmd/hookwise/cmd_notifications_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/notifications"
+)
+
+// TestNotifications_ReadsConfigDBPath is the #109 regression test: when a project
+// config sets a custom analytics.db_path, `notifications` (with no --data-dir flag)
+// must read THAT database — the same one `dispatch` writes to — not the default
+// ~/.hookwise/analytics.db. Before the fix, notifications ignored config and printed
+// "No notifications." from the default empty DB.
+func TestNotifications_ReadsConfigDBPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Isolate the default state dir so the "default" DB is empty (and absent).
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+
+	customDB := filepath.Join(tmpDir, "custom-notifications.db")
+
+	// A project dir with a hookwise.yaml pointing analytics at the custom DB.
+	projectDir := filepath.Join(tmpDir, "project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	cfgYAML := "analytics:\n  enabled: true\n  db_path: " + customDB + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "hookwise.yaml"), []byte(cfgYAML), 0o644))
+
+	// Seed one notification into the CUSTOM DB via the real NotificationService.
+	db := openTestDB(t, customDB)
+	ns := notifications.NewNotificationService(db)
+	require.NoError(t, ns.Create(context.Background(), "budget", "budget_threshold", "Cost exceeded $99.00"))
+	db.Close()
+
+	// Run `notifications` from the project dir with NO --data-dir flag.
+	t.Chdir(projectDir)
+	cmd := newNotificationsCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "Cost exceeded $99.00",
+		"notifications must read the config's db_path and show seeded notification, not 'No notifications.' from the default DB")
+}


### PR DESCRIPTION
## What & why

`hookwise notifications` is a **reader** that opened the analytics DB from only the `--data-dir` flag — falling through to `analytics.DefaultDBPath()` (`~/.hookwise/analytics.db`) and **ignoring `config.Analytics.DBPath`**. The **writer** (`dispatch`) records notifications to the config path. So under a custom `analytics.db_path`, the reader opened the wrong (default/empty) DB and showed no history.

This is the same reader/writer divergence class as the merged `stats` (#107) and `doctor` (#108) fixes — part of **#109**.

## Fix

Resolve the path exactly like `runStats`: `core.LoadConfig(cwd)` with a `GetDefaultConfig()` fallback (ARCH-1 fail-open), then `analytics.Open(resolveAnalyticsDBPath(dataDir, config))`. Reuses the existing `resolveAnalyticsDBPath` helper — no new resolver. **Reader-side only**; the dispatch hot path and daemon coordination are untouched.

## Test (TDD)

`TestNotifications_ReadsConfigDBPath` — with `HOOKWISE_STATE_DIR` pointed at an empty temp dir (so the default DB is absent) and a project `hookwise.yaml` setting a custom `analytics.db_path`, a notification seeded into the config DB is shown when `--data-dir` is empty. **RED→GREEN verified**: stashing the production fix makes the test fail (`"No notifications."`) on the old code.

Guarded gate green locally: `GOMEMLIMIT=4GiB go test -race -p 2 ./cmd/hookwise/` → `ok` (0 zombies before/after).

## Scope

Fixes divergence #1 of three found by the #109 reader-path audit. The other two (`DefaultSnapshotsDir()` + `tuiPIDPath()`) touch the **daemon writer** and are tracked in **#116** for a supervised PR rather than autopatched here.

Refs #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--data-dir` flag to the notifications command for overriding the default database directory.
  * Added `--limit` flag to control the maximum number of notifications displayed.

* **Tests**
  * Added regression test for notifications configuration database path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->