### PR TITLE
docs: correct stale better-sqlite3 claim in philosophy.md

### DIFF
--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -34,7 +34,7 @@ Graceful degradation is a design practice, not a philosophical argument against 
 
 hookwise is a developer tool platform. Developer tool platforms have databases, background daemons, and managed processes. This is normal and expected.
 
-hookwise already runs a background daemon for feeds, manages PID files, bundles better-sqlite3 as a native addon, and ships a Python TUI package. The bar for adding infrastructure should be: "Does this solve a real problem for users?" Not: "Is this zero-config?" and not: "Could this possibly go down?"
+hookwise already runs a background daemon for feeds, manages PID files, embeds a pure-Go SQLite engine (modernc.org/sqlite, CGO-free), and ships a Python TUI package. The bar for adding infrastructure should be: "Does this solve a real problem for users?" Not: "Is this zero-config?" and not: "Could this possibly go down?"
 
 What matters is that infrastructure is invisible to the user when it works, and diagnostic when it does not.
 


### PR DESCRIPTION
## What & why

`docs/philosophy.md` (Infrastructure Is Normal section) stated hookwise "bundles **better-sqlite3 as a native addon**." That's a false current-tense technical claim describing the **deleted TypeScript stack** — the Go binary uses `modernc.org/sqlite` (pure-Go, **CGO-free, no native addon**); Dolt and the TS runtime were both removed long ago.

Corrected to: "embeds a pure-Go SQLite engine (modernc.org/sqlite, CGO-free)". Ground truth: `go.mod` → `modernc.org/sqlite v1.46.1`.

## Scope

**Factual correction only** — one clause; the rest of the sentence (background daemon, PID files, Python TUI) is accurate and untouched. **No positioning or marketing changes.** This is the single unambiguous, judgment-free slice of the architecture audit's "factual inflation" blocker (#7); the entangled pieces (producer counts, coaching/recipe claims) are deliberately left for a human positioning decision.

Doc-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)