### PR TITLE
fix(upgrade): respect config analytics.db_path, not default DB (#109)

### DIFF
--- a/cmd/hookwise/cmd_upgrade.go
+++ b/cmd/hookwise/cmd_upgrade.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/vishnujayvel/hookwise/internal/core"
 	"github.com/vishnujayvel/hookwise/internal/migration"
 )
 
@@ -33,9 +34,20 @@ Original files are never modified (non-destructive).`,
 				}
 			}
 
+			// Resolve the analytics DB path the way the writer (dispatch) and
+			// other readers (stats/doctor) do, so upgrade imports into the SAME
+			// DB they use. Without this, a custom analytics.db_path is ignored
+			// and migrated data lands in the default DB that dispatch never
+			// touches -- leaving `hookwise stats` at $0 after upgrade (#109).
+			// ARCH-1: never hard-fail on a missing/broken config.
+			config, err := core.LoadConfig(projectDir)
+			if err != nil {
+				config = core.GetDefaultConfig()
+			}
+
 			result := migration.Run(migration.MigrationOpts{
 				DryRun:      dryRun,
-				DoltDataDir: dataDir,
+				DoltDataDir: resolveAnalyticsDBPath(dataDir, config),
 				ProjectDir:  projectDir,
 				Writer:      cmd.OutOrStdout(),
 			})

--- a/cmd/hookwise/cmd_upgrade_test.go
+++ b/cmd/hookwise/cmd_upgrade_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/analytics"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// TestRunUpgrade_ImportsIntoConfigDBPath is the #109 regression test: when a
+// project config sets a custom analytics.db_path, `hookwise upgrade` (with no
+// --data-dir flag) must import the legacy data into THAT database -- the same
+// one `dispatch` writes to and `stats` reads from -- not the default
+// ~/.hookwise/analytics.db.
+//
+// Before the fix, upgrade passed the empty --data-dir flag straight through to
+// migration.Run, which fell back to analytics.DefaultDBPath(). A user with a
+// custom db_path would migrate their data into a DB that dispatch/stats never
+// touch, so `hookwise stats` kept showing $0 after a "successful" upgrade.
+//
+// Hermetic: HOME is pinned to a temp dir so both the legacy-source detection
+// (~/.hookwise/state/cost-state.json) and the buggy default-target fallback
+// (~/.hookwise/analytics.db) resolve inside the temp dir, never touching the
+// real ~/.hookwise.
+func TestRunUpgrade_ImportsIntoConfigDBPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	// HomeDir() resolves from $HOME; pinning it isolates DefaultDBPath() and the
+	// legacy-source location so this test cannot read or write real state.
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise-state"))
+
+	// A legacy cost-state.json makes DetectTypeScript find a source so migration
+	// actually opens the target DB (it short-circuits before opening when no
+	// source is detected). No legacy analytics.db => the default target path is
+	// not pre-created, keeping the assertion below a clean discriminator.
+	legacyStateDir := filepath.Join(tmpDir, ".hookwise", "state")
+	require.NoError(t, os.MkdirAll(legacyStateDir, 0o700))
+	costJSON := `{"dailyCosts":{"2025-03-06":1.5},"sessionCosts":{"sess-x":1.5},"today":"2025-03-06","totalToday":1.5}`
+	require.NoError(t, os.WriteFile(filepath.Join(legacyStateDir, "cost-state.json"), []byte(costJSON), 0o644))
+
+	// Project config points analytics at a custom DB path (distinct directory).
+	customDB := filepath.Join(tmpDir, "custom", "analytics.db")
+	projectDir := filepath.Join(tmpDir, "project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	cfgYAML := "version: 1\nanalytics:\n  enabled: true\n  db_path: " + customDB + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, core.ProjectConfigFile), []byte(cfgYAML), 0o644))
+
+	// Run `upgrade` against the project, with NO --data-dir flag.
+	cmd := newUpgradeCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"--project-dir", projectDir})
+	require.NoError(t, cmd.Execute(), "upgrade output:\n%s", buf.String())
+
+	// The migrated DB must land at the config path, not the default.
+	assert.FileExists(t, customDB,
+		"upgrade must import into the config's analytics.db_path, not the default DB")
+	assert.NoFileExists(t, analytics.DefaultDBPath(),
+		"upgrade must NOT create/import into the default DB when a custom db_path is configured")
+}


### PR DESCRIPTION
## What

`hookwise upgrade` ignored a configured `analytics.db_path` and imported legacy data into the **default** DB (`~/.hookwise/analytics.db`) — the last remaining instance of the #109 reader/writer path-divergence class.

It passed the raw `--data-dir` flag (empty by default) into `migration.Run`, which falls back to `analytics.DefaultDBPath()`. But `dispatch` writes to `config.Analytics.DBPath`, and `stats`/`doctor` read from it. So a user with a custom `analytics.db_path` would run `upgrade`, see "success", and still get **$0** from `hookwise stats` because the migrated data landed in a DB nothing else touches.

## Fix

Resolve the DB path through the shared `resolveAnalyticsDBPath(flag, config)` helper (added in #107 for `stats`), so `upgrade` imports into the **same** DB the writer uses. Fail-open on a missing/broken config per ARCH-1.

```go
config, err := core.LoadConfig(projectDir)
if err != nil { config = core.GetDefaultConfig() }
... DoltDataDir: resolveAnalyticsDBPath(dataDir, config) ...
```

## Test (TDD red→green)

New `TestRunUpgrade_ImportsIntoConfigDBPath` (hermetic — pins `$HOME` to a temp dir so it never touches real `~/.hookwise`):
- **RED** (pre-fix): custom DB absent, default DB created — both assertions failed for the right reason.
- **GREEN**: migration lands at the config's `db_path`; the default DB is never created.

Uses a minimal legacy `cost-state.json` as the migration source (so `migration.Run` doesn't short-circuit before opening the target DB) and no legacy `analytics.db` (so the default-target path stays a clean discriminator).

## Verification
- `go build ./...` ✓, `go vet ./cmd/hookwise/` ✓
- full `cmd/hookwise` package green under `-race -p 2`, 0 zombie test procs
- change confined to `cmd/hookwise` (migration package unchanged)

Closes #109