### PR TITLE
fix(status-line): derive project segment live per session (#126)

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -478,16 +478,20 @@ func TestStatusLineWithFeedCache(t *testing.T) {
 	}
 	writeJSONFile(t, filepath.Join(cacheDir, "weather.json"), weatherEnvelope)
 
-	// Write project feed cache with real data.
+	// Write a STALE project feed cache from a different repo. The status line
+	// must IGNORE this and derive project live from the cwd (#126).
 	projectEnvelope := map[string]interface{}{
 		"type":      "project",
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
 		"data": map[string]interface{}{
-			"name":   "hookwise",
-			"branch": "main",
+			"name":   "some-other-repo",
+			"branch": "stale-branch",
 		},
 	}
 	writeJSONFile(t, filepath.Join(cacheDir, "project.json"), projectEnvelope)
+
+	// Make the cwd (tmpDir) a real git repo so the live project segment renders.
+	gitInitRepoAt(t, tmpDir, "live-branch")
 
 	configYAML := `version: 1
 status_line:
@@ -514,12 +518,12 @@ status_line:
 		t.Errorf("weather segment should show description 'Clear', got: %s", stripped)
 	}
 
-	// Project should show name and branch from cache.
-	if !strings.Contains(stripped, "hookwise") {
-		t.Errorf("project segment should show project name, got: %s", stripped)
+	// Project should show the LIVE cwd repo's branch, not the stale cached one.
+	if !strings.Contains(stripped, "(live-branch)") {
+		t.Errorf("project segment should show the live branch, got: %s", stripped)
 	}
-	if !strings.Contains(stripped, "(main)") {
-		t.Errorf("project segment should show branch, got: %s", stripped)
+	if strings.Contains(stripped, "some-other-repo") || strings.Contains(stripped, "stale-branch") {
+		t.Errorf("project segment must not show the stale cached repo/branch, got: %s", stripped)
 	}
 }
 

--- a/cmd/hookwise/cmd_status_line.go
+++ b/cmd/hookwise/cmd_status_line.go
@@ -17,8 +17,29 @@ import (
 	"github.com/vishnujayvel/hookwise/internal/analytics"
 	"github.com/vishnujayvel/hookwise/internal/bridge"
 	"github.com/vishnujayvel/hookwise/internal/core"
+	"github.com/vishnujayvel/hookwise/internal/feeds"
 	"github.com/vishnujayvel/hookwise/internal/notifications"
 )
+
+// projectInfoTimeout bounds the git calls used to derive the live project
+// segment so a slow/locked repo can never hang the status line.
+const projectInfoTimeout = 2 * time.Second
+
+// overlayLiveProject overwrites the cached "project" feed envelope with data
+// derived live from projectDir. The project segment (repo name + branch) is a
+// pure function of the session's directory, but the shared daemon cache holds
+// whichever repo the daemon last polled — so a new session in a different repo
+// would render that other repo's name/branch (#126). Deriving it live makes the
+// segment correct per-session regardless of cache state.
+func overlayLiveProject(feedCache map[string]interface{}, projectDir string) map[string]interface{} {
+	if feedCache == nil {
+		feedCache = map[string]interface{}{}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), projectInfoTimeout)
+	defer cancel()
+	feedCache["project"] = feeds.NewEnvelope("project", feeds.ProjectInfo(ctx, projectDir))
+	return feedCache
+}
 
 func newStatusLineCmd() *cobra.Command {
 	var projectDir string
@@ -64,6 +85,12 @@ func runStatusLine(cmd *cobra.Command, projectDir string) error {
 	// Use GetStateDir() to respect HOOKWISE_STATE_DIR env override.
 	cacheDir := filepath.Join(core.GetStateDir(), "state")
 	feedCache, _ := bridge.CollectFeedCache(cacheDir)
+
+	// The project segment (repo/branch) is session-specific. The shared daemon
+	// cache holds whichever repo the daemon last polled, so reading it shows a
+	// different session's repo/branch (#126). Overlay it with data derived live
+	// from THIS invocation's directory.
+	feedCache = overlayLiveProject(feedCache, projectDir)
 
 	// Load today's daily summary from the analytics DB for session/cost segments.
 	// Fail-open: nil summary → segments fall back to "--".
@@ -364,9 +391,11 @@ func renderProjectSegment(feedCache map[string]interface{}) string {
 		return ""
 	}
 
-	name := "project"
-	if n, ok := data["name"].(string); ok && n != "" {
-		name = n
+	// Omit the segment when there is no real project (e.g. the directory is not
+	// a git repo) rather than showing a meaningless generic "project" label.
+	name, _ := data["name"].(string)
+	if name == "" {
+		return ""
 	}
 
 	branch := ""

--- a/cmd/hookwise/cmd_status_line_project_test.go
+++ b/cmd/hookwise/cmd_status_line_project_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vishnujayvel/hookwise/internal/feeds"
+)
+
+// initStatusTestRepo creates a temp git repo with one commit on the given branch.
+func initStatusTestRepo(t *testing.T, branch string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "hookwise-sl-proj-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	gitInitRepoAt(t, dir, branch)
+	return dir
+}
+
+// gitInitRepoAt initialises a git repo with one commit on `branch` in `dir`.
+// Shared with cli_test.go so status-line tests can make their cwd a real repo.
+func gitInitRepoAt(t *testing.T, dir, branch string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, gerr := cmd.CombinedOutput()
+		require.NoError(t, gerr, "git %v: %s", args, out)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("x"), 0o600))
+	for _, args := range [][]string{
+		{"add", "."},
+		{"commit", "-q", "-m", "init"},
+		{"checkout", "-q", "-b", branch},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, gerr := cmd.CombinedOutput()
+		require.NoError(t, gerr, "git %v: %s", args, out)
+	}
+}
+
+// TestOverlayLiveProject_OverwritesStaleCache reproduces #126: the shared daemon
+// cache holds another session's repo, but the rendered project segment must show
+// THIS directory's repo/branch, not the stale cached one.
+func TestOverlayLiveProject_OverwritesStaleCache(t *testing.T) {
+	repo := initStatusTestRepo(t, "live-branch")
+
+	// Simulate a fresh-but-wrong daemon cache entry from a different repo.
+	staleCache := map[string]interface{}{
+		"project": feeds.NewEnvelope("project", map[string]interface{}{
+			"name":   "some-other-repo",
+			"branch": "stale-branch",
+		}),
+	}
+
+	out := overlayLiveProject(staleCache, repo)
+	seg := renderProjectSegment(out)
+
+	assert.Contains(t, seg, filepath.Base(repo), "should show this repo's name")
+	assert.Contains(t, seg, "live-branch", "should show this repo's branch")
+	assert.NotContains(t, seg, "some-other-repo", "must not show the stale cached repo")
+	assert.NotContains(t, seg, "stale-branch", "must not show the stale cached branch")
+}
+
+// TestOverlayLiveProject_NilCache verifies the helper tolerates a nil cache
+// (CollectFeedCache can return nil) and still renders live project data.
+func TestOverlayLiveProject_NilCache(t *testing.T) {
+	repo := initStatusTestRepo(t, "dev-trunk")
+
+	out := overlayLiveProject(nil, repo)
+	require.NotNil(t, out)
+
+	seg := renderProjectSegment(out)
+	assert.Contains(t, seg, filepath.Base(repo))
+}

--- a/internal/feeds/producer_project.go
+++ b/internal/feeds/producer_project.go
@@ -31,44 +31,52 @@ func (p *ProjectProducer) SetFeedsConfig(cfg core.FeedsConfig) {
 func (p *ProjectProducer) Produce(ctx context.Context) (interface{}, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return p.fallbackResult()
+		return NewEnvelope("project", emptyProjectInfo()), nil
 	}
-
-	// Detect git repo root.
-	repoRoot, err := p.runGit(ctx, cwd, "rev-parse", "--show-toplevel")
-	if err != nil {
-		// Not a git repo or git not installed — fail-open (ARCH-1).
-		return p.fallbackResult()
-	}
-
-	repoName := filepath.Base(repoRoot)
-
-	// Get current branch.
-	branchName, err := p.runGit(ctx, cwd, "rev-parse", "--abbrev-ref", "HEAD")
-	if err != nil {
-		branchName = ""
-	}
-
-	// Get short commit hash.
-	commitHash, err := p.runGit(ctx, cwd, "rev-parse", "--short", "HEAD")
-	if err != nil {
-		commitHash = ""
-	}
-
-	// Detect dirty state.
-	porcelain, err := p.runGit(ctx, cwd, "status", "--porcelain")
-	isDirty := err == nil && porcelain != ""
-
-	return NewEnvelope("project", map[string]interface{}{
-		"name":        repoName,
-		"branch":      branchName,
-		"last_commit": commitHash,
-		"dirty":       isDirty,
-	}), nil
+	return NewEnvelope("project", ProjectInfo(ctx, cwd)), nil
 }
 
-// runGit executes a git command in the given directory and returns trimmed stdout.
-func (p *ProjectProducer) runGit(ctx context.Context, dir string, args ...string) (string, error) {
+// ProjectInfo derives git project metadata (name/branch/last_commit/dirty) for
+// the given directory. It is a PURE function of `dir` — it does NOT call
+// os.Getwd — so a caller that knows its own working directory gets data for
+// THAT directory.
+//
+// This matters for the status line: project/branch is session-specific, but the
+// shared daemon feed cache holds whichever repo the daemon last polled. Rendering
+// from the cache showed a different session's repo/branch (#126). The status line
+// calls ProjectInfo with its own cwd instead.
+//
+// Fail-open (ARCH-1): a non-repo or missing git yields empty fields, never an error.
+func ProjectInfo(ctx context.Context, dir string) map[string]interface{} {
+	repoRoot, err := gitOutput(ctx, dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return emptyProjectInfo()
+	}
+
+	branch, _ := gitOutput(ctx, dir, "rev-parse", "--abbrev-ref", "HEAD")
+	commit, _ := gitOutput(ctx, dir, "rev-parse", "--short", "HEAD")
+	porcelain, perr := gitOutput(ctx, dir, "status", "--porcelain")
+
+	return map[string]interface{}{
+		"name":        filepath.Base(repoRoot),
+		"branch":      branch,
+		"last_commit": commit,
+		"dirty":       perr == nil && porcelain != "",
+	}
+}
+
+// emptyProjectInfo returns the zero-value project data (ARCH-1 fail-open shape).
+func emptyProjectInfo() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "",
+		"branch":      "",
+		"last_commit": "",
+		"dirty":       false,
+	}
+}
+
+// gitOutput executes a git command in the given directory and returns trimmed stdout.
+func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	out, err := cmd.Output()
@@ -76,16 +84,6 @@ func (p *ProjectProducer) runGit(ctx context.Context, dir string, args ...string
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
-}
-
-// fallbackResult returns a valid envelope with empty fields when git is unavailable (ARCH-1: fail-open).
-func (p *ProjectProducer) fallbackResult() (map[string]interface{}, error) {
-	return NewEnvelope("project", map[string]interface{}{
-		"name":        "",
-		"branch":      "",
-		"last_commit": "",
-		"dirty":       false,
-	}), nil
 }
 
 // ProjectTestFixture returns a deterministic project envelope for use in

--- a/internal/feeds/producer_project_test.go
+++ b/internal/feeds/producer_project_test.go
@@ -1,0 +1,72 @@
+package feeds
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initProjectTestRepo creates a temp git repo with one commit on the given
+// branch and returns its directory.
+func initProjectTestRepo(t *testing.T, branch string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "hookwise-proj-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	runGitT(t, dir, "init", "-q")
+	runGitT(t, dir, "config", "user.email", "test@example.com")
+	runGitT(t, dir, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("x"), 0o600))
+	runGitT(t, dir, "add", ".")
+	runGitT(t, dir, "commit", "-q", "-m", "init")
+	runGitT(t, dir, "checkout", "-q", "-b", branch)
+	return dir
+}
+
+func runGitT(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+}
+
+// TestProjectInfo_DerivesFromGivenDir is the core of #126: ProjectInfo is a pure
+// function of its `dir` argument, so two different repos queried in the SAME
+// process yield each repo's own name/branch with no shared/cached contamination.
+func TestProjectInfo_DerivesFromGivenDir(t *testing.T) {
+	ctx := context.Background()
+	repoA := initProjectTestRepo(t, "feature-a")
+	repoB := initProjectTestRepo(t, "release-b")
+
+	a := ProjectInfo(ctx, repoA)
+	assert.Equal(t, filepath.Base(repoA), a["name"])
+	assert.Equal(t, "feature-a", a["branch"])
+
+	b := ProjectInfo(ctx, repoB)
+	assert.Equal(t, filepath.Base(repoB), b["name"])
+	assert.Equal(t, "release-b", b["branch"])
+
+	// Same process, different dirs → different results (no global state).
+	assert.NotEqual(t, a["name"], b["name"])
+	assert.NotEqual(t, a["branch"], b["branch"])
+}
+
+// TestProjectInfo_NonRepoFailsOpen verifies ARCH-1: a non-repo directory yields
+// empty fields, never an error or panic.
+func TestProjectInfo_NonRepoFailsOpen(t *testing.T) {
+	dir, err := os.MkdirTemp("", "hookwise-nonrepo-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	info := ProjectInfo(context.Background(), dir)
+	assert.Equal(t, "", info["name"])
+	assert.Equal(t, "", info["branch"])
+	assert.Equal(t, false, info["dirty"])
+}


### PR DESCRIPTION
## Problem

Starting a new Claude Code session in a **different repo** showed the WRONG
repo name and branch in the status line.

Root cause: the project/branch feed is **session-specific**, but the daemon is a
singleton that polls producers from *its own* cwd and writes a single global
`~/.hookwise/state/project.json`. Every session's status line read that one
global cache → whichever repo the daemon last polled. (Genuinely-global feeds
like calendar/weather are fine to share; the project feed is not.)

## Fix

- Extract `feeds.ProjectInfo(ctx, dir)` — a **pure** function of `dir` (no
  `os.Getwd`), so a caller that knows its cwd gets data for THAT dir.
- `cmd_status_line.go` calls `overlayLiveProject(feedCache, projectDir)` after
  `CollectFeedCache`, overwriting the stale global `project` envelope with a
  live one derived from the session's own `projectDir` (2s timeout, fail-open).
- `renderProjectSegment` omits the segment on empty name (not a real repo)
  instead of defaulting to a "project" label.

Fail-open (ARCH-1): a non-repo or missing git yields empty fields, never an error.

## Tests

- `TestProjectInfo_DerivesFromGivenDir` — two repos on different branches in the
  SAME process yield each repo's own name/branch (no shared/cached contamination).
- `TestProjectInfo_NonRepoFailsOpen` — ARCH-1 fail-open shape.
- `TestOverlayLiveProject_OverwritesStaleCache` — reproduces #126: a fresh-but-wrong
  daemon cache entry is overwritten by THIS dir's live repo/branch.
- `TestOverlayLiveProject_NilCache` — tolerates a nil cache.
- Updated `TestStatusLineWithFeedCache` / `TestStatusLineWithMissingCache` to the
  intended per-session behavior.

RED→GREEN verified: a no-op overlay rendered `some-other-repo (stale-branch)`,
reproducing the exact symptom; the real overlay shows the live branch.

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)