### PR TITLE
build: add local commitlint commit-msg pre-commit hook (#83)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,17 @@
 # Optional local pre-commit hooks — the first line of the secret-scanning
-# defense-in-depth chain (pre-commit → GitHub push protection → CI gate).
+# defense-in-depth chain (pre-commit → GitHub push protection → CI gate),
+# plus a local commit-message guard mirroring the CI commitlint gate.
 #
 # Opt in once per clone:
 #   pipx install pre-commit   # or: brew install pre-commit
-#   pre-commit install
+#   pre-commit install                        # gitleaks on staged changes
+#   pre-commit install --hook-type commit-msg # commitlint on the message
 #
 # Thereafter `git commit` scans staged changes with gitleaks before the commit
-# is created, so a secret never reaches local git history.
+# is created (so a secret never reaches local git history), and validates the
+# commit message against .commitlintrc.yml (conventional type + header ≤72)
+# before push — catching what the CI commitlint gate would otherwise reject
+# only after a push + CI round-trip.
 
 repos:
   - repo: https://github.com/gitleaks/gitleaks
@@ -14,3 +19,10 @@ repos:
     hooks:
       - id: gitleaks
         args: ["--config", ".gitleaks.toml"]
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.25.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]


### PR DESCRIPTION
## What

Adds a local `commitlint` pre-commit hook (`commit-msg` stage) that mirrors the CI commitlint gate, so a non-conventional or over-length commit subject is caught at `git commit` time instead of only after a push + CI round-trip.

- `.pre-commit-config.yaml`: adds `alessandrojcm/commitlint-pre-commit-hook` (rev `v9.25.0`), `stages: [commit-msg]`, with `additional_dependencies: ["@commitlint/config-conventional"]`.
- Header comment updated to document the opt-in: `pre-commit install --hook-type commit-msg`.

Config-only change. No Go code, no hot-path/daemon risk. Opt-in per clone.

## Verification (clean clone, no `core.hooksPath` override)

Verified in a fresh `git clone` (confirming a real clone does NOT inherit the source repo's local `core.hooksPath`) with both hooks installed. All three #83 acceptance cases passed:

- valid `feat:` subject → **committed** ✓
- 112-char subject → **rejected** (`header-max-length`, "current length is 112") ✓
- `banana:` type → **rejected** (`type-enum`) ✓

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented commit message validation to enforce consistent messaging standards.
  * Enhanced documentation for development workflow enforcement mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->