### PR TITLE
test(arch): guard that every feed Producer has a non-test caller

### DIFF
--- a/internal/arch/producer_wiring_test.go
+++ b/internal/arch/producer_wiring_test.go
@@ -1,0 +1,121 @@
+package arch
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// producerWiringAllowlist lists feed Producer types that are KNOWN to have no
+// production wiring yet, each tied to a tracking issue. The guard below fails on
+// any *Producer type NOT in this list that is referenced only from its own
+// declaration file and/or _test.go files — its job is to stop NEW unwired
+// producers (a "shareable feed" that never runs) from being added.
+//
+// Entries are added deliberately, never to silence a freshly-introduced dead
+// producer. Each value is the tracking issue for wiring (or removing) it.
+var producerWiringAllowlist = map[string]string{
+	// CustomProducer is constructed via NewCustomProducer, but that constructor
+	// is currently called only from tests — custom feeds appear unwired from the
+	// daemon/config path. Tracked separately; do not remove until wiring is
+	// verified or the surface is removed.
+	"CustomProducer": "#124",
+}
+
+// TestArch_ProducerTypesAreWired enforces the WRITER AUDIT (#99) lesson for the
+// feed platform: a Producer type that is declared but never registered or
+// constructed in production is a dead feature — a "shareable feed" that can
+// never run. Built-in producers are wired via RegisterBuiltins
+// (Register(&XProducer{})); custom producers via NewXProducer(...).
+//
+// The guard walks the module source, finds every `type \w+Producer struct`
+// declaration, and asserts each is referenced from at least one non-test .go
+// file OTHER than its declaration file — via the type itself (`&Name{}`,
+// `*Name`) or its constructor (`NewName(`) — or is explicitly allowlisted with
+// a tracking issue.
+func TestArch_ProducerTypesAreWired(t *testing.T) {
+	root := findModuleRoot(t)
+
+	declRe := regexp.MustCompile(`type (\w+Producer) struct`)
+
+	type decl struct{ file string }
+	declared := map[string]decl{} // producer type -> declaring file (relative)
+
+	// Collected non-test source so we can scan for references in a second pass
+	// without re-reading the tree.
+	type srcFile struct{ rel, text string }
+	var sources []srcFile
+
+	walk := func(collect bool) error {
+		return filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+			if walkErr != nil || info.IsDir() {
+				return nil //nolint:nilerr // best-effort walk; unreadable entries are skipped
+			}
+			if !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			// Skip worktrees and vendored trees.
+			if strings.Contains(path, "/.claude/") || strings.Contains(path, "/vendor/") {
+				return nil
+			}
+			// Tests neither declare production producers nor count as production
+			// wiring.
+			if strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			src, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return nil
+			}
+			text := string(src)
+			rel := strings.TrimPrefix(path, root+"/")
+			for _, m := range declRe.FindAllStringSubmatch(text, -1) {
+				declared[m[1]] = decl{file: rel}
+			}
+			if collect {
+				sources = append(sources, srcFile{rel: rel, text: text})
+			}
+			return nil
+		})
+	}
+
+	if err := walk(true); err != nil {
+		t.Fatalf("walking module source: %v", err)
+	}
+
+	if len(declared) == 0 {
+		t.Fatal("found no Producer declarations — the guard's discovery regex is likely broken")
+	}
+
+	for name, d := range declared {
+		// A producer is wired if some non-test file OTHER than its declaration
+		// file references the type (`\bName\b` matches `&Name{`, `*Name`, etc.)
+		// or its constructor (`\bNewName\b` matches `NewName(...)` call sites but
+		// not the `func NewName(` definition, which lives in the decl file).
+		refRe := regexp.MustCompile(`\b(New)?` + regexp.QuoteMeta(name) + `\b`)
+		wired := false
+		for _, s := range sources {
+			if s.rel == d.file {
+				continue // self-reference in the declaration file does not count
+			}
+			if refRe.MatchString(s.text) {
+				wired = true
+				break
+			}
+		}
+		if wired {
+			continue
+		}
+		if issue, ok := producerWiringAllowlist[name]; ok {
+			t.Logf("known unwired producer %s (declared in %s) allowlisted: %s", name, d.file, issue)
+			continue
+		}
+		t.Errorf("PRODUCER-WIRING violation: %s (declared in %s) has no production "+
+			"registration/constructor caller — a Producer with no production wiring is a "+
+			"dead feed (see #99). Register it in RegisterBuiltins, construct it from the "+
+			"daemon/config path, or add it to producerWiringAllowlist with a tracking issue.",
+			name, d.file)
+	}
+}


### PR DESCRIPTION
## What

Extends the #99 writer-audit lesson — the TS→Go port shipped "readers without writers" — to the **feed platform**. The Write*State half landed in #111 (`writer_wiring_test.go`); this adds the **producer** half the same rule named.

A `Producer` type that is declared but never registered or constructed in production is a **dead feed**: a "shareable feed" that can never run. `TestArch_ProducerTypesAreWired` walks module source, finds every `type \w+Producer struct`, and asserts each is referenced from a non-test `.go` file **other than its declaration file** — via the type (`&Name{}`, `*Name`) or its constructor (`NewName(`) — or is allowlisted with a tracking issue.

## Real gap surfaced

`NewCustomProducer` is called **only from `feeds_test.go`** — custom feeds appear unwired from the daemon/config path. Filed as **#124** and allowlisted (daemon wiring is supervised and out of scope here). The 6 built-ins (Project/News/Calendar/Weather/Memories/Insights) all pass — they're registered in `RegisterBuiltins`.

## Verification (RED→GREEN)

- **GREEN**: 6 builtins pass; `CustomProducer` allowlisted to #124.
- **RED**: removing the allowlist entry → `CustomProducer` flagged with the `PRODUCER-WIRING violation` message. Restored → green. `-race -p 2`.

## Design notes

- **Test-only** file in `internal/arch/` — zero production code, zero hot-path/daemon risk. Mirrors `writer_wiring_test.go` structure + allowlist-with-issue convention.
- The reference regex `\b(New)?Name\b` matches `&Name{`/`*Name` and `NewName(` **call sites**, but the decl file is excluded so the `func NewName(` definition can't self-satisfy the guard (which would mask a constructor that's only test-called — exactly the CustomProducer case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)