### PR TITLE
fix(cost): clamp DailyCosts[today] to zero on negative Stop delta

### DIFF
--- a/cmd/hookwise/cmd_dispatch.go
+++ b/cmd/hookwise/cmd_dispatch.go
@@ -223,6 +223,13 @@ func recordAnalytics(ctx context.Context, eventType string, payload core.HookPay
 						state.TotalToday = 0
 					}
 					state.DailyCosts[today] += delta
+					// Mirror the non-negative floor: TotalToday and DailyCosts[today]
+					// are redundant views of the same daily total, so a negative delta
+					// (lowered Rates override or truncated transcript) must clamp both
+					// identically — clamping only one lets them diverge permanently.
+					if state.DailyCosts[today] < 0 {
+						state.DailyCosts[today] = 0
+					}
 					state.Today = today
 				}); uerr != nil {
 					core.Logger().Error("cost: update cost_state", "error", uerr)

--- a/cmd/hookwise/cmd_dispatch_cost_test.go
+++ b/cmd/hookwise/cmd_dispatch_cost_test.go
@@ -175,6 +175,57 @@ func TestRecordAnalytics_CostStop_TranscriptGrows(t *testing.T) {
 		"DailySummary.EstimatedCostUSD must reflect the grown-transcript recompute")
 }
 
+// TestRecordAnalytics_CostStop_NegativeDelta verifies that when a session's
+// recomputed cost is LOWER than its previously stored SessionCosts (reachable
+// via a lowered CostTracking.Rates override between two Stops, or a truncated/
+// rotated transcript), the non-negative clamp is applied CONSISTENTLY: both
+// TotalToday and DailyCosts[today] floor at 0 and stay equal. The bug this guards
+// against: TotalToday was clamped while DailyCosts[today] was not, letting the two
+// redundant views of "today's total" diverge permanently (DailyCosts going
+// negative, so later increments dig out from a negative floor).
+func TestRecordAnalytics_CostStop_NegativeDelta(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	transcriptPath := writeSonnetFixture(t) // recomputes to $18
+	sid := "cost-test-session-negdelta"
+	today := time.Now().Format("2006-01-02") // local date, matching the closure
+
+	// Pre-create the session and seed a cost state where this session is already
+	// recorded at $36 (higher than the $18 transcript will recompute to) while
+	// today's running totals sit at only $2 — so the -$18 delta drives TotalToday
+	// below zero and trips the clamp.
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.StartSession(context.Background(), sid, time.Now()))
+	require.NoError(t, db.WriteCostState(context.Background(), &analytics.CostState{
+		DailyCosts:   map[string]float64{today: 2.0},
+		SessionCosts: map[string]float64{sid: 36.0},
+		Today:        today,
+		TotalToday:   2.0,
+	}))
+	db.Close()
+
+	costCfg := core.CostTrackingConfig{Enabled: true}
+	payload := core.HookPayload{SessionID: sid, TranscriptPath: transcriptPath}
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+
+	db = openTestDB(t, dbPath)
+	defer db.Close()
+
+	state, err := db.ReadCostState(context.Background())
+	require.NoError(t, err)
+	assert.InDelta(t, 0.0, state.TotalToday, 0.001,
+		"TotalToday must clamp to 0 on a negative delta")
+	assert.InDelta(t, 0.0, state.DailyCosts[today], 0.001,
+		"DailyCosts[today] must clamp to 0 too, not go negative")
+	assert.InDelta(t, state.TotalToday, state.DailyCosts[today], 0.001,
+		"TotalToday and DailyCosts[today] must stay equal (consistent daily total)")
+	assert.InDelta(t, expectedSonnetCost, state.SessionCosts[sid], 0.001,
+		"SessionCosts[sid] must be overwritten with the recomputed $18")
+}
+
 // TestRecordAnalytics_CostStop_Disabled verifies that when CostTracking.Enabled=false,
 // no cost is written and TotalToday stays 0.
 func TestRecordAnalytics_CostStop_Disabled(t *testing.T) {


### PR DESCRIPTION
## Problem

The Stop-seam cost closure (`cmd_dispatch.go`) clamped `TotalToday` at zero on a negative delta but left `DailyCosts[today]` unclamped. The two are **redundant views of the same daily total**, so on a negative delta they diverged permanently: `DailyCosts[today]` could go negative while `TotalToday` floored at 0, and any later increment then dug out from a negative floor instead of from 0.

### Reachability

A negative delta (`sessionCost - SessionCosts[sid] < 0`) occurs when a session's recomputed cost is lower than its previously stored value — e.g.:
- a **lowered `CostTracking.Rates` override** applied between two Stop events, or
- a **truncated / rotated transcript** producing fewer usage blocks on recompute.

## Fix

Mirror the existing non-negative clamp onto `DailyCosts[today]` so both fields floor identically and the invariant `TotalToday == DailyCosts[Today]` holds. 3-line change inside the existing pure mutation closure — no hot-path, no daemon, no schema change.

## Test (TDD)

`TestRecordAnalytics_CostStop_NegativeDelta` seeds `SessionCosts[sid]=$36`, `TotalToday=$2`, `DailyCosts=$2`; an $18 transcript drives `delta = -$18`.
- **RED** (before): `DailyCosts[today] = -16` while `TotalToday = 0`.
- **GREEN** (after): both clamp to 0 and stay equal.

Full `cmd/hookwise` package green with `-race`, `go vet` clean.

## Scope

Deliberately *not* redesigning multi-session cost accounting — the clamp remains lossy in a multi-session day (it zeroes other sessions' legitimate cost, as `TotalToday` already did). That's a separate, larger concern; this PR only restores **consistency between the two fields**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)