### PR TITLE
test(notifications): cover %-wildcard escape in dedup LIKE

### DIFF
--- a/internal/notifications/dedup_like_test.go
+++ b/internal/notifications/dedup_like_test.go
@@ -72,6 +72,40 @@ func TestHasNotificationTodayWithContent_BackslashToolName(t *testing.T) {
 	assert.True(t, found, "dedup must match a tool name containing a literal backslash")
 }
 
+// TestHasNotificationTodayWithContent_PercentToolName completes the LIKE-escape
+// trio: sibling tests cover `_` and `\`, but the `%` branch of escapeLIKE was
+// untested even though its doc comment claims to escape `%`. A literal `%` in
+// the dedup substring must be escaped so SQLite treats it as a literal, not a
+// wildcard. If the `%` escape were dropped, dedup substrings would turn into
+// wildcards, producing false-positive matches that SILENTLY SUPPRESS legitimate
+// notifications. This test matches the row with a literal-`%` tool name AND
+// proves the discriminating negative that only fails under wildcard behaviour.
+func TestHasNotificationTodayWithContent_PercentToolName(t *testing.T) {
+	ns, _, cleanup := testService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// A tool name containing a literal percent sign must match its own row.
+	tool := "build%cache"
+	content := `Guard rule for "` + tool + `" triggered 8 times today`
+	require.NoError(t, ns.Create(ctx, ProducerGuard, TypeGuardEffectiveness, content))
+	today := storedDay(t, ns)
+
+	found, err := hasNotificationTodayWithContent(ctx, ns, ProducerGuard, TypeGuardEffectiveness, today, tool)
+	require.NoError(t, err)
+	assert.True(t, found, "dedup must match a tool name containing a literal percent sign")
+
+	// Discriminating negative: "build%che" only matches the stored "build%cache"
+	// if `%` is treated as a SQL wildcard (build…che, where "che" falls inside
+	// "cache"). With `%` correctly escaped it requires the literal "build%che",
+	// which is absent -> no false-positive dedup. This assertion is what fails if
+	// the `%` escape line is removed from escapeLIKE.
+	wildcard, err := hasNotificationTodayWithContent(ctx, ns, ProducerGuard, TypeGuardEffectiveness, today, "build%che")
+	require.NoError(t, err)
+	assert.False(t, wildcard, "an unescaped %-wildcard must not produce a false-positive dedup match")
+}
+
 // TestCheckGuardEffectiveness_DeduplicatesUnderscoreTool is the user-facing
 // proof: running the producer twice for an MCP-style tool with >=5 blocks must
 // create exactly ONE notification, not a duplicate on every run. The assertion


### PR DESCRIPTION
## Coverage gap

`escapeLIKE` escapes all three SQL `LIKE` special characters (`\`, `%`, `_`), but only `_` and `\` had sibling tests (`..._UnderscoreToolName`, `..._BackslashToolName`). The `%` branch was untested — even though `escapeLIKE`'s own doc comment claims to escape it.

**Why it matters:** if the `%`-escape line were dropped (refactor, bad merge), dedup substrings would turn into SQL `LIKE` wildcards, producing false-positive dedup matches that **silently suppress legitimate notifications**. No existing test would catch that regression.

## Test (TDD-for-coverage)

`TestHasNotificationTodayWithContent_PercentToolName`:
- **Positive:** a literal-`%` tool name (`build%cache`) matches its own stored row.
- **Discriminating negative:** querying `build%che` must **not** match stored `build%cache` — it only would if `%` were treated as a wildcard (`build`…`che`, where `che` falls inside `cache`).

**Verified red→green by mutation:** removing the `s = strings.ReplaceAll(s, "%", "\\%")` line makes the negative assertion fail; restoring it passes. This proves the test kills the mutant rather than being a vacuous characterization test.

Test-only change — no production code touched (`producers.go` identical to `main`). Full `internal/notifications` package green with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for notification deduplication handling of special characters in tool names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->