### PR TITLE
fix(analytics): DefaultSnapshotsDir honors HOOKWISE_STATE_DIR (#116 Divergence A)

### DIFF
--- a/internal/analytics/snapshot.go
+++ b/internal/analytics/snapshot.go
@@ -25,9 +25,10 @@ const snapshotTimeFormat = "20060102T150405Z"
 var snapshotFileRe = regexp.MustCompile(`^\d{8}T\d{6}Z(-\d+)?\.db$`)
 
 // DefaultSnapshotsDir returns the conventional directory for analytics snapshots
-// (~/.hookwise/snapshots), mirroring DefaultDBPath.
+// (~/.hookwise/snapshots), mirroring DefaultDBPath. It honors the
+// HOOKWISE_STATE_DIR environment variable when set.
 func DefaultSnapshotsDir() string {
-	return filepath.Join(core.HomeDir(), ".hookwise", "snapshots")
+	return filepath.Join(core.GetStateDir(), "snapshots")
 }
 
 // Snapshot writes a consistent point-in-time copy of the analytics database to

--- a/internal/analytics/snapshot_statedir_test.go
+++ b/internal/analytics/snapshot_statedir_test.go
@@ -1,0 +1,31 @@
+package analytics
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// TestDefaultSnapshotsDir_HonorsStateDirOverride verifies that DefaultSnapshotsDir
+// returns a path rooted in HOOKWISE_STATE_DIR when that variable is set.
+// Pre-fix: the function used core.HomeDir()/.hookwise, ignoring the env var → red.
+// Post-fix: it uses core.GetStateDir() which returns the env var value → green.
+func TestDefaultSnapshotsDir_HonorsStateDirOverride(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", tmp)
+
+	got := DefaultSnapshotsDir()
+	assert.Equal(t, filepath.Join(tmp, "snapshots"), got)
+}
+
+// TestDefaultSnapshotsDir_DefaultUnchanged verifies that when HOOKWISE_STATE_DIR
+// is empty, DefaultSnapshotsDir falls back to the standard ~/.hookwise/snapshots path.
+// This is a no-regression test: behaviour is identical before and after the fix.
+func TestDefaultSnapshotsDir_DefaultUnchanged(t *testing.T) {
+	t.Setenv("HOOKWISE_STATE_DIR", "")
+
+	got := DefaultSnapshotsDir()
+	assert.Equal(t, filepath.Join(core.DefaultStateDir, "snapshots"), got)
+}


### PR DESCRIPTION
## What
`analytics.DefaultSnapshotsDir()` resolved from `core.HomeDir()/.hookwise/snapshots`, ignoring the `HOOKWISE_STATE_DIR` override. Under an overridden state dir, `hookwise log`/`diff`/`snapshot` and the daemon snapshot writer all looked in `~/.hookwise/snapshots` instead of the override location.

Fix: resolve via `core.GetStateDir()`. **No-op when no override is set** (`GetStateDir()` returns `DefaultStateDir` = `HomeDir()/.hookwise`); only changes behavior under `HOOKWISE_STATE_DIR`. Readers and the daemon writer share `DefaultSnapshotsDir()`, so they stay consistent.

## Scope: Divergence A only
#116 listed two divergences. This PR ships **A (snapshots)** only.

**Divergence B (TUI PID file) is deliberately deferred** — and the issue's framing was a trap worth calling out: the Python TUI **hardcodes** `~/.hookwise` (`tui/hookwise_tui/data.py:39` `_config_dir`, `app.py:101` PID path) and ignores `HOOKWISE_STATE_DIR`. Today the Go daemon *also* hardcodes `~/.hookwise/tui.pid`, so the two **agree**. Making only the Go `tuiPIDPath()` honor the override would **desync** them under an override — introducing a cross-language divergence rather than fixing one. B therefore needs a **coordinated Go+Python change** (Go `tuiPIDPath` + `tui.launch.lock` + Python `_config_dir` + `app.py` PID path) with pytest coverage, as its own PR.

This was surfaced by running `openlore orient`, which flagged `_config_dir` that a grep-first pass had missed.

## Tests (TDD)
- `TestDefaultSnapshotsDir_HonorsStateDirOverride` — red pre-fix (returns `~/.hookwise/snapshots`), green post-fix.
- `TestDefaultSnapshotsDir_DefaultUnchanged` — no-regression guard when the env var is empty.

Full `internal/analytics` package green under `-race -p 2`, 0 zombies. `openlore drift` → specs acceptable (existing `EmptySnapshotsDirUsesDefault` scenario remains accurate).

## Risk
Go-only path resolution. No default-behavior change; no hot-path or daemon-coordination logic touched.

Refs #116 (Divergence A; B tracked separately).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshots directory now respects the `HOOKWISE_STATE_DIR` environment variable, allowing customization of where analytics snapshots are stored. If not set, it uses the standard default state directory.

* **Tests**
  * Added unit tests to verify the snapshots directory path when `HOOKWISE_STATE_DIR` is set and when it is unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->