### PR TITLE
test(bridge): pin updated_at envelope precedence over data

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -172,10 +172,18 @@ func FlattenForTUI(merged map[string]interface{}) map[string]interface{} {
 				}
 			}
 
-			// Add updated_at (renamed from timestamp).
+			// Add updated_at (renamed from timestamp). This is the reserved
+			// feed-freshness key: the TUI computes staleness as now-updated_at
+			// vs ttl_seconds (tui/hookwise_tui/data.py), so it MUST be the
+			// envelope's production timestamp. The envelope deliberately wins
+			// over any same-named field a producer put in its data payload —
+			// do NOT guard this assignment (that would let a domain field
+			// hijack freshness). This asymmetry with ttl_seconds below is
+			// intentional, not a bug.
 			flat["updated_at"] = timestamp
 
-			// Add ttl_seconds if not already present.
+			// Add ttl_seconds only if absent: unlike updated_at, the staleness
+			// window IS producer-overridable, so a data-supplied value wins.
 			if _, hasTTL := flat["ttl_seconds"]; !hasTTL {
 				flat["ttl_seconds"] = DefaultTTLSeconds
 			}

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -423,6 +423,43 @@ func TestFlattenForTUI_EnvelopeToFlat(t *testing.T) {
 	assert.Equal(t, "F", weatherEntry["unit"])
 }
 
+// TestFlattenForTUI_EnvelopeUpdatedAtWinsOverData pins the reserved-key
+// precedence for updated_at. It is the feed-freshness field the TUI uses to
+// compute staleness (now-updated_at vs ttl_seconds), so the envelope's
+// production timestamp MUST win over any same-named field a producer placed in
+// its data payload — otherwise a domain "updated_at" would hijack freshness and
+// the TUI would mis-report the feed as fresh/stale. This is intentionally
+// asymmetric with ttl_seconds (which a producer CAN override); the test below
+// asserts both halves so a future "consistency" refactor that guards updated_at
+// the way ttl_seconds is guarded fails loudly.
+func TestFlattenForTUI_EnvelopeUpdatedAtWinsOverData(t *testing.T) {
+	envelopeTS := "2026-03-06T10:00:00Z"
+	dataTS := "2020-01-01T00:00:00Z" // a producer's own, stale, updated_at
+	merged := map[string]interface{}{
+		"calendar": map[string]interface{}{
+			"type":      "calendar",
+			"timestamp": envelopeTS,
+			"data": map[string]interface{}{
+				"updated_at":  dataTS,        // reserved key: must be overridden
+				"ttl_seconds": float64(900),  // overridable: must be preserved
+				"event":       "standup",
+			},
+		},
+	}
+
+	flat := FlattenForTUI(merged)
+	entry, ok := flat["calendar"].(map[string]interface{})
+	require.True(t, ok)
+
+	// updated_at: the envelope timestamp wins (freshness is not hijackable).
+	assert.Equal(t, envelopeTS, entry["updated_at"],
+		"envelope timestamp must override a data-supplied updated_at (TUI freshness key)")
+	// ttl_seconds: the producer's value is preserved (staleness window is overridable).
+	assert.Equal(t, float64(900), entry["ttl_seconds"],
+		"a data-supplied ttl_seconds must be preserved, not replaced by the default")
+	assert.Equal(t, "standup", entry["event"])
+}
+
 // ---------------------------------------------------------------------------
 // Test 18: FlattenForTUI — already-flat entries pass through
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

A pure-code hunt flagged `FlattenForTUI` overwriting `updated_at` while guarding `ttl_seconds` as a "bug," proposing to guard `updated_at` so a data-supplied value wins. **Investigation showed that fix would itself be a bug.**

`updated_at` is the **reserved feed-freshness key**: the Python TUI computes staleness as `now - updated_at` vs `ttl_seconds` (`tui/hookwise_tui/data.py:121-128`). So the envelope's production timestamp **must** win over any same-named field a producer placed in its `data` payload — otherwise a domain `updated_at` would hijack freshness and the TUI would mis-report the feed as fresh/stale. `ttl_seconds` is intentionally the opposite: a producer **may** override the staleness window.

The asymmetry is correct and load-bearing — but it was **untested and easily misread** (a hunt agent just misread it). A well-meaning "consistency" refactor guarding `updated_at` the same way would silently break TUI freshness.

## Change

- **Comment-only** clarification at the `updated_at` assignment explaining the reserved-key precedence and why it must *not* be guarded (production behavior unchanged — diff is comments only).
- `TestFlattenForTUI_EnvelopeUpdatedAtWinsOverData` pinning both halves: envelope `updated_at` wins; data-supplied `ttl_seconds` is preserved.

## Verification

Mutation-checked: applying the proposed guard (`if _, ok := flat["updated_at"]; !ok`) lets a stale `2020-01-01` data timestamp leak through and **fails** the test — proving it protects the contract. Full `internal/bridge` package green with `-race`, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)