### PR TITLE
fix(status-line): countdown not "tomorrow" for imminent events (#135)

### DIFF
--- a/cmd/hookwise/cmd_status_line.go
+++ b/cmd/hookwise/cmd_status_line.go
@@ -482,7 +482,12 @@ func calendarRelativeTime(now, eventStart time.Time) string {
 	eventDate := time.Date(eventStart.Year(), eventStart.Month(), eventStart.Day(), 0, 0, 0, 0, eventStart.Location())
 	dayDiff := int(eventDate.Sub(nowDate).Hours() / 24)
 
-	if dayDiff == 0 {
+	// Same calendar day, or imminent enough that a countdown beats a clock time
+	// even across midnight: show "in Xh[ Ym]". Without the diff guard a
+	// late-night event a couple of hours away (e.g. 23:00 -> 01:30) crosses the
+	// calendar-day boundary and mislabels as "tomorrow 1:30am" instead of the
+	// far more useful "in 2h 30m".
+	if dayDiff == 0 || diff < 6*time.Hour {
 		hours := totalMinutes / 60
 		minutes := totalMinutes % 60
 		if minutes < 5 {

--- a/cmd/hookwise/cmd_status_line_calendar_test.go
+++ b/cmd/hookwise/cmd_status_line_calendar_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCalendarRelativeTime covers the relative-time labelling for calendar
+// events, including the midnight-crossing regression: an imminent event a few
+// hours away that happens to fall on the next calendar day must read as a
+// countdown ("in 2h 30m"), not "tomorrow 1:30am". The day-based labels
+// ("tomorrow"/weekday) are reserved for events that are genuinely far out.
+func TestCalendarRelativeTime(t *testing.T) {
+	utc := time.UTC
+	at := func(y int, mo time.Month, d, h, mi int) time.Time {
+		return time.Date(y, mo, d, h, mi, 0, 0, utc)
+	}
+
+	tests := []struct {
+		name  string
+		now   time.Time
+		event time.Time
+		want  string
+	}{
+		{
+			name:  "imminent under a minute is now",
+			now:   at(2026, 6, 15, 10, 0),
+			event: at(2026, 6, 15, 10, 0),
+			want:  "now",
+		},
+		{
+			name:  "under an hour shows minutes",
+			now:   at(2026, 6, 15, 10, 0),
+			event: at(2026, 6, 15, 10, 30),
+			want:  "in 30m",
+		},
+		{
+			name:  "same day a few hours shows hours and minutes",
+			now:   at(2026, 6, 15, 10, 0),
+			event: at(2026, 6, 15, 13, 30),
+			want:  "in 3h 30m",
+		},
+		{
+			name:  "same day exact hour omits minutes",
+			now:   at(2026, 6, 15, 10, 0),
+			event: at(2026, 6, 15, 13, 0),
+			want:  "in 3h",
+		},
+		{
+			// Regression: 2h30m away but crosses midnight -> must be a countdown.
+			name:  "imminent crossing midnight is a countdown not tomorrow",
+			now:   at(2026, 6, 15, 23, 0),
+			event: at(2026, 6, 16, 1, 30),
+			want:  "in 2h 30m",
+		},
+		{
+			// Regression: 61 minutes away across midnight (minutes < 5 -> "in 1h").
+			name:  "just over an hour crossing midnight is a countdown",
+			now:   at(2026, 6, 15, 23, 30),
+			event: at(2026, 6, 16, 0, 31),
+			want:  "in 1h",
+		},
+		{
+			// Just under the 6h threshold, crosses midnight -> still a countdown.
+			name:  "five hours crossing midnight is a countdown",
+			now:   at(2026, 6, 15, 20, 0),
+			event: at(2026, 6, 16, 1, 0),
+			want:  "in 5h",
+		},
+		{
+			// Beyond the threshold on the next calendar day -> "tomorrow" label.
+			name:  "next-day morning beyond threshold is tomorrow",
+			now:   at(2026, 6, 15, 22, 0),
+			event: at(2026, 6, 16, 18, 0),
+			want:  "tomorrow 6:00pm",
+		},
+		{
+			// Classic next-day afternoon (28h out) stays "tomorrow".
+			name:  "next-day afternoon is tomorrow",
+			now:   at(2026, 6, 15, 10, 0),
+			event: at(2026, 6, 16, 14, 0),
+			want:  "tomorrow 2:00pm",
+		},
+		{
+			// Several days out -> weekday label. 2026-06-18 is a Thursday.
+			name:  "several days out shows weekday",
+			now:   at(2026, 6, 15, 10, 0),
+			event: at(2026, 6, 18, 9, 0),
+			want:  "Thu 9:00am",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, calendarRelativeTime(tc.now, tc.event))
+		})
+	}
+}


### PR DESCRIPTION
## What

The calendar status-line segment showed `"tomorrow 1:30am"` for an event only **2.5 hours away** when `now` was late at night. `calendarRelativeTime` computed `dayDiff` from midnight-of-day timestamps, so any event past the next midnight — even 61 minutes out — got `dayDiff == 1` and the "tomorrow" label.

## Fix

Take the relative-hours branch when the event is the same calendar day **or** imminent (`diff < 6h`):

```go
if dayDiff == 0 || diff < 6*time.Hour {
    // "in Xh[ Ym]"
}
```

Day-based labels (`tomorrow`/weekday) stay for events ≥6h out on a later calendar day, so `"tomorrow 2:00pm"` (28h out) and `"tomorrow 6:00pm"` (20h out) are unchanged.

## Test (TDD red→green)

New deterministic table-test `TestCalendarRelativeTime` (10 cases). `calendarRelativeTime` takes `now` as a param and is called only with `time.Now()` in production, so it's in no snapshot/contract fixture — safe to change.

- **RED**: exactly the 3 cross-midnight cases failed (`"tomorrow ..."` vs countdown); every same-day / tomorrow / weekday / minutes / now case already passed.
- **GREEN**: all 10 pass.

## Verification
- `go build ./...` ✓, `go vet ./cmd/hookwise/` ✓
- full `cmd/hookwise` package green under `-race -p 2`, 0 zombie test procs
- pure function; no daemon / hot-path / SQLite risk

Closes #135