### PR TITLE
fix(feeds): return nil windSpeed in unavailable weather fallback

### DIFF
--- a/internal/feeds/producer_weather.go
+++ b/internal/feeds/producer_weather.go
@@ -181,7 +181,7 @@ func (p *WeatherProducer) fallbackResult(reason string) map[string]interface{} {
 	return NewEnvelope("weather", map[string]interface{}{
 		"temperature":     nil,
 		"temperatureUnit": unit,
-		"windSpeed":       0,
+		"windSpeed":       nil,
 		"weatherCode":     nil,
 		"emoji":           "\U0001f324\ufe0f",
 		"description":     "Unavailable",

--- a/internal/feeds/producer_weather_test.go
+++ b/internal/feeds/producer_weather_test.go
@@ -1,0 +1,33 @@
+package feeds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWeatherProducer_FallbackNoCache_NilNumerics pins the documented contract of
+// fallbackResult (producer_weather.go): when the Open-Meteo API is unavailable
+// AND no prior result is cached, every NUMERIC reading must be nil so consumers
+// render "--" rather than interpreting a literal 0 as a real measurement.
+// windSpeed was the one numeric field set to 0, breaking the symmetry with
+// temperature/weatherCode and the function's own "nil numerics" comment -- a
+// cross-boundary 0-vs-nil bug (the Go->JSON->Python class, cf. weather bug #29):
+// the TUI would show "0 mph" wind while the rest of the panel reads unavailable.
+func TestWeatherProducer_FallbackNoCache_NilNumerics(t *testing.T) {
+	p := &WeatherProducer{} // no cached lastResult, zero config
+
+	env := p.fallbackResult("test: api down")
+	data, ok := env["data"].(map[string]interface{})
+	require.True(t, ok, "envelope must carry a data map")
+
+	assert.Nil(t, data["temperature"], "temperature must be nil when unavailable")
+	assert.Nil(t, data["weatherCode"], "weatherCode must be nil when unavailable")
+	assert.Nil(t, data["windSpeed"],
+		"windSpeed must be nil when unavailable, not 0 (a literal 0 reads as a real 0 mph reading)")
+
+	// The unit label is descriptive, not a numeric reading — it stays populated.
+	assert.Equal(t, "fahrenheit", data["temperatureUnit"])
+	assert.Equal(t, "Unavailable", data["description"])
+}


### PR DESCRIPTION
## The bug

`WeatherProducer.fallbackResult()` (the path taken when the Open-Meteo API fails **and** nothing is cached yet) sets:

```go
"temperature":     nil,
"windSpeed":       0,    // ← inconsistent
"weatherCode":     nil,
```

…while the function's own comment, twice, promises *"nil numerics so consumers show `--` instead of interpreting 0 as a real reading."* `windSpeed` was the one numeric field breaking that contract.

**Impact:** on weather-API-failure-with-no-cache, the TUI renders **"0 mph" wind** next to an otherwise-"Unavailable" panel — a literal 0 masquerading as a real measurement. This is the Go→JSON→Python 0-vs-nil semantic class (weather bug #29).

## The fix

One line: `"windSpeed": 0` → `"windSpeed": nil`, restoring symmetry with `temperature`/`weatherCode`.

## Why it's safe

- The Go status-line segment doesn't read `windSpeed` at all (grep-confirmed).
- `temperature` and `weatherCode` are **already** nil in this path, so every consumer already handles nil weather fields — `windSpeed→nil` is consistent, not new behavior.
- `WeatherTestFixture` (the static fixture bridge tests bind to) is **untouched** — only the fallback path changed.

## TDD

Genuine red→green from the real bug (no mutation dance): new `producer_weather_test.go` asserts all numeric fields are nil in the no-cache fallback — **fails** on `windSpeed: 0`, **passes** after the fix.

## Verification

- `GOMEMLIMIT=4GiB go test -race -p 2` on `internal/feeds/`: full package green.
- 0 `hookwise.test` zombies throughout.

## Scope

`internal/feeds` producer fallback only — no daemon coordination, no hot path, no live-network test. Respects ARCH-1..7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weather data display to show "--" for unavailable numeric values (temperature, wind speed) instead of displaying "0", preventing users from misinterpreting missing data as actual measurements while keeping unit information properly displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->