### PR TITLE
feat(doctor): warn when sessions recorded but $0 cost computed

### DIFF
--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -106,6 +106,14 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(w, "INFO  legacy-dolt: %s present (archived; safe to remove)\n", doltDir)
 	}
 
+	// Check 8: Cost-tracking honesty. DailySummary aggregates per-session
+	// estimated_cost_usd from the SAME UTC day `hookwise stats` and the
+	// status-line read, so doctor agrees with what the user sees there. If
+	// sessions were recorded today but $0 was computed, the cost writer is
+	// likely dead -- the exact failure that kept stats/status-line silently at
+	// $0. Mirrors the feed zero-liveness principle (cache-fresh != data-present).
+	warnings += checkCostHonesty(w, dbPath)
+
 	// Check 4: Daemon liveness via socket dial (replaces PID file check).
 	// Use GetStateDir() to respect HOOKWISE_STATE_DIR env override.
 	socketPath := filepath.Join(core.GetStateDir(), "daemon.sock")
@@ -397,6 +405,44 @@ func feedZeroLivenessReason(feedName string, dataMap map[string]interface{}) str
 		}
 	}
 	return ""
+}
+
+// checkCostHonesty reports a doctor warning when sessions were recorded today
+// but the computed cost is still $0 -- the signature of a dead cost writer
+// (sessions present but the cost value absent). It reads DailySummary for the
+// current UTC day, the same source `hookwise stats` and the status-line use, so
+// doctor stays consistent with what the user sees there. Returns the number of
+// warnings emitted (0 or 1). Absent or unopenable DBs are silent no-ops -- the
+// analytics check (Check 3) already owns reporting those.
+func checkCostHonesty(w io.Writer, dbPath string) int {
+	if _, err := os.Stat(dbPath); err != nil {
+		return 0
+	}
+	db, err := analytics.Open(dbPath)
+	if err != nil {
+		return 0
+	}
+	defer db.Close()
+
+	today := time.Now().UTC().Format("2006-01-02")
+	summary, err := analytics.NewAnalytics(db).DailySummary(context.Background(), today)
+	if err != nil {
+		return 0
+	}
+
+	switch {
+	case summary.TotalSessions == 0:
+		fmt.Fprintln(w, "INFO  cost: no sessions recorded today yet")
+		return 0
+	case summary.EstimatedCostUSD == 0:
+		fmt.Fprintf(w, "WARN  cost: %d session(s) today but $0.00 computed "+
+			"(cost tracking may be dead -- see 'hookwise stats')\n", summary.TotalSessions)
+		return 1
+	default:
+		fmt.Fprintf(w, "PASS  cost: $%.2f across %d session(s) today\n",
+			summary.EstimatedCostUSD, summary.TotalSessions)
+		return 0
+	}
 }
 
 // getFeedInterval returns the configured interval_seconds for a feed name.

