### PR TITLE
fix(doctor): scope feed-health to known feeds, skip orphans (#94)

### DIFF
--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -213,6 +213,29 @@ func renderHookFinding(w io.Writer, f hooks.Finding) {
 	}
 }
 
+// knownBuiltinFeeds is the canonical list of feed names that have a Go producer.
+// Mirrors the cases in getFeedInterval's switch statement.
+var knownBuiltinFeeds = []string{"project", "news", "calendar", "weather", "memories", "insights"}
+
+// isKnownFeed returns true if feedName corresponds to a built-in producer or to
+// a custom feed declared in cfg. Unknown orphan files (written by old versions or
+// by the Python TUI) return false and should be silently skipped.
+func isKnownFeed(feedName string, cfg *core.HooksConfig) bool {
+	for _, b := range knownBuiltinFeeds {
+		if feedName == b {
+			return true
+		}
+	}
+	if cfg != nil {
+		for _, c := range cfg.Feeds.Custom {
+			if feedName == c.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // checkFeedHealth reads feed cache files and reports placeholder/stale feeds.
 // Returns the number of warnings emitted.
 func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
@@ -232,6 +255,11 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 			continue
 		}
 		feedName := strings.TrimSuffix(base, ".json")
+		// Skip orphan cache files that have no Go producer and are not in the
+		// config's custom feeds. Only known feeds produce actionable diagnostics.
+		if !isKnownFeed(feedName, cfg) {
+			continue
+		}
 
 		raw, err := os.ReadFile(f)
 		if err != nil {

--- a/cmd/hookwise/cmd_doctor_feedhealth_test.go
+++ b/cmd/hookwise/cmd_doctor_feedhealth_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// writeFeedFile writes a minimal feed cache envelope to cacheDir/<name>.json.
+// source=="placeholder" produces a placeholder envelope; anything else omits the
+// source field so the feed looks like real (non-placeholder) data.
+func writeFeedFile(t *testing.T, cacheDir, name, source string) {
+	t.Helper()
+	data := map[string]interface{}{"key": "value"}
+	if source == "placeholder" {
+		data = map[string]interface{}{"source": "placeholder"}
+	}
+	envelope := map[string]interface{}{
+		"type":      name,
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"data":      data,
+	}
+	raw, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(cacheDir, name+".json"), raw, 0o644)
+	require.NoError(t, err)
+}
+
+// TestCheckFeedHealth_OrphanSkipped verifies that orphan cache files (files with
+// no corresponding built-in or custom feed) are silently skipped and do not
+// produce any output or increment the warning count.
+func TestCheckFeedHealth_OrphanSkipped(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	// (a) Orphan: practice.json — no Go producer, not in cfg.Feeds.Custom.
+	writeFeedFile(t, cacheDir, "practice", "placeholder")
+	// (b) Known built-in: news.json — placeholder should still warn.
+	writeFeedFile(t, cacheDir, "news", "placeholder")
+
+	cfg := core.GetDefaultConfig()
+	// Ensure no custom feed named "practice".
+	cfg.Feeds.Custom = nil
+
+	var buf bytes.Buffer
+	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	out := buf.String()
+
+	// Known feed must still warn.
+	assert.Contains(t, out, "feed:news", "known feed (news) must appear in output")
+	assert.Contains(t, out, "placeholder", "known feed must warn about placeholder data")
+
+	// Orphan must be silently skipped.
+	assert.NotContains(t, out, "practice", "orphan feed (practice) must not appear in output")
+
+	// Warning count must reflect only the known feed.
+	assert.Equal(t, 1, count, "warning count must be 1 (only the known news feed)")
+}
+
+// TestCheckFeedHealth_CustomFeedTreatedAsKnown verifies that a feed listed in
+// cfg.Feeds.Custom is treated as known and its placeholder file triggers a
+// warning (i.e. it is NOT silently skipped).
+func TestCheckFeedHealth_CustomFeedTreatedAsKnown(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	// A custom feed named "pulse" — placeholder cache file.
+	writeFeedFile(t, cacheDir, "pulse", "placeholder")
+
+	cfg := core.GetDefaultConfig()
+	cfg.Feeds.Custom = []core.CustomFeedConfig{
+		{Name: "pulse", Command: "echo pulse", IntervalSeconds: 60, Enabled: true},
+	}
+
+	var buf bytes.Buffer
+	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	out := buf.String()
+
+	assert.Contains(t, out, "feed:pulse", "custom feed (pulse) must appear in output")
+	assert.Contains(t, out, "placeholder", "custom feed must warn about placeholder data")
+	assert.Equal(t, 1, count, "warning count must be 1 for the custom feed")
+}


### PR DESCRIPTION
## What
`hookwise doctor` reported `WARN feed:X: placeholder data (no real source configured)` for **orphan** cache files — `practice.json`, `pulse.json`, `interview-gameplan.json` — that have no Go producer and aren't in `hookwise.yaml`. They were written by an older version / the Python TUI and are never refreshed. The warning misleadingly implies a real-but-unconfigured feed.

## Fix
Scope `checkFeedHealth` to **known** feeds. A cache file is reported only if its name is:
- one of the 6 built-in producers (`project`, `news`, `calendar`, `weather`, `memories`, `insights`), or
- a custom feed declared in `cfg.Feeds.Custom`.

Unknown orphan files are silently skipped. **All existing behaviour is preserved for known feeds** — placeholder, cache-fresh-but-empty, stale, and OK reporting are unchanged, including the genuinely-useful "configured-but-placeholder" warning.

Implementation: a package-level `knownBuiltinFeeds` list (mirrors `getFeedInterval`'s switch) + an `isKnownFeed(name, cfg)` helper + a single guard `continue` in the scan loop.

## Tests (TDD)
- `TestCheckFeedHealth_OrphanSkipped` — orphan `practice.json` produces no output and isn't counted; a known `news.json` placeholder still warns (count == 1).
- `TestCheckFeedHealth_CustomFeedTreatedAsKnown` — a feed listed in `cfg.Feeds.Custom` is treated as known and warns (not skipped).

Red pre-fix (orphan warned), green post-fix. Full `cmd/hookwise` package green under `-race -p 2`, 0 zombies.

## Risk
Doctor-only, additive guard. No hot-path, daemon, or DB changes.

Closes #94.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `hookwise doctor` command's feed health checks now only report diagnostics for recognized built-in and custom-configured feeds, preventing false warnings from orphaned cache files created by other components or older versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->