### PR TITLE
fix(transcript): don't abort cost on one oversized line

### DIFF
--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -5,7 +5,9 @@ package transcript
 import (
 	"bufio"
 	"encoding/json"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/vishnujayvel/hookwise/internal/pricing"
 )
@@ -31,10 +33,12 @@ type transcriptUsage struct {
 	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
 }
 
-// scannerBufSize is the initial Scanner buffer size (10 MiB).
-// Transcript lines can easily exceed the default 64 KiB limit when assistant
-// messages embed large tool-result payloads.
-const scannerBufSize = 10 * 1024 * 1024 // 10 MiB
+// maxLineBytes is the upper bound on lines we will attempt to JSON-parse.
+// Lines longer than this are skipped (not fatal) — they exceed any realistic
+// transcript line shape and would only arise from embedded base64 blobs or
+// corrupted data. ReadString buffers a full line in memory; this cap bounds
+// the json-parse step while keeping accounting for all other lines intact.
+const maxLineBytes = 50 * 1024 * 1024 // 50 MiB
 
 // SumUsage opens the .jsonl transcript at path, scans it line by line, and
 // returns a map from model ID to the total token usage accumulated across all
@@ -44,6 +48,7 @@ const scannerBufSize = 10 * 1024 * 1024 // 10 MiB
 //   - Non-JSON and malformed lines are skipped (not fatal).
 //   - Lines where type != "assistant" are skipped.
 //   - Assistant lines with no usage block are skipped.
+//   - Lines longer than maxLineBytes are skipped (not fatal).
 //   - All other lines contribute their token counts to the per-model accumulator.
 //
 // A missing file returns a non-nil error.
