### PR TITLE
fix(analytics): atomic cost-state update to fix lost-update race

### DIFF
--- a/cmd/hookwise/cmd_dispatch.go
+++ b/cmd/hookwise/cmd_dispatch.go
@@ -203,7 +203,11 @@ func recordAnalytics(ctx context.Context, eventType string, payload core.HookPay
 				for model, u := range usageByModel {
 					sessionCost += pricing.ComputeWithRates(model, u, costCfg.Rates)
 				}
-				if state, serr := db.ReadCostState(ctx); serr == nil {
+				// Atomic read-modify-write: each dispatch is its own process
+				// sharing one WAL DB, so a plain Read→Write would lose updates
+				// when two Stop events race. UpdateCostState serializes via
+				// BEGIN IMMEDIATE (audit #6).
+				if uerr := db.UpdateCostState(ctx, func(state *analytics.CostState) {
 					today := now.Format("2006-01-02")
 					delta := sessionCost - state.SessionCosts[payload.SessionID]
 					state.SessionCosts[payload.SessionID] = sessionCost
@@ -213,11 +217,8 @@ func recordAnalytics(ctx context.Context, eventType string, payload core.HookPay
 					}
 					state.DailyCosts[today] += delta
 					state.Today = today
-					if werr := db.WriteCostState(ctx, state); werr != nil {
-						core.Logger().Error("cost: write cost_state", "error", werr)
-					}
-				} else {
-					core.Logger().Warn("cost: read cost_state", "error", serr)
+				}); uerr != nil {
+					core.Logger().Error("cost: update cost_state", "error", uerr)
 				}
 			}
 		}

--- a/internal/analytics/state.go
+++ b/internal/analytics/state.go
@@ -34,14 +34,31 @@ func defaultCostState() *CostState {
 	}
 }
 
+// costStateSelectSQL reads the singleton cost_state row (id=1). Shared by the
+// pooled ReadCostState and the transaction-bound UpdateCostState so both issue
+// an identical query.
+const costStateSelectSQL = `SELECT daily_costs, session_costs, today, total_today
+	 FROM cost_state WHERE id = 1`
+
+// costStateExecer is satisfied by *sql.DB and *sql.Conn, letting writeCostState
+// run either on the pool (WriteCostState) or inside a pinned transaction
+// (UpdateCostState).
+type costStateExecer interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}
+
 // ReadCostState loads the singleton cost state from SQLite.
 // If no row exists, it returns a default state with today's date.
 // If the stored date differs from today, TotalToday is reset to 0.
 func (d *DB) ReadCostState(ctx context.Context) (*CostState, error) {
-	row := d.QueryRow(ctx,
-		`SELECT daily_costs, session_costs, today, total_today
-		 FROM cost_state WHERE id = 1`)
+	return scanCostStateRow(d.QueryRow(ctx, costStateSelectSQL))
+}
 
