### PR TITLE
feat(feeds): InsightsSource seam + envelope mapping (#98, pre-PR4)

### DIFF
--- a/internal/feeds/insights_source.go
+++ b/internal/feeds/insights_source.go
@@ -1,0 +1,78 @@
+package feeds
+
+import "context"
+
+// InsightsSource supplies aggregated usage metrics for the insights feed.
+// Implemented in the cmd layer over the analytics DB (ARCH-3: feeds must not
+// import analytics; the concrete impl is injected from package main).
+type InsightsSource interface {
+	InsightsSummary(ctx context.Context, stalenessDays int) (InsightsSummary, error)
+}
+
+// InsightsToolCount is a single tool-usage entry returned by InsightsSource.
+type InsightsToolCount struct {
+	Name  string
+	Count int
+}
+
+// InsightsRecentSession holds the most-recent session metrics available from
+// the analytics layer.
+type InsightsRecentSession struct {
+	ID          string
+	DurationMin float64
+	LinesAdded  int
+}
+
+// InsightsSummary is the feeds-side DTO for aggregated usage metrics.
+// It is intentionally a separate copy from any analytics DTO so that feeds
+// does not import internal/analytics (ARCH-3).
+type InsightsSummary struct {
+	TotalSessions    int
+	TotalLinesAdded  int
+	AvgDurationMin   float64
+	TopTools         []InsightsToolCount
+	PeakHourUTC      int
+	DaysActive       int
+	RecentDaysActive int
+	Recent           InsightsRecentSession
+}
+
+// MapInsightsSummary converts a DB-backed InsightsSummary into the insights
+// feed's envelope `data` map. The shape is byte-for-byte the same keys/types the
+// existing producer emits, so a later PR can swap the data source without
+// changing the feed contract. Fields with no analytics source (messages,
+// friction, outcome, tool_errors, recent_msgs_per_day) map to the same zero
+// defaults as zeroedEnvelope.
+func MapInsightsSummary(s InsightsSummary, stalenessDays int) map[string]interface{} {
+	topTools := make([]map[string]interface{}, 0, len(s.TopTools))
+	for _, t := range s.TopTools {
+		topTools = append(topTools, map[string]interface{}{
+			"name":  t.Name,
+			"count": t.Count,
+		})
+	}
+
+	return map[string]interface{}{
+		"total_sessions":       s.TotalSessions,
+		"total_messages":       0,
+		"total_lines_added":    s.TotalLinesAdded,
+		"avg_duration_minutes": s.AvgDurationMin,
+		"top_tools":            topTools,
+		"friction_counts":      map[string]interface{}{},
+		"friction_total":       0,
+		"peak_hour":            s.PeakHourUTC,
+		"days_active":          s.DaysActive,
+		"staleness_days":       stalenessDays,
+		"recent_msgs_per_day":  0,
+		"recent_messages":      0,
+		"recent_days_active":   s.RecentDaysActive,
+		"recent_session": map[string]interface{}{
+			"id":               s.Recent.ID,
+			"duration_minutes": s.Recent.DurationMin,
+			"lines_added":      s.Recent.LinesAdded,
+			"friction_count":   0,
+			"outcome":          "",
+			"tool_errors":      0,
+		},
+	}
+}

--- a/internal/feeds/insights_source_test.go
+++ b/internal/feeds/insights_source_test.go
@@ -1,0 +1,117 @@
+package feeds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapInsightsSummary_PopulatedShape(t *testing.T) {
+	s := InsightsSummary{
+		TotalSessions:   3,
+		TotalLinesAdded: 42,
+		AvgDurationMin:  12.5,
+		TopTools: []InsightsToolCount{
+			{Name: "Read", Count: 25},
+			{Name: "Edit", Count: 18},
+		},
+		PeakHourUTC:      14,
+		DaysActive:       2,
+		RecentDaysActive: 1,
+		Recent: InsightsRecentSession{
+			ID:          "sess-1",
+			DurationMin: 9.0,
+			LinesAdded:  7,
+		},
+	}
+
+	data := MapInsightsSummary(s, 30)
+
+	// Top-level keys and values.
+	assert.Equal(t, 3, data["total_sessions"])
+	assert.Equal(t, 0, data["total_messages"])
+	assert.Equal(t, 42, data["total_lines_added"])
+	assert.Equal(t, 12.5, data["avg_duration_minutes"])
+	assert.Equal(t, 14, data["peak_hour"])
+	assert.Equal(t, 2, data["days_active"])
+	assert.Equal(t, 30, data["staleness_days"])
+	assert.Equal(t, 0, data["recent_msgs_per_day"])
+	assert.Equal(t, 0, data["recent_messages"])
+	assert.Equal(t, 1, data["recent_days_active"])
+	assert.Equal(t, 0, data["friction_total"])
+
+	// friction_counts is an empty map (not nil).
+	fc, ok := data["friction_counts"].(map[string]interface{})
+	require.True(t, ok, "friction_counts must be map[string]interface{}")
+	assert.Empty(t, fc)
+
+	// top_tools: correct type, length, and values.
+	tt, ok := data["top_tools"].([]map[string]interface{})
+	require.True(t, ok, "top_tools must be []map[string]interface{}")
+	require.Len(t, tt, 2)
+	assert.Equal(t, "Read", tt[0]["name"])
+	assert.Equal(t, 25, tt[0]["count"])
+	assert.Equal(t, "Edit", tt[1]["name"])
+	assert.Equal(t, 18, tt[1]["count"])
+
+	// recent_session sub-map.
+	rs, ok := data["recent_session"].(map[string]interface{})
+	require.True(t, ok, "recent_session must be map[string]interface{}")
+	assert.Equal(t, "sess-1", rs["id"])
+	assert.Equal(t, 9.0, rs["duration_minutes"])
+	assert.Equal(t, 7, rs["lines_added"])
+	assert.Equal(t, 0, rs["friction_count"])
+	assert.Equal(t, "", rs["outcome"])
+	assert.Equal(t, 0, rs["tool_errors"])
+}
+
+func TestMapInsightsSummary_ZeroValueMatchesZeroedDefaults(t *testing.T) {
+	data := MapInsightsSummary(InsightsSummary{}, 7)
+
+	// All numeric top-level fields are zero.
+	assert.Equal(t, 0, data["total_sessions"])
+	assert.Equal(t, 0, data["total_messages"])
+	assert.Equal(t, 0, data["total_lines_added"])
+	assert.Equal(t, float64(0), data["avg_duration_minutes"])
+	assert.Equal(t, 0, data["peak_hour"])
+	assert.Equal(t, 0, data["days_active"])
+	assert.Equal(t, 7, data["staleness_days"])
+	assert.Equal(t, 0, data["recent_msgs_per_day"])
+	assert.Equal(t, 0, data["recent_messages"])
+	assert.Equal(t, 0, data["recent_days_active"])
+	assert.Equal(t, 0, data["friction_total"])
+
+	// top_tools is a non-nil empty slice (matches zeroedEnvelope []map[string]interface{}{}).
+	tt, ok := data["top_tools"].([]map[string]interface{})
+	require.True(t, ok, "top_tools must be []map[string]interface{}")
+	assert.NotNil(t, tt)
+	assert.Len(t, tt, 0)
+
+	// friction_counts is an empty map.
+	fc, ok := data["friction_counts"].(map[string]interface{})
+	require.True(t, ok, "friction_counts must be map[string]interface{}")
+	assert.Empty(t, fc)
+
+	// Key set matches the 14 keys in zeroedEnvelope.
+	expectedKeys := []string{
+		"total_sessions", "total_messages", "total_lines_added", "avg_duration_minutes",
+		"top_tools", "friction_counts", "friction_total", "peak_hour", "days_active",
+		"staleness_days", "recent_msgs_per_day", "recent_messages", "recent_days_active",
+		"recent_session",
+	}
+	assert.Len(t, data, len(expectedKeys), "key count must match zeroedEnvelope")
+	for _, k := range expectedKeys {
+		assert.Contains(t, data, k, "missing key: %s", k)
+	}
+
+	// recent_session sub-map with zero/empty values.
+	rs, ok := data["recent_session"].(map[string]interface{})
+	require.True(t, ok, "recent_session must be map[string]interface{}")
+	assert.Equal(t, "", rs["id"])
+	assert.Equal(t, float64(0), rs["duration_minutes"])
+	assert.Equal(t, 0, rs["lines_added"])
+	assert.Equal(t, 0, rs["friction_count"])
+	assert.Equal(t, "", rs["outcome"])
+	assert.Equal(t, 0, rs["tool_errors"])
+}


### PR DESCRIPTION
## What

Additive groundwork for re-sourcing the `insights` feed from the analytics DB (#98). Introduces the injection seam **without touching the producer**, so the producer-swap review gate stays intact.

- `InsightsSource` interface + feeds-side DTOs (`InsightsSummary`, `InsightsToolCount`, `InsightsRecentSession`) — deliberate mirrors of the analytics PR1 types, kept as a separate copy so `internal/feeds` never imports `internal/analytics` (**ARCH-3**, enforced by `TestArch_FeedsDoNotImportAnalytics`).
- Pure `MapInsightsSummary(summary, stalenessDays) map[string]interface{}` — produces a `data` map **shape-identical** to the current insights envelope (same 14 keys; `top_tools` a non-nil `[]map[string]interface{}`; zeroed defaults for fields with no analytics source: messages, friction, outcome, tool_errors, recent_msgs_per_day).

## Why this scope

`Produce()` is **untouched** — zero runtime behavior change, and no contract fixtures move (there are no insights contract fixtures anyway). This is strictly **before** the producer swap: a later reviewed PR injects an analytics-backed `InsightsSource` into the producer (PR4) and repoints the Python TUI (PR5). Keeps the seam ready + tested while honoring the pause-before-swap gate.

## Tests (TDD)

- `TestMapInsightsSummary_PopulatedShape` — every top-level key + `top_tools` name/count + `recent_session` sub-map asserted.
- `TestMapInsightsSummary_ZeroValueMatchesZeroedDefaults` — zero-value summary maps to the same shape/defaults as the producer's `zeroedEnvelope` (empty non-nil slice, empty map, zeroes).

## Verification

- `GOMEMLIMIT=4GiB go test -race -p 2 ./internal/feeds/ ./internal/arch/` → **ok** (feeds 5.9s, arch 6.5s — ARCH-3 holds), 0 zombies
- `go build ./...`, `go vet ./internal/feeds/...` clean

#98 stays open. Producer swap (PR4) + TUI repoint (PR5) await review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Established internal framework for standardizing aggregation and reporting of usage metrics and insights data across the platform.
  * Implemented comprehensive unit tests to validate metrics collection and data transformation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->