### PR TITLE
fix(notifications): add SQL ESCAPE so MCP-tool dedup works (#137)

### DIFF
--- a/internal/notifications/dedup_like_test.go
+++ b/internal/notifications/dedup_like_test.go
@@ -1,0 +1,77 @@
+package notifications
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/analytics"
+)
+
+// TestHasNotificationTodayWithContent_UnderscoreToolName guards the LIKE-escape
+// dedup path. A content substring containing SQL LIKE wildcards (`_` or `%`) --
+// as in MCP tool names like "mcp__server__tool" -- must still match its own
+// stored row. The helper backslash-escapes those wildcards, which only takes
+// effect if the SQL LIKE clause declares `ESCAPE '\'`. Without that clause,
+// SQLite has no default escape character, treats the backslashes as literals,
+// the dedup lookup never matches, and duplicate guard-effectiveness
+// notifications pile up for every MCP tool (double underscores).
+func TestHasNotificationTodayWithContent_UnderscoreToolName(t *testing.T) {
+	ns, _, cleanup := testService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	today := time.Now().UTC().Format("2006-01-02")
+
+	tool := "mcp__playwright__click"
+	content := `Guard rule for "` + tool + `" triggered 7 times today`
+	require.NoError(t, ns.Create(ctx, ProducerGuard, TypeGuardEffectiveness, content))
+
+	// The dedup lookup must find the row it just wrote, despite the underscores.
+	found, err := hasNotificationTodayWithContent(ctx, ns, ProducerGuard, TypeGuardEffectiveness, today, tool)
+	require.NoError(t, err)
+	assert.True(t, found, "dedup must match an MCP tool name containing underscores")
+
+	// A different tool name must NOT match (no false-positive dedup).
+	other, err := hasNotificationTodayWithContent(ctx, ns, ProducerGuard, TypeGuardEffectiveness, today, "mcp__other__tool")
+	require.NoError(t, err)
+	assert.False(t, other, "dedup must not match a different tool name")
+}
+
+// TestCheckGuardEffectiveness_DeduplicatesUnderscoreTool is the user-facing
+// proof: running the producer twice for an MCP-style tool with >=5 blocks must
+// create exactly ONE notification, not a duplicate on every run.
+func TestCheckGuardEffectiveness_DeduplicatesUnderscoreTool(t *testing.T) {
+	ns, db, cleanup := testService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	a := analytics.NewAnalytics(db)
+	now := time.Now().UTC()
+	sessionID := "guard-eff-mcp-sess"
+	require.NoError(t, a.StartSession(ctx, sessionID, now))
+
+	tool := "mcp__playwright__click"
+	for i := 0; i < 6; i++ {
+		require.NoError(t, a.RecordEvent(ctx, sessionID, analytics.EventRecord{
+			EventType: "PreToolUse",
+			ToolName:  tool,
+			Timestamp: now.Add(time.Duration(i) * time.Minute),
+		}))
+	}
+
+	require.NoError(t, CheckGuardEffectiveness(ctx, ns, db))
+	require.NoError(t, CheckGuardEffectiveness(ctx, ns, db)) // second run must dedup
+
+	notifs, err := ns.List(ctx, 50)
+	require.NoError(t, err)
+	count := 0
+	for _, n := range notifs {
+		if n.Producer == ProducerGuard && n.Type == TypeGuardEffectiveness {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "an MCP tool must yield exactly one guard-effectiveness notification across runs")
+}

--- a/internal/notifications/dedup_like_test.go
+++ b/internal/notifications/dedup_like_test.go
@@ -10,6 +10,18 @@ import (
 	"github.com/vishnujayvel/hookwise/internal/analytics"
 )
 
+// storedDay returns the UTC date string of the most recently created
+// notification. Deriving "today" from the row's own created_at stamp (rather
+// than a separate time.Now() call) makes the dedup-lookup tests immune to a
+// UTC-midnight race between the test's clock read and the stamp inside Create.
+func storedDay(t *testing.T, ns *NotificationService) string {
+	t.Helper()
+	rows, err := ns.List(context.Background(), 1)
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+	return rows[0].CreatedAt.UTC().Format("2006-01-02")
+}
+
 // TestHasNotificationTodayWithContent_UnderscoreToolName guards the LIKE-escape
 // dedup path. A content substring containing SQL LIKE wildcards (`_` or `%`) --
 // as in MCP tool names like "mcp__server__tool" -- must still match its own
@@ -23,11 +35,11 @@ func TestHasNotificationTodayWithContent_UnderscoreToolName(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	today := time.Now().UTC().Format("2006-01-02")
 
 	tool := "mcp__playwright__click"
 	content := `Guard rule for "` + tool + `" triggered 7 times today`
 	require.NoError(t, ns.Create(ctx, ProducerGuard, TypeGuardEffectiveness, content))
+	today := storedDay(t, ns)
 
 	// The dedup lookup must find the row it just wrote, despite the underscores.
 	found, err := hasNotificationTodayWithContent(ctx, ns, ProducerGuard, TypeGuardEffectiveness, today, tool)
@@ -40,9 +52,30 @@ func TestHasNotificationTodayWithContent_UnderscoreToolName(t *testing.T) {
 	assert.False(t, other, "dedup must not match a different tool name")
 }
 
+// TestHasNotificationTodayWithContent_BackslashToolName guards the escape-char
+// completeness: with the ESCAPE '\' clause in place, a literal backslash in the
+// substring must itself be escaped, otherwise SQLite treats it as the escape
+// character and corrupts the match. (escapeLIKE escapes `\` before % and _.)
+func TestHasNotificationTodayWithContent_BackslashToolName(t *testing.T) {
+	ns, _, cleanup := testService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	tool := `weird\tool`
+	content := `Guard rule for "` + tool + `" triggered 9 times today`
+	require.NoError(t, ns.Create(ctx, ProducerGuard, TypeGuardEffectiveness, content))
+	today := storedDay(t, ns)
+
+	found, err := hasNotificationTodayWithContent(ctx, ns, ProducerGuard, TypeGuardEffectiveness, today, tool)
+	require.NoError(t, err)
+	assert.True(t, found, "dedup must match a tool name containing a literal backslash")
+}
+
 // TestCheckGuardEffectiveness_DeduplicatesUnderscoreTool is the user-facing
 // proof: running the producer twice for an MCP-style tool with >=5 blocks must
-// create exactly ONE notification, not a duplicate on every run.
+// create exactly ONE notification, not a duplicate on every run. The assertion
+// counts by producer/type (no test-side clock), so it is not midnight-sensitive.
 func TestCheckGuardEffectiveness_DeduplicatesUnderscoreTool(t *testing.T) {
 	ns, db, cleanup := testService(t)
 	defer cleanup()

--- a/internal/notifications/producers.go
+++ b/internal/notifications/producers.go
@@ -203,6 +203,11 @@ func hasNotificationTodayWithContent(ctx context.Context, ns *NotificationServic
 
 // escapeLIKE escapes SQL LIKE wildcard characters (% and _) in a string.
 func escapeLIKE(s string) string {
+	// Escape the escape char itself FIRST, so the backslashes added for % and _
+	// below are not re-escaped. Required because the dedup LIKE query uses
+	// ESCAPE '\': an unescaped backslash in s would otherwise be treated as an
+	// escape character by SQLite and silently corrupt the match.
+	s = strings.ReplaceAll(s, "\\", "\\\\")
 	s = strings.ReplaceAll(s, "%", "\\%")
 	s = strings.ReplaceAll(s, "_", "\\_")
 	return s

--- a/internal/notifications/producers.go
+++ b/internal/notifications/producers.go
@@ -185,9 +185,13 @@ func hasNotificationToday(ctx context.Context, ns *NotificationService, producer
 // producer, type, and content substring was already created today.
 func hasNotificationTodayWithContent(ctx context.Context, ns *NotificationService, producer, notifType, today, contentSubstr string) (bool, error) {
 	escaped := escapeLIKE(contentSubstr)
+	// escapeLIKE backslash-escapes % and _ in the substring; SQLite only honors
+	// that with an explicit ESCAPE clause (it has no default escape char).
+	// Without it, tool names with underscores (e.g. MCP "mcp__server__tool")
+	// never match and dedup silently fails -> duplicate notifications.
 	row := ns.db.QueryRow(ctx,
 		`SELECT COUNT(*) FROM notifications
-		 WHERE producer = ? AND notification_type = ? AND created_at LIKE ? AND content LIKE ?`,
+		 WHERE producer = ? AND notification_type = ? AND created_at LIKE ? AND content LIKE ? ESCAPE '\'`,
 		producer, notifType, today+"%", "%"+escaped+"%",
 	)
 	var count int


### PR DESCRIPTION
## What

Guard-effectiveness notifications **duplicated on every producer run** for MCP tool names (`mcp__server__tool`).

`hasNotificationTodayWithContent` dedups by matching the tool name as a `content LIKE ?` substring and calls `escapeLIKE` to backslash-escape the SQL wildcards `%`/`_`. But the `LIKE` clause had **no `ESCAPE '\'`** — and SQLite has no default escape character, so the backslashes were treated as literals. Any tool name containing `_` or `%` (every MCP tool, double underscores) then failed to match its own stored row → dedup returned "not found" → duplicate notification.

## Fix

```sql
... AND content LIKE ? ESCAPE '\'
```

(The query is a backtick raw string, so the backslash stays literal and matches `escapeLIKE`'s output.) Pure dedup-query change — no daemon / hot-path / write-path impact.

## Test (TDD red→green)

- `TestHasNotificationTodayWithContent_UnderscoreToolName` (unit): the helper must match `mcp__playwright__click` against its own stored content.
- `TestCheckGuardEffectiveness_DeduplicatesUnderscoreTool` (integration): running the producer twice for an MCP tool with ≥5 blocks yields exactly **1** notification.

**RED**: helper returned false; producer produced **2** notifications. **GREEN**: helper matches; exactly **1** across runs.

## Verification
- `go build ./...` ✓, `go vet ./internal/notifications/` ✓
- full `notifications` package green under `-race -p 2`, 0 zombie test procs

Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where notifications weren't properly deduplicated when tool names contained certain special characters, eliminating unexpected duplicate notifications in these scenarios.

* **Tests**
  * Added tests to verify notification deduplication behavior functions correctly with tool names containing special characters and across multiple sequential events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->