### PR TITLE
fix(status): project segment reads producer fields (name/dirty/ts)

### DIFF
--- a/internal/feeds/producer_project.go
+++ b/internal/feeds/producer_project.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -57,21 +58,33 @@ func ProjectInfo(ctx context.Context, dir string) map[string]interface{} {
 	commit, _ := gitOutput(ctx, dir, "rev-parse", "--short", "HEAD")
 	porcelain, perr := gitOutput(ctx, dir, "status", "--porcelain")
 
-	return map[string]interface{}{
+	info := map[string]interface{}{
 		"name":        filepath.Base(repoRoot),
 		"branch":      branch,
 		"last_commit": commit,
 		"dirty":       perr == nil && porcelain != "",
+		// last_commit_ts is the committer epoch (seconds) of HEAD. The status
+		// line renders it as a "Xm ago" suffix; nil when unavailable so the
+		// suffix is simply omitted. Keeping the key always-present keeps the
+		// shape uniform with the fixture (cross-boundary parity, issue #155).
+		"last_commit_ts": nil,
 	}
+	if ctStr, cerr := gitOutput(ctx, dir, "log", "-1", "--format=%ct"); cerr == nil {
+		if ts, perr := strconv.ParseInt(ctStr, 10, 64); perr == nil {
+			info["last_commit_ts"] = ts
+		}
+	}
+	return info
 }
 
 // emptyProjectInfo returns the zero-value project data (ARCH-1 fail-open shape).
 func emptyProjectInfo() map[string]interface{} {
 	return map[string]interface{}{
-		"name":        "",
-		"branch":      "",
-		"last_commit": "",
-		"dirty":       false,
+		"name":           "",
+		"branch":         "",
+		"last_commit":    "",
+		"dirty":          false,
+		"last_commit_ts": nil,
 	}
 }
 
@@ -90,9 +103,10 @@ func gitOutput(ctx context.Context, dir string, args ...string) (string, error) 
 // cross-package tests. Shared fixture so tests bind to actual field names.
 func ProjectTestFixture() map[string]interface{} {
 	return NewEnvelopeAt("project", map[string]interface{}{
-		"name":        "hookwise",
-		"branch":      "main",
-		"last_commit": "abc1234",
-		"dirty":       false,
+		"name":           "hookwise",
+		"branch":         "main",
+		"last_commit":    "abc1234",
+		"dirty":          false,
+		"last_commit_ts": int64(1772877600), // 2026-03-07T10:00:00Z
 	}, time.Date(2026, 3, 7, 10, 0, 0, 0, time.UTC))
 }

--- a/tui/hookwise_tui/tabs/status.py
+++ b/tui/hookwise_tui/tabs/status.py
@@ -456,12 +456,12 @@ class StatusTab(Widget):
             return str(entry.get("text", ""))
 
         if seg == "project":
-            repo = entry.get("repo", "")
+            repo = entry.get("name", "")
             if not repo:
                 return ""
             branch = entry.get("branch", "unknown")
-            if entry.get("detached"):
-                branch = "detached"
+            if entry.get("dirty"):
+                branch = f"{branch}*"
             parts = [f"\U0001f4e6 {repo} ({branch})"]
             ts = entry.get("last_commit_ts")
             if ts is not None:

--- a/tui/tests/test_status_segments.py
+++ b/tui/tests/test_status_segments.py
@@ -61,3 +61,53 @@ class TestCalendarSegment:
             "next_event must render the producer's 'name'; reading 'title' falls "
             "through to 'Free' (issue #155)"
         )
+
+
+class TestProjectSegment:
+    """The project producer emits name/branch/last_commit/dirty/last_commit_ts;
+    the renderer must read those, not repo/detached (issue #155)."""
+
+    def test_renders_repo_name_from_producer_name_field(self):
+        # Mirrors feeds.ProjectTestFixture(): the repo identity key is 'name'.
+        cache = {
+            "project": {
+                "name": "hookwise",
+                "branch": "main",
+                "last_commit": "abc1234",
+                "dirty": False,
+            }
+        }
+        out = StatusTab._render_segment("project", cache)
+        assert "hookwise" in out, (
+            "project must render the producer's 'name'; reading 'repo' gates the "
+            "segment to empty (issue #155)"
+        )
+        assert "main" in out
+
+    def test_marks_dirty_working_tree(self):
+        # The producer emits 'dirty' (working-tree state), not 'detached'.
+        cache = {"project": {"name": "hookwise", "branch": "main", "dirty": True}}
+        out = StatusTab._render_segment("project", cache)
+        assert "hookwise" in out
+        assert "*" in out, "a dirty working tree must show a '*' marker (issue #155)"
+
+    def test_clean_tree_has_no_dirty_marker(self):
+        cache = {"project": {"name": "hookwise", "branch": "main", "dirty": False}}
+        out = StatusTab._render_segment("project", cache)
+        assert "*" not in out, "a clean tree must not show the dirty marker"
+
+    def test_renders_commit_age_from_last_commit_ts(self):
+        # The producer now emits 'last_commit_ts' (committer epoch); the renderer
+        # turns it into an "Xm ago" suffix. Binds the new producer field name to
+        # its consumer so it can't silently drift (issue #155).
+        import time
+
+        cache = {
+            "project": {
+                "name": "hookwise",
+                "branch": "main",
+                "last_commit_ts": int(time.time()) - 120,  # 2 minutes ago
+            }
+        }
+        out = StatusTab._render_segment("project", cache)
+        assert "ago" in out, "last_commit_ts must render an 'ago' suffix"


### PR DESCRIPTION
Part of #155 (project half; calendar half shipped in #156). Canonical side per maintainer decision: **Python adapts to the Go producer.**

## Bug
The project status-line renderer reads `repo` / `detached`, but the Go producer emits `name` / `dirty`. `FlattenForTUI` spreads producer fields verbatim (no rename layer), and the renderer **gates** on `repo` (`if not repo: return ""`), so the **project segment rendered empty in production**. The "Xm ago" suffix also never showed because the producer never emitted a commit timestamp.

## Fix
- **`status.py`**: read `name` (un-gates the segment); show a `*` marker when `dirty` instead of the never-emitted `detached` relabel.
- **`producer_project.go`**: emit `last_commit_ts` (committer epoch via `git log -1 --format=%ct`) so the renderer's existing "Xm ago" suffix gets real data. Key is always present (nil when unavailable) to keep fixture/shape parity.
- **`ProjectTestFixture` + `emptyProjectInfo`**: carry `last_commit_ts`. `TestProjectTestFixture_FieldConsistency` auto-validates producer↔fixture key parity (bidirectional).
- **`test_status_segments.py`**: project renders `name`, the dirty marker, and the ago suffix (red→green for name + dirty).

## Verification
- New project tests fail on `main` (segment empty), pass after the fix.
- Go: `TestProject*` + `FieldConsistency` green under `-race -p 2`, 0 zombies.
- Python: full `test_status_segments` + `test_status_live_output` + `test_data` = 57 pass.
- Note: `TestDaemon_ConcurrentStartOnlyOneWins` flaked once under full-package race load (socket-binding timing) but passes in isolation — unrelated to this diff (project producer only).

Final follow-up (PR 3) will add the Calendar/Project bridge field-name tests (the #154-class Go regression guards) and **close #155**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)