### PR TITLE
fix(status-line): remove the session-count segment (#129)

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -441,14 +441,14 @@ func TestRenderBuiltinSegments(t *testing.T) {
 }
 
 // TestSessionSegmentRemoved verifies the daily-session-count "session" segment
-// is gone (#129): even with a non-zero TotalSessions, it must not render the
-// "session: N" count. The count was a daily aggregate, not per-session info,
-// and was confusing/low-value in the status line.
+// is gone (#129): even with a non-zero TotalSessions, it must render NOTHING —
+// not the count, and not the gray unknown-segment fallback. A config carried
+// over from before the removal must not surface a dead "session" label.
 func TestSessionSegmentRemoved(t *testing.T) {
 	summary := &analytics.DailySummaryResult{TotalSessions: 5}
-	result := stripANSI(renderBuiltinSegment("session", map[string]interface{}{}, summary))
-	if strings.Contains(result, "session:") {
-		t.Errorf("session segment must no longer render a count, got: %q", result)
+	result := renderBuiltinSegment("session", map[string]interface{}{}, summary)
+	if result != "" {
+		t.Errorf("removed session segment must render empty, got: %q", stripANSI(result))
 	}
 }
 

--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -263,8 +263,8 @@ func TestStatusLineEnabled(t *testing.T) {
 status_line:
   enabled: true
   segments:
-    - builtin: session
     - builtin: cost
+    - builtin: project
 `
 	configPath := filepath.Join(tmpDir, core.ProjectConfigFile)
 	os.WriteFile(configPath, []byte(configYAML), 0o644)
@@ -425,7 +425,7 @@ func TestRenderBuiltinSegments(t *testing.T) {
 	emptyCache := map[string]interface{}{}
 
 	// Segments with no data should return empty (omitted from output).
-	noDataSegments := []string{"session", "cost", "project", "calendar", "weather"}
+	noDataSegments := []string{"cost", "project", "calendar", "weather"}
 	for _, name := range noDataSegments {
 		result := renderBuiltinSegment(name, emptyCache, nil)
 		if result != "" {
@@ -437,6 +437,18 @@ func TestRenderBuiltinSegments(t *testing.T) {
 	unknown := renderBuiltinSegment("unknown_segment", emptyCache, nil)
 	if unknown == "" {
 		t.Error("unknown builtin segment should still render")
+	}
+}
+
+// TestSessionSegmentRemoved verifies the daily-session-count "session" segment
+// is gone (#129): even with a non-zero TotalSessions, it must not render the
+// "session: N" count. The count was a daily aggregate, not per-session info,
+// and was confusing/low-value in the status line.
+func TestSessionSegmentRemoved(t *testing.T) {
+	summary := &analytics.DailySummaryResult{TotalSessions: 5}
+	result := stripANSI(renderBuiltinSegment("session", map[string]interface{}{}, summary))
+	if strings.Contains(result, "session:") {
+		t.Errorf("session segment must no longer render a count, got: %q", result)
 	}
 }
 
@@ -930,26 +942,6 @@ func TestStatusLinePlaceholderFallback(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// 21. Session segment with daily summary
-// ---------------------------------------------------------------------------
-
-func TestStatusLineSessionSegment(t *testing.T) {
-	summary := &analytics.DailySummaryResult{TotalSessions: 3}
-	result := renderBuiltinSegment("session", nil, summary)
-	stripped := stripANSI(result)
-	if !strings.Contains(stripped, "session: 3") {
-		t.Errorf("session segment should show count, got: %s", stripped)
-	}
-}
-
-func TestStatusLineSessionSegmentNoSummary(t *testing.T) {
-	result := renderBuiltinSegment("session", nil, nil)
-	if result != "" {
-		t.Errorf("session segment without summary should return empty, got: %s", stripANSI(result))
-	}
-}
-
-// ---------------------------------------------------------------------------
 // 22. Cost segment with daily summary
 // ---------------------------------------------------------------------------
 
@@ -1309,7 +1301,6 @@ func TestStatusLineMultiLine(t *testing.T) {
 status_line:
   enabled: true
   segments:
-    - session
     - cost
 `
 	configPath := filepath.Join(tmpDir, core.ProjectConfigFile)
@@ -1513,7 +1504,6 @@ func TestDoctorFeedHealthSegmentCoverage(t *testing.T) {
 status_line:
   enabled: true
   segments:
-    - session
     - weather
     - project
     - calendar

--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -314,8 +314,8 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 			if name == "" {
 				continue
 			}
-			// session and cost are computed from analytics, not feed-backed.
-			if name == "session" || name == "cost" {
+			// cost is computed from analytics, not feed-backed.
+			if name == "cost" {
 				continue
 			}
 			feedSegments++

--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -314,6 +314,11 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 			if name == "" {
 				continue
 			}
+			// Removed builtins (e.g. session, #129) are not feed-backed — a stray
+			// config entry must not produce a misleading "feed:<name>" warning.
+			if _, removed := removedSegments[name]; removed {
+				continue
+			}
 			// cost is computed from analytics, not feed-backed.
 			if name == "cost" {
 				continue

--- a/cmd/hookwise/cmd_status_line.go
+++ b/cmd/hookwise/cmd_status_line.go
@@ -230,9 +230,20 @@ func renderSegment(seg core.SegmentConfig, feedCache map[string]interface{}, sum
 	return ""
 }
 
+// removedSegments are builtins that used to exist but were deliberately removed.
+// They render nothing — NOT the gray unknown-segment fallback below — so a config
+// carried over from before the removal doesn't surface a dead label.
+//   - "session": daily session-count segment, removed in #129.
+var removedSegments = map[string]string{
+	"session": "#129",
+}
+
 // renderBuiltinSegment renders a known builtin segment by name, reading
 // real data from the feed cache and analytics DB daily summary when available.
 func renderBuiltinSegment(name string, feedCache map[string]interface{}, summary *analytics.DailySummaryResult) string {
+	if _, removed := removedSegments[name]; removed {
+		return ""
+	}
 	switch name {
 	case "cost":
 		if summary != nil && summary.EstimatedCostUSD > 0 {

--- a/cmd/hookwise/cmd_status_line.go
+++ b/cmd/hookwise/cmd_status_line.go
@@ -92,8 +92,8 @@ func runStatusLine(cmd *cobra.Command, projectDir string) error {
 	// from THIS invocation's directory.
 	feedCache = overlayLiveProject(feedCache, projectDir)
 
-	// Load today's daily summary from the analytics DB for session/cost segments.
-	// Fail-open: nil summary → segments fall back to "--".
+	// Load today's daily summary from the analytics DB for the cost segment.
+	// Fail-open: nil summary → the segment is omitted.
 	var dailySummary *analytics.DailySummaryResult
 	if db, err := analytics.Open(config.Analytics.DBPath); err == nil {
 		defer db.Close()
@@ -234,11 +234,6 @@ func renderSegment(seg core.SegmentConfig, feedCache map[string]interface{}, sum
 // real data from the feed cache and analytics DB daily summary when available.
 func renderBuiltinSegment(name string, feedCache map[string]interface{}, summary *analytics.DailySummaryResult) string {
 	switch name {
-	case "session":
-		if summary != nil && summary.TotalSessions > 0 {
-			return ansiBold + ansiGreen + fmt.Sprintf("session: %d", summary.TotalSessions) + ansiReset
-		}
-		return "" // No data — omit segment instead of showing "--"
 	case "cost":
 		if summary != nil && summary.EstimatedCostUSD > 0 {
 			return ansiYellow + fmt.Sprintf("cost: $%.2f", summary.EstimatedCostUSD) + ansiReset

--- a/docs/features/status-line.md
+++ b/docs/features/status-line.md
@@ -13,7 +13,6 @@
 | Segment | Shows |
 |---------|-------|
 | `clock` | Current time |
-| `session` | Duration + tool count |
 | `cost` | Session cost estimate |
 | `builder_trap` | Alert level + nudge message |
 | `mantra` | Rotating motivational prompt |
@@ -60,7 +59,6 @@
 status_line:
   enabled: true
   segments:
-    - session
     - builder_trap
     - cost
     - project

--- a/examples/analytics.yaml
+++ b/examples/analytics.yaml
@@ -42,4 +42,3 @@ status_line:
   enabled: true
   segments:
     - ai_ratio   # AI vs human authorship percentage
-    - session    # session duration and tool call count

--- a/examples/coaching.yaml
+++ b/examples/coaching.yaml
@@ -55,5 +55,4 @@ coaching:
 status_line:
   enabled: true
   segments:
-    - session        # session duration
     - builder_trap   # builder trap status indicator

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -88,7 +88,6 @@ status_line:
   enabled: true
   segments:
     - ai_ratio       # AI vs human authorship percentage
-    - session        # session duration and tool call count
     - builder_trap   # builder trap status indicator
     - cost           # current cost vs daily budget
 

--- a/hookwise.yaml
+++ b/hookwise.yaml
@@ -21,7 +21,6 @@ feeds:
 status_line:
   enabled: true
   segments:
-    - session
     - cost
     - weather
     - project


### PR DESCRIPTION
## Problem

The status-line `session` segment rendered `session: N` where N = `TotalSessions`
— a **daily count of sessions** from the analytics DB, not "this session" info.
Confusing and low-value, so remove it entirely (user request).

## Changes (Go status line — the surface users see)

- Drop `case "session"` from `renderBuiltinSegment` (`cmd_status_line.go`).
- Drop the `"session"` half of the doctor analytics-skip special-case (keep `cost`).
- Remove `- session` from committed example configs (`analytics`/`coaching`/`full.yaml`),
  the tracked `hookwise.yaml`, and `docs/features/status-line.md`.
- Tests: delete the two obsolete session-segment tests, drop `session` from
  `noDataSegments`, fix the doctor coverage test (3 feed segments → `1/3`), and add
  `TestSessionSegmentRemoved` (asserts no `session:` count even with `TotalSessions=5`).

## Decisions

- **Kept `analytics.TotalSessions`** — it's a generic DB metric still printed by
  `hookwise stats` ("Sessions: N", `cmd_stats.go:73`). It is *not* the segment;
  removing it would break `stats`. Verified the only segment-side reader was the
  removed `case`.
- **TUI session-ID indicator deferred** to a follow-up PR. The TUI's `session`
  segment shows a session *ID / active indicator* (different from the count), lives
  in a separate Python surface with snapshot-regen risk. Scoped out to keep this
  change small and safe. Still tracked under #129.

## Verification

TDD RED→GREEN: RED reproduced `session: 5`; after removal the count is gone.
Full guarded gate green (`GOMEMLIMIT=4GiB task test:go:unit`) + `cmd/hookwise`
status-line/doctor tests green. No contract fixtures render status-line segments,
so ARCH-6 is unaffected.

> Note: `internal/feeds.TestDaemon_ConcurrentStartOnlyOneWins` flaked once
> (socket race) then passed 3/3 in isolation — pre-existing, unrelated to this
> change (feeds untouched).

Closes #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Feature Changes**
  * Removed the `session` segment from the status line display; session information will no longer appear in configured status lines.

* **Documentation**
  * Updated configuration examples and documentation to reflect the removal of the `session` segment from available status line segments.

* **Tests**
  * Updated test suite to verify the `session` segment no longer renders in the status line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->