--- a/cmd/hookwise/cmd_doctor_cost_test.go
+++ b/cmd/hookwise/cmd_doctor_cost_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/analytics"
+)
+
+// TestCheckCostHonesty_SessionsButZeroCost is the doctor-honesty regression:
+// a session was recorded today but $0 cost was computed for it. This is the
+// exact signature of a dead cost writer (the failure that kept `hookwise stats`
+// and the cost status-line segment silently at $0). doctor must WARN, not pass
+// silently. A started-but-never-costed session reproduces it directly — no
+// EndSession, so estimated_cost_usd stays 0.
+func TestCheckCostHonesty_SessionsButZeroCost(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.StartSession(context.Background(), "cost-honesty-zero", time.Now().UTC()))
+	db.Close()
+
+	buf := &bytes.Buffer{}
+	warnings := checkCostHonesty(buf, dbPath)
+
+	out := buf.String()
+	assert.Equal(t, 1, warnings, "a recorded session with $0 cost must produce exactly one warning")
+	assert.Contains(t, out, "WARN  cost:")
+	assert.Contains(t, out, "$0.00 computed",
+		"warning must name the zero-cost-despite-sessions condition")
+}
+
+// TestCheckCostHonesty_SessionsWithCost verifies the healthy path: sessions
+// recorded AND non-zero cost computed → PASS, no warning. This is the
+// discriminating negative — it must NOT fire the dead-writer warning when the
+// writer is alive.
+func TestCheckCostHonesty_SessionsWithCost(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	ctx := context.Background()
+	require.NoError(t, a.StartSession(ctx, "cost-honesty-live", time.Now().UTC()))
+	require.NoError(t, a.EndSession(ctx, "cost-honesty-live", time.Now().UTC(),
+		analytics.SessionStats{EstimatedCostUSD: 12.34}))
+	db.Close()
+
+	buf := &bytes.Buffer{}
+	warnings := checkCostHonesty(buf, dbPath)
+
+	out := buf.String()
+	assert.Equal(t, 0, warnings, "a session with non-zero cost must not warn")
+	assert.Contains(t, out, "PASS  cost: $12.34 across 1 session(s) today")
+	assert.NotContains(t, out, "WARN")
+}
+
+// TestCheckCostHonesty_NoSessions verifies that an empty/idle install (no
+// sessions today) is INFO, not WARN — $0 with zero sessions is genuinely "no
+// work yet", not a dead writer. Warning here would be a false-positive nag on
+// every fresh install.
+func TestCheckCostHonesty_NoSessions(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db := openTestDB(t, dbPath)
+	db.Close() // schema created, but no sessions recorded
+
+	buf := &bytes.Buffer{}
+	warnings := checkCostHonesty(buf, dbPath)
+
+	out := buf.String()
+	assert.Equal(t, 0, warnings, "no sessions today must not warn")
+	assert.Contains(t, out, "INFO  cost: no sessions recorded today yet")
+	assert.NotContains(t, out, "WARN")
+}
+
+// TestCheckCostHonesty_NoDB verifies graceful no-op when the analytics DB does
+// not yet exist — the analytics check already reports DB absence, so the cost
+// check must stay silent (zero output, zero warnings) rather than double-report
+// or crash.
+func TestCheckCostHonesty_NoDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "does-not-exist.db")
+
+	buf := &bytes.Buffer{}
+	warnings := checkCostHonesty(buf, dbPath)
+
+	assert.Equal(t, 0, warnings)
+	assert.Empty(t, buf.String(), "absent DB must produce no cost output (analytics check owns that report)")
+}


### PR DESCRIPTION
## What

`hookwise doctor` had **no cost-tracking check**. The dead-`$0`-writer bug that motivated the whole cost-writer port had no diagnostic canary — doctor would happily report everything green while cost was silently broken.

Adds a `checkCostHonesty` doctor check (Check 8):

| Today's state | Output |
|---|---|
| sessions recorded **but `$0` computed** | `WARN  cost: N session(s) today but $0.00 computed (cost tracking may be dead -- see 'hookwise stats')` |
| no sessions yet | `INFO  cost: no sessions recorded today yet` (no false-positive nag on fresh installs) |
| sessions + non-zero cost | `PASS  cost: $X.XX across N session(s) today` |

This mirrors the existing feed zero-liveness principle (`feedZeroLivenessReason`): *cache/sessions present ≠ data present*.

## Why this source

Reads `DailySummary` (sessions table) for `time.Now().UTC()` — the **same source `hookwise stats` and the status-line segment use**. So doctor agrees with what the user actually sees in `stats`, and it sidesteps the known dispatch local-vs-UTC `CostState.Today` quirk entirely.

## TDD

- Test written first (red — helper undefined), then implemented (green).
- 4 subtests: zero-cost-with-sessions → WARN; non-zero → PASS; no sessions → INFO; absent DB → silent no-op (the analytics check owns DB-absence reporting).
- Zero-cost repro is a started-but-never-costed session — the literal dead-writer scenario.

## Verification

- `GOMEMLIMIT=4GiB go test -race -p 2` on `cmd/hookwise/`: all 4 cost subtests pass; full package green (no doctor-output regression).
- 0 `hookwise.test` zombies throughout.

## Scope

Doctor command only — no PostToolUse hot path, no daemon coordination, no analytics write path touched. Additive read-only check. Respects ARCH-1..7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)