### PR TITLE
fix(status-line): truncate notification content on rune boundary

### DIFF
--- a/cmd/hookwise/cmd_status_line.go
+++ b/cmd/hookwise/cmd_status_line.go
@@ -175,10 +175,10 @@ func renderNotificationSegment(dbPath string) string {
 
 	// Show count and the most recent notification's content (truncated).
 	latest := unsurfaced[len(unsurfaced)-1]
-	content := latest.Content
-	if len(content) > 40 {
-		content = content[:37] + "..."
-	}
+	// Rune-aware truncation (matches the news segment): byte-index slicing here
+	// would split a multi-byte rune and emit invalid UTF-8 (U+FFFD) in the status
+	// line when content contains non-ASCII characters.
+	content := truncateRunes(latest.Content, 40)
 
 	segment := fmt.Sprintf("%s%d notif%s%s %s%s%s",
 		ansiYellow, len(unsurfaced), pluralS(len(unsurfaced)), ansiReset,

--- a/cmd/hookwise/cmd_status_line_notif_test.go
+++ b/cmd/hookwise/cmd_status_line_notif_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/notifications"
+)
+
+// TestRenderNotificationSegment_MultibyteTruncation guards against byte-index
+// truncation corrupting multi-byte UTF-8 in the status-line notification
+// segment. The content is built so a 4-byte emoji straddles byte offset 37 --
+// the old `content[:37]` cut lands mid-rune, yielding invalid UTF-8 that the
+// terminal renders as U+FFFD (replacement char). The rune-aware truncateRunes
+// helper (already used by the news segment) cuts on a rune boundary instead.
+func TestRenderNotificationSegment_MultibyteTruncation(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	// 35 ASCII bytes + ten 4-byte emoji = 75 bytes / 45 runes. The first emoji
+	// occupies bytes 35-38, so a byte-37 cut splits it; >40 runes also forces a
+	// real truncation under the rune-aware path.
+	content := strings.Repeat("a", 35) + strings.Repeat("\U0001F4B8", 10)
+	require.Greater(t, len(content), 40, "content must exceed the 40-byte truncation threshold")
+	require.False(t, utf8.RuneStart(content[37]), "byte 37 must land inside a multi-byte rune for this test to bite")
+
+	db := openTestDB(t, dbPath)
+	ns := notifications.NewNotificationService(db)
+	require.NoError(t, ns.Create(context.Background(),
+		notifications.ProducerGuard, notifications.TypeGuardEffectiveness, content))
+	db.Close()
+
+	out := renderNotificationSegment(dbPath)
+	require.NotEmpty(t, out, "an unsurfaced notification must render a non-empty segment")
+	assert.True(t, utf8.ValidString(out),
+		"rendered notification segment must be valid UTF-8 (no mid-rune byte slice)")
+	assert.NotContains(t, out, "�",
+		"segment must not contain the U+FFFD replacement char from a mid-rune cut")
+}


### PR DESCRIPTION
## Bug

`renderNotificationSegment` truncated the latest notification's content with **byte-index slicing**:

```go
if len(content) > 40 {
    content = content[:37] + "..."
}
```

When `content` contains a multi-byte rune (emoji, accented char, CJK) that straddles byte offset 37, the cut splits the rune and produces **invalid UTF-8**. Go does not panic on byte-slicing a string, so this is silent: the terminal renders the broken bytes as U+FFFD (�), corrupting the status line.

The same file already has a rune-aware `truncateRunes` helper, used by the news segment (`cmd_status_line.go:390`) — this path just didn't use it (same shape as the #146 `escapeLIKE` gap: correct helper present, not applied).

## Fix

```go
content := truncateRunes(latest.Content, 40)
```

Rune-boundary truncation, consistent with the news segment. Pure presentation logic — no DB queries, no hot path, no daemon; the `MarkSurfaced` side-effect is untouched.

## Test (TDD)

`TestRenderNotificationSegment_MultibyteTruncation` seeds a notification whose content is 35 ASCII bytes + ten 4-byte emoji (75 bytes / 45 runes), so the first emoji straddles byte 37 and >40 runes forces a real truncation:
- **RED:** `utf8.ValidString(out)` is false (mid-rune byte cut).
- **GREEN:** valid UTF-8, no U+FFFD.

Full `cmd/hookwise` package green with `-race`, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification display to correctly handle multi-byte Unicode characters (such as emojis), preventing text corruption when notifications appear in the status line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->