### PR TITLE
fix(guards): doctor-warn on empty substring guard value (#147)

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -438,6 +438,25 @@ func ValidateConfig(raw map[string]interface{}) ValidationResult {
 						Message: "guard rule must have a 'reason' string",
 					})
 				}
+				for _, condKey := range []string{"when", "unless"} {
+					condVal, hasKey := guard[condKey]
+					if !hasKey {
+						continue
+					}
+					expr := fmt.Sprintf("%v", condVal)
+					parsed := ParseCondition(expr)
+					if parsed == nil {
+						continue
+					}
+					substringOps := map[string]bool{"contains": true, "starts_with": true, "ends_with": true}
+					if substringOps[parsed.Operator] && parsed.Value == "" {
+						errors = append(errors, ValidationError{
+							Path:       fmt.Sprintf("guards[%d].%s", i, condKey),
+							Message:    fmt.Sprintf("guard condition uses %q with an empty value, which matches every field (likely an unintended match-all)", parsed.Operator),
+							Suggestion: "Provide a non-empty substring value, or use a different operator if a catch-all is truly intended",
+						})
+					}
+				}
 			}
 		}
 	}

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -664,6 +664,72 @@ func TestValidateConfig_GuardInvalidAction(t *testing.T) {
 	}
 }
 
+func TestValidateConfig_EmptySubstringGuardValue(t *testing.T) {
+	validGuard := func(condKey, condVal string) map[string]interface{} {
+		return map[string]interface{}{
+			"match":  "Bash",
+			"action": "warn",
+			"reason": "x",
+			condKey:  condVal,
+		}
+	}
+
+	errorsForPath := func(raw map[string]interface{}, path string) []ValidationError {
+		result := ValidateConfig(raw)
+		var out []ValidationError
+		for _, e := range result.Errors {
+			if e.Path == path {
+				out = append(out, e)
+			}
+		}
+		return out
+	}
+
+	// Positive cases: each substring operator with empty value must produce an error.
+	for _, op := range []string{"contains", "starts_with", "ends_with"} {
+		for _, condKey := range []string{"when", "unless"} {
+			expr := `command ` + op + ` ""`
+			path := "guards[0]." + condKey
+			raw := map[string]interface{}{
+				"guards": []interface{}{validGuard(condKey, expr)},
+			}
+			errs := errorsForPath(raw, path)
+			if len(errs) == 0 {
+				t.Errorf("operator=%q condKey=%q: expected ValidationError at path %q, got none", op, condKey, path)
+				continue
+			}
+			msg := errs[0].Message
+			if !strings.Contains(msg, "empty") && !strings.Contains(msg, "match-all") {
+				t.Errorf("operator=%q condKey=%q: expected message to mention 'empty' or 'match-all', got %q", op, condKey, msg)
+			}
+			if errs[0].Suggestion == "" {
+				t.Errorf("operator=%q condKey=%q: expected non-empty Suggestion", op, condKey)
+			}
+		}
+	}
+
+	// Negative cases: must NOT produce empty-substring error.
+	negativeCases := []struct {
+		label   string
+		condKey string
+		expr    string
+	}{
+		{"non-empty contains", "when", `command contains "rm"`},
+		{"equals with empty value", "when", `command == ""`},
+		{"matches with empty value", "when", `command matches ""`},
+	}
+	for _, tc := range negativeCases {
+		path := "guards[0]." + tc.condKey
+		raw := map[string]interface{}{
+			"guards": []interface{}{validGuard(tc.condKey, tc.expr)},
+		}
+		errs := errorsForPath(raw, path)
+		if len(errs) > 0 {
+			t.Errorf("case=%q: expected no empty-substring error at path %q, got %v", tc.label, path, errs)
+		}
+	}
+}
+
 // =============================================================================
 // Unit Tests: GetDefaultConfig
 // =============================================================================


### PR DESCRIPTION
## What

`hookwise doctor` now flags a guard condition that uses `contains` /
`starts_with` / `ends_with` with an **empty value** — e.g. `command contains ""`.

Go's `strings.Contains` / `HasPrefix` / `HasSuffix` all return `true` for an
empty needle, so such a condition silently matches **every** present field,
turning a narrow `block`/`warn`/`confirm` into a match-all. The dominant trigger
is an accidentally-empty value from config templating.

## Scope — Option C only (non-behavior-changing)

Issue #147 was filed (by the maintenance loop) as a **supervised** decision
because the two semantic fixes both have safety tradeoffs:

- **A** — reject empty value at parse → silently drops an *intended* catch-all (fail-open).
- **B** — eval empty substring → `false` → same dispatch-semantics shift.
- **C** — *(this PR)* surface it at validation/doctor time; runtime unchanged.

This PR implements **C only**. `EvaluateCondition` (the PreToolUse dispatch
path) is deliberately untouched, so runtime guard behavior is identical and the
A-vs-B decision stays open for a supervised call. The change lives in
`ValidateConfig`, which is called by `cmd doctor` and is **not** on the dispatch
path (verified).

## Tests

`TestValidateConfig_EmptySubstringGuardValue` (internal/core):
- Positive: all 3 substring operators × `when`/`unless` → error at `guards[i].<key>`.
- Negative: non-empty `contains`, `== ""`, `matches ""` → not flagged.

Verified with the guarded gate (`GOMEMLIMIT=4GiB go test -race -p 2 ./internal/core/`);
mutation-red confirmed the test guards the new logic. Full `internal/core` green.

Closes #147 partially (Option C). Leaves the A-vs-B runtime-semantics decision open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)