### PR TITLE
feat(pricing): warn when cost uses unknown-model fallback rates

### DIFF
--- a/cmd/hookwise/cmd_dispatch.go
+++ b/cmd/hookwise/cmd_dispatch.go
@@ -201,6 +201,13 @@ func recordAnalytics(ctx context.Context, eventType string, payload core.HookPay
 				core.Logger().Warn("cost: read transcript usage", "error", terr)
 			} else {
 				for model, u := range usageByModel {
+					// Degrade gracefully AND warn: an unknown model still costs
+					// at Sonnet fallback rates, but silently mispricing an
+					// as-yet-unknown family undercounts cost. Surface it (audit #26).
+					if !pricing.Recognized(model) {
+						core.Logger().Warn("cost: unknown model, using fallback rates",
+							"model", model)
+					}
 					sessionCost += pricing.ComputeWithRates(model, u, costCfg.Rates)
 				}
 				// Atomic read-modify-write: each dispatch is its own process

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -88,21 +88,34 @@ var builtinRates = map[family]modelRates{
 	},
 }
 
-// matchFamily returns the model family for the given model ID.
-// Matching is case-insensitive substring search in priority order:
-// opus → sonnet → haiku.  Unrecognised IDs return defaultFamily.
-func matchFamily(model string) family {
+// matchFamily returns the model family for the given model ID and whether the
+// ID was recognised. Matching is case-insensitive substring search in priority
+// order: opus → sonnet → haiku.  Unrecognised IDs return (defaultFamily, false)
+// so callers can distinguish a genuine Sonnet match from a fallback.
+func matchFamily(model string) (family, bool) {
 	lower := strings.ToLower(model)
 	switch {
 	case strings.Contains(lower, "opus"):
-		return familyOpus
+		return familyOpus, true
 	case strings.Contains(lower, "sonnet"):
-		return familySonnet
+		return familySonnet, true
 	case strings.Contains(lower, "haiku"):
-		return familyHaiku
+		return familyHaiku, true
 	default:
-		return defaultFamily
+		return defaultFamily, false
 	}
+}
+
+// Recognized reports whether the model ID maps to a known family
+// (opus/sonnet/haiku) rather than falling back to the default Sonnet rates.
+//
+// Cost computation never fails on an unknown model — it silently uses Sonnet
+// rates — which can badly under- or over-count a model from an as-yet-unknown
+// family. Callers on the cost path use this to emit a diagnostic when a cost is
+// derived from fallback rates ("degrade gracefully AND always warn").
+func Recognized(model string) bool {
+	_, ok := matchFamily(model)
+	return ok
 }
 
 // resolveRates returns the effective modelRates for the given family, applying
@@ -140,7 +153,7 @@ func computeCost(u Usage, r modelRates) float64 {
 // using built-in rate tables.  Unknown model IDs fall back to Sonnet rates
 // and never panic.  Zero usage always returns 0.0.
 func Compute(model string, u Usage) float64 {
-	fam := matchFamily(model)
+	fam, _ := matchFamily(model)
 	r := resolveRates(fam, nil)
 	return computeCost(u, r)
 }
@@ -152,7 +165,7 @@ func Compute(model string, u Usage) float64 {
 // Unknown model IDs fall back to Sonnet rates; unknown override keys are
 // silently ignored.  Never panics.
 func ComputeWithRates(model string, u Usage, overrides map[string]float64) float64 {
-	fam := matchFamily(model)
+	fam, _ := matchFamily(model)
 	r := resolveRates(fam, overrides)
 	return computeCost(u, r)
 }

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -311,3 +311,48 @@ func TestFractionalTokens_Sonnet(t *testing.T) {
 	cost := pricing.Compute("claude-sonnet-4", u)
 	assert.InDelta(t, want, cost, 1e-9)
 }
+
+// ---------------------------------------------------------------------------
+// Recognized (audit #26: fallback telemetry)
+// ---------------------------------------------------------------------------
+
+// TestRecognized verifies that known families report true (case-insensitively,
+// via substring) and that unknown IDs report false so the cost path can warn
+// when a cost is derived from fallback Sonnet rates.
+func TestRecognized(t *testing.T) {
+	known := []string{
+		"claude-opus-4-8",
+		"CLAUDE-OPUS-4-20250601",
+		"claude-sonnet-4-6",
+		"claude-3-5-haiku-20241022",
+		"some-haiku-variant",
+	}
+	for _, m := range known {
+		assert.True(t, pricing.Recognized(m), "expected %q to be recognized", m)
+	}
+
+	unknown := []string{
+		"",
+		"gpt-4o",
+		"gemini-2.5-pro",
+		"claude-x-9",
+		"unknown-model",
+	}
+	for _, m := range unknown {
+		assert.False(t, pricing.Recognized(m), "expected %q to be unrecognized", m)
+	}
+}
+
+// TestRecognized_FallbackStillComputes confirms the telemetry change did not
+// alter cost math: an unrecognized model still computes at Sonnet rates and is
+// identical to an explicitly-Sonnet model with the same usage.
+func TestRecognized_FallbackStillComputes(t *testing.T) {
+	u := pricing.Usage{InputTokens: 1_000_000, OutputTokens: 500_000}
+
+	unknownCost := pricing.Compute("gpt-4o", u)
+	sonnetCost := pricing.Compute("claude-sonnet-4-6", u)
+
+	require.False(t, pricing.Recognized("gpt-4o"))
+	assert.InDelta(t, sonnetCost, unknownCost, delta,
+		"unknown model must still compute at Sonnet fallback rates")
+}


### PR DESCRIPTION
## What

`pricing.Compute`/`ComputeWithRates` silently price an **unrecognized** model at the default **Sonnet** fallback rates. For an as-yet-unknown model family this can badly under- or over-count cost (an Opus-class unknown model is undercounted ~5×) with **no signal** — a "degrade silently" violation of the project's *degrade gracefully **AND** always warn* philosophy. This is **audit #26**.

## Fix

- `matchFamily` now returns `(family, bool)`; new exported **`pricing.Recognized(model) bool`** reports whether a model maps to a known family (opus/sonnet/haiku) vs falling back to default Sonnet rates.
- The Stop-seam cost loop in `cmd_dispatch.go` emits `core.Logger().Warn("cost: unknown model, using fallback rates", ...)` before computing at fallback rates.
- **Cost math is unchanged** — unknown models still compute at Sonnet rates, exactly as before.

### Design
The pure `pricing` package stays **logger-free** (only imports `strings`). Recognition status crosses the boundary as a `bool`; the caller (`dispatch`, which already has a logger) owns the diagnostic. This keeps the package pure and fully unit-testable.

## Verification (RED→GREEN)

- `TestRecognized` — known IDs (case-insensitive substring) → true; unknown/empty → false.
- `TestRecognized_FallbackStillComputes` — an unknown model computes the **same** USD as an explicit Sonnet model (math preserved).
- **RED**: flipping the fallback flag to `true` fails both tests; **GREEN** after restore. `internal/pricing` + `cmd/hookwise` green under `-race -p 2`.

## ARCH / safety
- The warn is on the **Stop seam only** (once per turn), not the PostToolUse per-tool hot path.
- Fail-open preserved: a warn never blocks; cost still computes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)