### PR TITLE
test(config): cover SegmentConfig dual-form YAML unmarshal

### DIFF
--- a/internal/core/segment_config_test.go
+++ b/internal/core/segment_config_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// SegmentConfig.UnmarshalYAML (types.go) is a custom unmarshaller giving status-
+// line segments dual-form polymorphism: a segment may be a bare string ("- cost")
+// OR a full struct ("- builtin: cost" / "- custom: {command: ...}"). It had zero
+// unit coverage. This is a silent-fail-open surface: a regression in the bare-
+// string-then-struct-fallback logic would parse valid configs wrong, and ARCH-1
+// fail-open would hide it (no status-line output, exit 0). These tests pin both
+// forms and their coexistence.
+
+func TestSegmentConfig_UnmarshalYAML_BareString(t *testing.T) {
+	var slc StatusLineConfig
+	require.NoError(t, yaml.Unmarshal([]byte("segments:\n  - cost\n  - news\n"), &slc))
+
+	require.Len(t, slc.Segments, 2)
+	assert.Equal(t, "cost", slc.Segments[0].Builtin, "a bare string segment must populate Builtin")
+	assert.Nil(t, slc.Segments[0].Custom, "a bare string segment must not create a Custom struct")
+	assert.Equal(t, "news", slc.Segments[1].Builtin)
+}
+
+func TestSegmentConfig_UnmarshalYAML_Struct(t *testing.T) {
+	y := "segments:\n" +
+		"  - builtin: cost\n" +
+		"  - custom:\n" +
+		"      command: ./my-seg.sh\n" +
+		"      label: MySeg\n"
+	var slc StatusLineConfig
+	require.NoError(t, yaml.Unmarshal([]byte(y), &slc))
+
+	require.Len(t, slc.Segments, 2)
+	assert.Equal(t, "cost", slc.Segments[0].Builtin, "an explicit {builtin:} struct must populate Builtin")
+	require.NotNil(t, slc.Segments[1].Custom, "a {custom:} struct must deserialize into Custom")
+	assert.Equal(t, "./my-seg.sh", slc.Segments[1].Custom.Command)
+	assert.Equal(t, "MySeg", slc.Segments[1].Custom.Label)
+	assert.Empty(t, slc.Segments[1].Builtin, "a custom segment must not also set Builtin")
+}
+
+func TestSegmentConfig_UnmarshalYAML_Mixed(t *testing.T) {
+	// Bare string and full struct coexisting in one array — the form the bug
+	// class most likely breaks, since it exercises both the string branch and
+	// the struct fallback within a single sequence decode.
+	y := "segments:\n" +
+		"  - cost\n" +
+		"  - custom:\n" +
+		"      command: ./x.sh\n"
+	var slc StatusLineConfig
+	require.NoError(t, yaml.Unmarshal([]byte(y), &slc))
+
+	require.Len(t, slc.Segments, 2)
+	assert.Equal(t, "cost", slc.Segments[0].Builtin)
+	assert.Nil(t, slc.Segments[0].Custom)
+	require.NotNil(t, slc.Segments[1].Custom)
+	assert.Equal(t, "./x.sh", slc.Segments[1].Custom.Command)
+	assert.Empty(t, slc.Segments[1].Builtin)
+}


### PR DESCRIPTION
## What

Adds `internal/core/segment_config_test.go` — unit coverage for `SegmentConfig.UnmarshalYAML`, the custom unmarshaller that lets a status-line segment be written **either** as a bare string (`- cost`) **or** a full struct (`- builtin: cost` / `- custom: {command: ...}`). It had **zero** unit tests.

## Why

This is a documented config gotcha and a **silent-fail-open** surface: a regression in the bare-string-then-struct-fallback logic would parse valid configs wrong, and ARCH-1 fail-open would hide it entirely (no status-line output, exit 0). Worth pinning.

Three tests:
- **BareString** — `- cost` populates `Builtin`, leaves `Custom` nil
- **Struct** — `- builtin:` / `- custom: {command, label}` deserialize into the right fields
- **Mixed** — both forms coexist in one array (exercises the string branch *and* the struct fallback in a single sequence decode — where the bug class most likely bites)

## Non-vacuous (mutation-verified)

Coverage test on already-correct code, so I proved it bites: temporarily neutered the bare-string capture (`s.Builtin = str` → `""`) → **BareString + Mixed fail**, Struct still passes (it uses the struct fallback) → restored. **Test-only change; `types.go` is byte-identical to main.**

## Verification

- `GOMEMLIMIT=4GiB go test -race -p 2` on `internal/core/`: full package green.
- 0 `hookwise.test` zombies throughout.

## Scope

Pure test addition. No production code, no hot path, no daemon. Respects ARCH-1..7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)