@@ -58,47 +63,38 @@ func SumUsage(path string) (map[string]pricing.Usage, error) {
 
 	result := make(map[string]pricing.Usage)
 
-	sc := bufio.NewScanner(f)
-	// Allocate a 10 MiB initial buffer; allow it to grow up to 10 MiB max.
-	buf := make([]byte, scannerBufSize)
-	sc.Buffer(buf, scannerBufSize)
-
-	for sc.Scan() {
-		raw := sc.Bytes()
-		if len(raw) == 0 {
-			continue
+	r := bufio.NewReader(f)
+	for {
+		raw, err := r.ReadString('\n')
+		// Process whatever was read before checking the error.
+		line := strings.TrimSpace(raw)
+		if line != "" {
+			// Skip pathologically large lines — don't attempt to json.Unmarshal them.
+			if len(line) > maxLineBytes {
+				// oversized line: skip, not fatal (ARCH-1 spirit: degrade gracefully)
+			} else {
+				var tl transcriptLine
+				if jsonErr := json.Unmarshal([]byte(line), &tl); jsonErr == nil {
+					if tl.Type == "assistant" && tl.Message.Usage != nil && tl.Message.Model != "" {
+						u := tl.Message.Usage
+						existing := result[tl.Message.Model]
+						result[tl.Message.Model] = pricing.Usage{
+							InputTokens:         existing.InputTokens + u.InputTokens,
+							OutputTokens:        existing.OutputTokens + u.OutputTokens,
+							CacheReadTokens:     existing.CacheReadTokens + u.CacheReadInputTokens,
+							CacheCreationTokens: existing.CacheCreationTokens + u.CacheCreationInputTokens,
+						}
+					}
+				}
+				// Malformed JSON or non-assistant line — skip, not fatal.
+			}
 		}
-
-		var line transcriptLine
-		if err := json.Unmarshal(raw, &line); err != nil {
-			// Malformed line — skip, not fatal.
-			continue
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
 		}
-
-		if line.Type != "assistant" {
-			continue
-		}
-		if line.Message.Usage == nil {
-			continue
-		}
-		if line.Message.Model == "" {
-			continue
-		}
-
-		u := line.Message.Usage
-		existing := result[line.Message.Model]
-		result[line.Message.Model] = pricing.Usage{
-			InputTokens:         existing.InputTokens + u.InputTokens,
-			OutputTokens:        existing.OutputTokens + u.OutputTokens,
-			CacheReadTokens:     existing.CacheReadTokens + u.CacheReadInputTokens,
-			CacheCreationTokens: existing.CacheCreationTokens + u.CacheCreationInputTokens,
-		}
-	}
-
-	// sc.Err() returns nil on normal EOF; any scanner error (e.g., token too
-	// long even after our large buffer) would surface here — treat as fatal.
-	if err := sc.Err(); err != nil {
-		return nil, err
 	}
 
 	return result, nil

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -216,6 +216,38 @@ func TestVeryLongLine(t *testing.T) {
 	assert.Equal(t, int64(1), u.CacheCreationTokens)
 }
 
+// TestLineOverBufferLimitNotFatal verifies that a single line exceeding the scanner's
+// buffer cap does NOT abort the whole scan. The two valid assistant lines before and
+// after the giant junk line must both be counted, and the call must return nil error.
+func TestLineOverBufferLimitNotFatal(t *testing.T) {
+	line1 := assistantLine("claude-opus-4-8", 10, 2, 0, 0)
+	giantJunk := strings.Repeat("x", 11*1024*1024) // 11 MiB of non-JSON junk, exceeds old 10 MiB cap
+	line3 := assistantLine("claude-sonnet-4-6", 20, 4, 0, 0)
+
+	f, err := os.CreateTemp(t.TempDir(), "overlimit_*.jsonl")
+	require.NoError(t, err)
+	_, err = fmt.Fprintf(f, "%s\n%s\n%s\n", line1, giantJunk, line3)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	result, err := transcript.SumUsage(f.Name())
+	require.NoError(t, err, "giant junk line must not abort the scan")
+
+	opus, ok := result["claude-opus-4-8"]
+	require.True(t, ok, "expected 'claude-opus-4-8' key")
+	assert.Equal(t, int64(10), opus.InputTokens)
+	assert.Equal(t, int64(2), opus.OutputTokens)
+	assert.Equal(t, int64(0), opus.CacheReadTokens)
+	assert.Equal(t, int64(0), opus.CacheCreationTokens)
+
+	sonnet, ok := result["claude-sonnet-4-6"]
+	require.True(t, ok, "expected 'claude-sonnet-4-6' key")
+	assert.Equal(t, int64(20), sonnet.InputTokens)
+	assert.Equal(t, int64(4), sonnet.OutputTokens)
+	assert.Equal(t, int64(0), sonnet.CacheReadTokens)
+	assert.Equal(t, int64(0), sonnet.CacheCreationTokens)
+}
+
 // TestResultTypeIsPricingUsage is a compile-time assertion that SumUsage returns map[string]pricing.Usage.
 // If the return type ever changes, this assignment will fail to compile.
 func TestResultTypeIsPricingUsage(t *testing.T) {


### PR DESCRIPTION
## What & why

`transcript.SumUsage` scanned the session `.jsonl` with a `bufio.Scanner` capped at 10 MiB. A single line over that limit — an assistant message embedding a large base64 tool-result or image — made `sc.Err()` return `bufio.ErrTooLong`, which the code treated as **fatal** (`return nil, err`). The Stop-seam cost writer then recorded **$0 for the entire session** even though every other line parsed fine. That violates fail-open (ARCH-1 spirit): cost accounting should degrade gracefully, not vanish.

Audit finding #25 / closes #118.

## Fix

Replace the fixed-cap `bufio.Scanner` with a `bufio.Reader` + `ReadString('\n')` loop:
- Lines longer than a 50 MiB `maxLineBytes` are **skipped** (not JSON-parsed, not fatal).
- A genuine non-EOF read error is still fatal; `io.EOF` ends the loop.
- All other behavior is preserved (missing file → error; empty file → empty map + nil err; malformed/non-assistant/missing-usage lines skipped; per-model accumulation identical).

One oversized line is now ignored while the rest of the session is still costed. (Tradeoff noted in a code comment: `ReadString` buffers a full line in memory before the cap applies; transcript lines are bounded by Claude Code's own output, so a single unbounded line isn't a realistic shape — a fully-streaming reader would close even that.)

## Test (TDD)

`TestLineOverBufferLimitNotFatal` — fixture `[opus 10/2][11 MiB of non-JSON junk][sonnet 20/4]` → asserts both models are summed and `err == nil`. **RED→GREEN verified**: stashing the production change makes it fail with `bufio.Scanner: token too long` (the exact bug). Existing `TestVeryLongLine` (100 KB line) is unchanged.

Guarded gate green locally: `GOMEMLIMIT=4GiB go test -race -p 2 ./internal/transcript/` → `ok` (0 zombies before/after).

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript file parsing robustness to gracefully handle and skip abnormally large lines, preventing processing failures while ensuring accurate usage metrics aggregation continues uninterrupted.

* **Tests**
  * Added test coverage validating transcript parsing resilience with unexpectedly large lines, confirming usage metrics are correctly calculated and aggregated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->