+// scanCostStateRow scans a single cost_state row (or applies defaults when the
+// row is absent) and performs the date-boundary reset. Shared by ReadCostState
+// (pooled) and UpdateCostState (transaction-bound) so both observe identical
+// parse and reset semantics.
+func scanCostStateRow(row *sql.Row) (*CostState, error) {
 	var (
 		dailyCostsJSON   sql.NullString
 		sessionCostsJSON sql.NullString
@@ -93,6 +110,12 @@ func (d *DB) ReadCostState(ctx context.Context) (*CostState, error) {
 
 // WriteCostState persists the cost state to the singleton row (id=1).
 func (d *DB) WriteCostState(ctx context.Context, state *CostState) error {
+	return writeCostState(ctx, d.db, state)
+}
+
+// writeCostState marshals and REPLACEs the singleton cost_state row using the
+// given execer (the pool or a transaction-bound connection).
+func writeCostState(ctx context.Context, ex costStateExecer, state *CostState) error {
 	dailyCostsJSON, err := json.Marshal(state.DailyCosts)
 	if err != nil {
 		return fmt.Errorf("analytics: marshal daily_costs: %w", err)
@@ -103,7 +126,7 @@ func (d *DB) WriteCostState(ctx context.Context, state *CostState) error {
 		return fmt.Errorf("analytics: marshal session_costs: %w", err)
 	}
 
-	_, err = d.Exec(ctx,
+	_, err = ex.ExecContext(ctx,
 		`REPLACE INTO cost_state
 		 (id, daily_costs, session_costs, today, total_today)
 		 VALUES (1, ?, ?, ?, ?)`,
@@ -112,6 +135,55 @@ func (d *DB) WriteCostState(ctx context.Context, state *CostState) error {
 	if err != nil {
 		return fmt.Errorf("analytics: write cost_state: %w", err)
 	}
+	return nil
+}
+
+// UpdateCostState atomically reads, mutates, and persists the singleton cost
+// state inside a single BEGIN IMMEDIATE transaction on a dedicated connection.
+//
+// Each `hookwise dispatch` runs in its own OS process with its own connection
+// to the shared WAL database, so a plain Read→mutate→Write is a cross-process
+// lost-update race: two Stop events can both read the same TotalToday and the
+// second writer clobbers the first. BEGIN IMMEDIATE takes the write lock at
+// transaction start, so a concurrent updater blocks (up to busy_timeout) and
+// then reads the already-committed state instead of a stale snapshot.
+//
+// A dedicated *sql.Conn is required: under SetMaxOpenConns(1) the pooled
+// helpers would deadlock against a connection this method already holds.
+func (d *DB) UpdateCostState(ctx context.Context, mutate func(*CostState)) error {
+	conn, err := d.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("analytics: cost_state conn: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return fmt.Errorf("analytics: cost_state begin: %w", err)
+	}
+
+	committed := false
+	defer func() {
+		if !committed {
+			// Best-effort rollback; the deferred Close also releases the lock.
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	state, err := scanCostStateRow(conn.QueryRowContext(ctx, costStateSelectSQL))
+	if err != nil {
+		return err
+	}
+
+	mutate(state)
+
+	if err := writeCostState(ctx, conn, state); err != nil {
+		return err
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("analytics: cost_state commit: %w", err)
+	}
+	committed = true
 	return nil
 }
 

--- a/internal/analytics/state_test.go
+++ b/internal/analytics/state_test.go
@@ -3,8 +3,10 @@ package analytics
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -126,6 +128,64 @@ func TestCostState_EmptyMaps(t *testing.T) {
 	assert.NotNil(t, loaded.SessionCosts)
 	assert.Empty(t, loaded.DailyCosts)
 	assert.Empty(t, loaded.SessionCosts)
+}
+
+// TestUpdateCostState_ConcurrentNoLostUpdate simulates the cross-process race
+// (audit #6): two `hookwise dispatch` processes each open their own connection
+// to the SAME WAL database and run cost updates concurrently. A plain
+// Read→mutate→Write loses updates because both readers observe the same
+// snapshot; UpdateCostState must serialize via BEGIN IMMEDIATE so every
+// increment is preserved.
+func TestUpdateCostState_ConcurrentNoLostUpdate(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "hookwise-cost-race-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	// Two independent handles to one file, mirroring two separate OS processes
+	// (each with SetMaxOpenConns(1)).
+	db1, err := Open(dbPath)
+	require.NoError(t, err)
+	defer db1.Close()
+	db2, err := Open(dbPath)
+	require.NoError(t, err)
+	defer db2.Close()
+
+	ctx := context.Background()
+	today := time.Now().Format("2006-01-02")
+
+	const opsPerHandle = 25
+	handles := []*DB{db1, db2}
+
+	var wg sync.WaitGroup
+	for h, db := range handles {
+		for i := 0; i < opsPerHandle; i++ {
+			wg.Add(1)
+			go func(db *DB, h, i int) {
+				defer wg.Done()
+				sessionID := fmt.Sprintf("h%d-op%d", h, i)
+				uerr := db.UpdateCostState(ctx, func(state *CostState) {
+					state.SessionCosts[sessionID] = 1.0
+					state.TotalToday += 1.0
+					state.DailyCosts[today] += 1.0
+					state.Today = today
+				})
+				assert.NoError(t, uerr)
+			}(db, h, i)
+		}
+	}
+	wg.Wait()
+
+	total := opsPerHandle * len(handles)
+	loaded, err := db1.ReadCostState(ctx)
+	require.NoError(t, err)
+	assert.InDelta(t, float64(total), loaded.TotalToday, 0.001,
+		"every concurrent increment must survive (no lost update)")
+	assert.InDelta(t, float64(total), loaded.DailyCosts[today], 0.001,
+		"daily total must equal the sum of all increments")
+	assert.Len(t, loaded.SessionCosts, total,
+		"every session's cost must be recorded")
 }
 
 // --- Feed Cache Tests ---


### PR DESCRIPTION
## What

The Stop-seam cost accounting did a plain `ReadCostState` → mutate → `WriteCostState`. Each `hookwise dispatch` is its **own OS process** with its own connection to the shared WAL `analytics.db`, so two concurrent Stop events both read the same `TotalToday` and the second writer **clobbers** the first — a classic cross-process lost update. `busy_timeout(5000)` prevents `SQLITE_BUSY` but **not** a read-then-write lost update.

This is **audit #6** from the architecture audit (correctness gap, not a strict launch blocker).

## Fix

- Add `UpdateCostState(ctx, mutate func(*CostState))` — read-modify-write inside a single `BEGIN IMMEDIATE` transaction on a dedicated `*sql.Conn`. `BEGIN IMMEDIATE` takes the write lock at transaction **start**, so a concurrent updater blocks (up to `busy_timeout`) then reads fresh committed state instead of a stale snapshot.
- Extract shared `scanCostStateRow` (parse + date-boundary reset) and `writeCostState(execer)` so the pooled `Read/WriteCostState` and the transaction path stay byte-identical in logic.
- Wire the dispatch Stop seam to `UpdateCostState` (the mutation logic is unchanged).

### Why a dedicated `*sql.Conn`
Under `SetMaxOpenConns(1)` (ARCH-2), calling the pooled `WriteCostState` inside the transaction would self-deadlock on the single connection. The dedicated conn pins one connection for the whole `BEGIN..COMMIT`.

### Arch-guard (#111) stays green
`WriteCostState` keeps its production caller in `internal/migration/migration.go`, so the writer-wiring guard does not regress.

## Verification (RED→GREEN)

`TestUpdateCostState_ConcurrentNoLostUpdate` opens **two** `*DB` handles to **one** temp file (two-process simulation), runs 50 concurrent increments under `-race`, and asserts zero lost updates.

- **RED** (naive non-transactional RMW swapped in): lost 47/50 updates — only 3 survived.
- **GREEN** (real `BEGIN IMMEDIATE`): all 50 survive, `-race` clean.

Guarded gate green on `internal/{analytics,arch,migration,notifications}` + `cmd/hookwise` (`-race -p 2`).

## ARCH compliance
- ARCH-1 (fail-open): `UpdateCostState` errors are logged and dispatch continues.
- ARCH-2 (single-writer): unchanged; uses the one connection.
- Cost writes stay on the **Stop seam only** — no PostToolUse hot-path or daemon changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured cost-state database operations to use transactional consistency.
  * Consolidated query and data parsing logic across read/write operations.

* **Tests**
  * Added test validating cost-state consistency under concurrent updates across multiple database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->