### PR TITLE
fix(doctor): warn on fresh insights cache with zero sessions (#98)

### DIFF
--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -305,6 +305,17 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 			continue
 		}
 
+		// Zero-liveness check: some producers emit a fully-keyed but all-zero
+		// envelope when their data source is empty (issue #98). The segment
+		// renders blank even though len(dataMap) > 0, so the empty-map guard
+		// above won't catch it. Detect feed-specific zero-liveness conditions.
+		if reason := feedZeroLivenessReason(feedName, dataMap); reason != "" {
+			fmt.Fprintf(w, "WARN  feed:%s: %s\n", feedName, reason)
+			warnings++
+			feedStatuses[feedName] = "empty"
+			continue
+		}
+
 		// Parse timestamp once for staleness and reporting.
 		tsStr := envelope["timestamp"].(string)
 		ts, parseErr := core.ParseTimeFlex(tsStr)
@@ -371,6 +382,21 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 	}
 
 	return warnings
+}
+
+// feedZeroLivenessReason reports whether a fresh, non-empty feed envelope
+// actually contains zero live data (cache-fresh != data-present, issue #98).
+// Some producers (e.g. insights) emit a fully-keyed but all-zero envelope when
+// their data source is empty, which would otherwise pass as OK. Returns a
+// human-readable reason when the feed should be flagged, or "" when it looks live.
+func feedZeroLivenessReason(feedName string, dataMap map[string]interface{}) string {
+	switch feedName {
+	case "insights":
+		if n, ok := dataMap["total_sessions"].(float64); ok && n == 0 {
+			return "cache fresh but no sessions recorded"
+		}
+	}
+	return ""
 }
 
 // getFeedInterval returns the configured interval_seconds for a feed name.

--- a/cmd/hookwise/cmd_doctor_feedhealth_test.go
+++ b/cmd/hookwise/cmd_doctor_feedhealth_test.go
@@ -85,3 +85,77 @@ func TestCheckFeedHealth_CustomFeedTreatedAsKnown(t *testing.T) {
 	assert.Contains(t, out, "placeholder", "custom feed must warn about placeholder data")
 	assert.Equal(t, 1, count, "warning count must be 1 for the custom feed")
 }
+
+// writeInsightsFeedFile writes a fresh insights cache envelope with the given
+// total_sessions value and a representative set of other zeroed/non-zero fields.
+// This mirrors the real zeroedEnvelope shape (fully-keyed, not empty).
+func writeInsightsFeedFile(t *testing.T, cacheDir string, totalSessions int) {
+	t.Helper()
+	data := map[string]interface{}{
+		"total_sessions":       totalSessions,
+		"total_messages":       0,
+		"total_lines_added":    0,
+		"avg_duration_minutes": float64(0),
+		"top_tools":            []interface{}{},
+		"friction_counts":      map[string]interface{}{},
+		"friction_total":       0,
+		"peak_hour":            0,
+		"days_active":          0,
+		"staleness_days":       0,
+		"recent_msgs_per_day":  0,
+		"recent_messages":      0,
+		"recent_days_active":   0,
+		"recent_session":       map[string]interface{}{},
+	}
+	envelope := map[string]interface{}{
+		"type":      "insights",
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"data":      data,
+	}
+	raw, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(cacheDir, "insights.json"), raw, 0o644)
+	require.NoError(t, err)
+}
+
+// TestCheckFeedHealth_InsightsZeroSessionsWarns verifies that a fresh insights
+// cache with total_sessions==0 (the zeroedEnvelope shape) emits a WARN rather
+// than a false-positive OK. The data map is non-empty so the generic empty-map
+// guard would NOT catch this without the zero-liveness check (issue #98).
+func TestCheckFeedHealth_InsightsZeroSessionsWarns(t *testing.T) {
+	cacheDir := t.TempDir()
+	writeInsightsFeedFile(t, cacheDir, 0)
+
+	cfg := core.GetDefaultConfig()
+	cfg.Feeds.Insights.Enabled = true
+
+	var buf bytes.Buffer
+	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	out := buf.String()
+
+	assert.Contains(t, out, "WARN  feed:insights: cache fresh but no sessions recorded",
+		"zero-sessions insights envelope must warn")
+	assert.NotContains(t, out, "feed:insights: OK",
+		"zero-sessions insights envelope must NOT report OK")
+	assert.Equal(t, 1, count, "warning count must be 1 for the zero-sessions insights feed")
+}
+
+// TestCheckFeedHealth_InsightsWithSessionsOK verifies that a fresh insights cache
+// with total_sessions>0 is reported as healthy (no zero-liveness WARN).
+func TestCheckFeedHealth_InsightsWithSessionsOK(t *testing.T) {
+	cacheDir := t.TempDir()
+	writeInsightsFeedFile(t, cacheDir, 5)
+
+	cfg := core.GetDefaultConfig()
+	cfg.Feeds.Insights.Enabled = true
+
+	var buf bytes.Buffer
+	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	out := buf.String()
+
+	assert.Contains(t, out, "feed:insights: OK",
+		"insights feed with sessions must report OK")
+	assert.NotContains(t, out, "cache fresh but no sessions recorded",
+		"insights feed with sessions must NOT emit zero-liveness warning")
+	assert.Equal(t, 0, count, "warning count must be 0 for a healthy insights feed")
+}


### PR DESCRIPTION
## What

Doctor's feed-health honesty check only warned when a feed's cache `data` object was **completely empty** (`len(dataMap) == 0`). The insights producer emits a `zeroedEnvelope` that is **fully keyed but all-zero** (`total_sessions: 0`, `top_tools: []`, …), so `len(dataMap) > 0` and doctor reported `INFO feed:insights: OK` — even though no sessions were recorded and the segment renders blank. Classic cache-fresh ≠ data-present (#99/#98).

## Change

Adds `feedZeroLivenessReason(feedName, dataMap)`: for the `insights` feed, a fresh-but-`total_sessions==0` envelope now emits:

```
WARN  feed:insights: cache fresh but no sessions recorded
```

(status `empty`, counts as a warning), inserted after the existing `len==0` guard. The per-feed `switch` generalizes to other producers that emit fully-keyed zero envelopes.

This is the standalone **doctor-honesty** follow-up (greenlit cheap #99 item); it's the autonomous-safe slice of the #98 insights port — no producer/TUI wiring, well before the PR4/PR5 pause point. #98 stays open.

## Tests (TDD)

- `TestCheckFeedHealth_InsightsZeroSessionsWarns` — fully-keyed envelope, `total_sessions: 0` → asserts the WARN appears and `feed:insights: OK` does **not**.
- `TestCheckFeedHealth_InsightsWithSessionsOK` — `total_sessions: 5` → OK, no zero-liveness warn.

## Verification

- `GOMEMLIMIT=4GiB go test -race -p 2 ./cmd/hookwise/` → **ok, 4.205s**, 0 zombies
- `go build ./...`, `go vet ./cmd/hookwise/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)