### PR TITLE
fix(guards): doctor-warn on malformed guard when/unless condition

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -440,12 +440,21 @@ func ValidateConfig(raw map[string]interface{}) ValidationResult {
 				}
 				for _, condKey := range []string{"when", "unless"} {
 					condVal, hasKey := guard[condKey]
-					if !hasKey {
+					if !hasKey || condVal == nil {
 						continue
 					}
-					expr := fmt.Sprintf("%v", condVal)
+					expr := strings.TrimSpace(fmt.Sprintf("%v", condVal))
+					if expr == "" {
+						// empty/absent condition means "no condition" — not an error
+						continue
+					}
 					parsed := ParseCondition(expr)
 					if parsed == nil {
+						errors = append(errors, ValidationError{
+							Path:       fmt.Sprintf("guards[%d].%s", i, condKey),
+							Message:    "guard condition is malformed and will be silently ignored at runtime (the rule will not match as intended)",
+							Suggestion: "Use the form: field_path operator value (operators: contains, starts_with, ends_with, ==, equals, matches)",
+						})
 						continue
 					}
 					substringOps := map[string]bool{"contains": true, "starts_with": true, "ends_with": true}

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -1728,6 +1728,131 @@ daemon:
 	}
 }
 
+func TestValidateConfig_MalformedGuardCondition(t *testing.T) {
+	validGuard := func(condKey, condVal string) map[string]interface{} {
+		return map[string]interface{}{
+			"match":  "Bash",
+			"action": "warn",
+			"reason": "x",
+			condKey:  condVal,
+		}
+	}
+
+	errorsForPath := func(raw map[string]interface{}, path string) []ValidationError {
+		result := ValidateConfig(raw)
+		var out []ValidationError
+		for _, e := range result.Errors {
+			if e.Path == path {
+				out = append(out, e)
+			}
+		}
+		return out
+	}
+
+	// Positive cases: malformed expressions must produce a "malformed" error.
+	positiveCases := []struct {
+		label   string
+		condKey string
+		expr    string
+	}{
+		{"operator typo when", "when", `command containss "x"`},
+		{"operator typo unless", "unless", `command containss "x"`},
+		{"missing field path when", "when", `contains "x"`},
+		{"garbage expression when", "when", `this is not a condition`},
+	}
+	for _, tc := range positiveCases {
+		path := "guards[0]." + tc.condKey
+		raw := map[string]interface{}{
+			"guards": []interface{}{validGuard(tc.condKey, tc.expr)},
+		}
+		errs := errorsForPath(raw, path)
+		if len(errs) == 0 {
+			t.Errorf("case=%q: expected ValidationError at path %q, got none", tc.label, path)
+			continue
+		}
+		msg := errs[0].Message
+		if !strings.Contains(msg, "malformed") {
+			t.Errorf("case=%q: expected message to mention 'malformed', got %q", tc.label, msg)
+		}
+		if errs[0].Suggestion == "" {
+			t.Errorf("case=%q: expected non-empty Suggestion", tc.label)
+		}
+	}
+
+	// Negative cases: valid and absent conditions must NOT produce a "malformed" error.
+	negativeCases := []struct {
+		label   string
+		condKey string
+		expr    string
+	}{
+		{"valid contains", "when", `command contains "rm"`},
+		{"valid equals", "when", `tool_input.command == "git"`},
+	}
+	for _, tc := range negativeCases {
+		path := "guards[0]." + tc.condKey
+		raw := map[string]interface{}{
+			"guards": []interface{}{validGuard(tc.condKey, tc.expr)},
+		}
+		errs := errorsForPath(raw, path)
+		for _, e := range errs {
+			if strings.Contains(e.Message, "malformed") {
+				t.Errorf("case=%q: expected no 'malformed' error, got %q", tc.label, e.Message)
+			}
+		}
+	}
+
+	// Guard with no "when" key at all — must not produce a malformed error.
+	{
+		noCondGuard := map[string]interface{}{
+			"match":  "Bash",
+			"action": "warn",
+			"reason": "x",
+		}
+		raw := map[string]interface{}{
+			"guards": []interface{}{noCondGuard},
+		}
+		for _, e := range ValidateConfig(raw).Errors {
+			if strings.Contains(e.Message, "malformed") {
+				t.Errorf("guard with no condition key: expected no 'malformed' error, got %q at %q", e.Message, e.Path)
+			}
+		}
+	}
+
+	// Guard with empty string "when" — not malformed (means "no condition").
+	{
+		emptyCondGuard := validGuard("when", "")
+		raw := map[string]interface{}{
+			"guards": []interface{}{emptyCondGuard},
+		}
+		for _, e := range ValidateConfig(raw).Errors {
+			if e.Path == "guards[0].when" && strings.Contains(e.Message, "malformed") {
+				t.Errorf("empty-string condition: expected no 'malformed' error, got %q", e.Message)
+			}
+		}
+	}
+
+	// The existing empty-substring case: "command contains """ should be flagged
+	// with "empty"/"match-all" message, NOT "malformed".
+	{
+		path := "guards[0].when"
+		raw := map[string]interface{}{
+			"guards": []interface{}{validGuard("when", `command contains ""`)},
+		}
+		errs := errorsForPath(raw, path)
+		if len(errs) == 0 {
+			t.Errorf("empty-substring case: expected at least one error at %q", path)
+		} else {
+			msg := errs[0].Message
+			if strings.Contains(msg, "malformed") {
+				t.Errorf("empty-substring case: message should not contain 'malformed', got %q", msg)
+			}
+			if !strings.Contains(msg, "empty") && !strings.Contains(msg, "match-all") {
+				t.Errorf("empty-substring case: expected message to mention 'empty' or 'match-all', got %q", msg)
+			}
+		}
+	}
+}
+
 // =============================================================================
 // Test helpers
 // =============================================================================


### PR DESCRIPTION
## What

`hookwise doctor` now flags a guard `when`/`unless` condition that fails to
parse — e.g. an operator typo (`command containss "x"`) or a missing field path
(`contains "x"`).

## Why

In `Evaluate` (internal/core/guards.go), a malformed condition makes
`EvaluateCondition` return `nil`, which is treated as **no-match**:

- a malformed **`when`** → the rule is silently skipped → a `block` guard
  **never fires** (the author believes they're protected; they aren't).
- a malformed **`unless`** → the skip check is false → the rule silently
  **over-fires** (the intended exception is ignored).

Either way a typo'd safety rule fails silently, and `ValidateConfig` did not
catch it. This is the natural completion of the #147/#160 condition-validation
work (which only covered the empty-substring case).

## Scope — validation-time only (non-behavior-changing)

The change is in `ValidateConfig`, called by `cmd doctor` and **not** on the
dispatch path. `EvaluateCondition` / `Evaluate` are untouched — runtime guard
behavior is identical. An empty/absent `when`/`unless` still means "no
condition" and is **not** flagged.

## Tests

`TestValidateConfig_MalformedGuardCondition` (internal/core):
- Positive (flagged "malformed"): operator typo on `when` and `unless`, missing
  field path, garbage expression.
- Negative (not flagged): valid conditions, no `when` key, empty `when: ""`, and
  `contains ""` (which is flagged by the existing empty-value branch, not this one).

Verified with the guarded gate (`GOMEMLIMIT=4GiB go test -race -p 2 ./internal/core/`,
0 zombies); mutation-red confirmed the test guards the new logic. Full
`internal/core` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)