### PR TITLE
test(cost): cover Rates override flowing through Stop seam

### DIFF
--- a/cmd/hookwise/cmd_dispatch_cost_test.go
+++ b/cmd/hookwise/cmd_dispatch_cost_test.go
@@ -296,3 +296,44 @@ func TestRecordAnalytics_CostStop_NoTranscript(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0.0, summary.EstimatedCostUSD, "EstimatedCostUSD must be 0 with no transcript")
 }
+
+// TestRecordAnalytics_CostStop_RatesOverride verifies the CostTrackingConfig.Rates
+// override flows end-to-end through the Stop seam: config -> ComputeWithRates
+// (cmd_dispatch.go:211) -> recorded cost state. pricing_test.go covers
+// ComputeWithRates in isolation, but nothing proves dispatch actually PASSES
+// costCfg.Rates through. A refactor that dropped the Rates arg (passing nil) would
+// pass every pricing unit test while silently disabling user rate overrides -- the
+// dead-feature class this whole cost port exists to prevent. Override sonnet.input
+// $3 -> $99: the $18 fixture ($3 in + $15 out, 1M each) must now record $114
+// ($99 in + $15 out), not the built-in $18.
+func TestRecordAnalytics_CostStop_RatesOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	transcriptPath := writeSonnetFixture(t)
+	sid := "cost-test-session-rates"
+
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.StartSession(context.Background(), sid, time.Now()))
+	db.Close()
+
+	const overriddenCost = 114.00 // $99 input (overridden from $3) + $15 output
+	costCfg := core.CostTrackingConfig{
+		Enabled: true,
+		Rates:   map[string]float64{"sonnet.input": 99.0},
+	}
+	payload := core.HookPayload{SessionID: sid, TranscriptPath: transcriptPath}
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+
+	db = openTestDB(t, dbPath)
+	defer db.Close()
+
+	state, err := db.ReadCostState(context.Background())
+	require.NoError(t, err)
+	assert.InDelta(t, overriddenCost, state.SessionCosts[sid], 0.001,
+		"override sonnet.input=$99 must reach SessionCosts[sid]; default $18 means Rates was not passed through")
+	assert.InDelta(t, overriddenCost, state.TotalToday, 0.001,
+		"override must also flow into TotalToday")
+}


### PR DESCRIPTION
## What

Adds `TestRecordAnalytics_CostStop_RatesOverride` — an **end-to-end** test that a `CostTrackingConfig.Rates` override actually flows config → `pricing.ComputeWithRates` → recorded cost state through the dispatch Stop seam.

## Why

`pricing_test.go` covers `ComputeWithRates` in isolation, but **nothing proved `recordAnalytics` actually passes `costCfg.Rates` through** (`cmd_dispatch.go:211`). A refactor that dropped the arg (passing `nil`) would pass every pricing unit test while **silently disabling user rate overrides** — the exact dead-feature class this cost port exists to prevent.

## The test

Override `sonnet.input` from the built-in `$3` to `$99`. The `$18` Sonnet fixture (1M in + 1M out) must then record **`$114`** (`$99` in + `$15` out) in both `SessionCosts[sid]` and `TotalToday` — not the built-in `$18`.

## Non-vacuous (mutation-verified)

This is a coverage test on already-correct code, so I proved it bites: temporarily changed line 211 to pass `nil` overrides → test **fails** (`$18` vs `$114`, diff `$96`) → restored. **Test-only change; `cmd_dispatch.go` is byte-identical to main.**

## Verification

- `GOMEMLIMIT=4GiB go test -race -p 2` on `cmd/hookwise/`: full package green.
- 0 `hookwise.test` zombies throughout.

## Scope

Pure test addition on the cost-port surface. No production code, no hot path, no daemon. Respects ARCH-1..7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to validate that cost tracking correctly applies rate overrides and accurately reflects the overridden pricing in analytics records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->