### PR TITLE
fix(guards): doctor-warn on invalid regex in matches condition

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -465,6 +465,15 @@ func ValidateConfig(raw map[string]interface{}) ValidationResult {
 							Suggestion: "Provide a non-empty substring value, or use a different operator if a catch-all is truly intended",
 						})
 					}
+					if parsed.Operator == "matches" {
+						if _, reErr := regexp.Compile(parsed.Value); reErr != nil {
+							errors = append(errors, ValidationError{
+								Path:       fmt.Sprintf("guards[%d].%s", i, condKey),
+								Message:    fmt.Sprintf("guard condition has an invalid regular expression %q: %v (the rule will never match at runtime)", parsed.Value, reErr),
+								Suggestion: "Fix the regex pattern, or use contains/starts_with/ends_with for a literal substring match",
+							})
+						}
+					}
 				}
 			}
 		}

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -1853,6 +1853,83 @@ func TestValidateConfig_MalformedGuardCondition(t *testing.T) {
 	}
 }
 
+func TestValidateConfig_InvalidRegexGuardCondition(t *testing.T) {
+	validGuard := func(condKey, condVal string) map[string]interface{} {
+		return map[string]interface{}{
+			"match":  "Bash",
+			"action": "warn",
+			"reason": "x",
+			condKey:  condVal,
+		}
+	}
+
+	errorsForPath := func(raw map[string]interface{}, path string) []ValidationError {
+		result := ValidateConfig(raw)
+		var out []ValidationError
+		for _, e := range result.Errors {
+			if e.Path == path {
+				out = append(out, e)
+			}
+		}
+		return out
+	}
+
+	// Positive cases: matches operator with invalid regex must produce an error
+	// whose Message mentions "regex" or "regular expression".
+	positiveCases := []struct {
+		label   string
+		condKey string
+		expr    string
+	}{
+		{"unclosed char class when", "when", `command matches "["`},
+		{"unclosed group when", "when", `command matches "("`},
+		{"unclosed group unless", "unless", `command matches "("`},
+		{"bare repetition when", "when", `command matches "*"`},
+	}
+	for _, tc := range positiveCases {
+		path := "guards[0]." + tc.condKey
+		raw := map[string]interface{}{
+			"guards": []interface{}{validGuard(tc.condKey, tc.expr)},
+		}
+		errs := errorsForPath(raw, path)
+		if len(errs) == 0 {
+			t.Errorf("case=%q: expected ValidationError at path %q, got none", tc.label, path)
+			continue
+		}
+		msg := errs[0].Message
+		if !strings.Contains(msg, "regex") && !strings.Contains(msg, "regular expression") {
+			t.Errorf("case=%q: expected message to mention 'regex' or 'regular expression', got %q", tc.label, msg)
+		}
+		if errs[0].Suggestion == "" {
+			t.Errorf("case=%q: expected non-empty Suggestion", tc.label)
+		}
+	}
+
+	// Negative cases: must NOT produce a regex error at the guard path.
+	negativeCases := []struct {
+		label   string
+		condKey string
+		expr    string
+	}{
+		{"valid regex rm.*", "when", `command matches "rm.*"`},
+		{"valid regex .*", "when", `command matches ".*"`},
+		{"contains with literal [", "when", `command contains "["`},
+		{"equals with literal [", "when", `command == "["`},
+	}
+	for _, tc := range negativeCases {
+		path := "guards[0]." + tc.condKey
+		raw := map[string]interface{}{
+			"guards": []interface{}{validGuard(tc.condKey, tc.expr)},
+		}
+		errs := errorsForPath(raw, path)
+		for _, e := range errs {
+			if strings.Contains(e.Message, "regex") || strings.Contains(e.Message, "regular expression") {
+				t.Errorf("case=%q: expected no regex error at path %q, got %q", tc.label, path, e.Message)
+			}
+		}
+	}
+}
+
 // =============================================================================
 // Test helpers
 // =============================================================================


### PR DESCRIPTION
## What

`hookwise doctor` now flags a guard `when`/`unless` condition that uses the
`matches` operator with an **invalid regular expression** — e.g.
`command matches "["`.

## Why

A `matches` condition compiles its regex only at dispatch (`guards.go`). An
invalid pattern fails `regexp.Compile`, `EvaluateCondition` returns `false`, and
the rule **silently never matches** — a `block` guard that doesn't protect.
`ParseCondition` accepts the expression (it's syntactically valid — operator
`matches`, value `[`), so the malformed-condition check from #161 does **not**
catch it.

This completes the validation-time guard-condition-correctness trilogy:
- #160 — empty substring value (match-all footgun)
- #161 — malformed/unparseable condition
- **this** — syntactically-valid condition with an invalid regex

## Scope — validation-time only (non-behavior-changing)

The check lives in `ValidateConfig` (called by `cmd doctor`, **not** on the
dispatch path). `EvaluateCondition` / `Evaluate` are untouched; runtime guard
behavior is identical. Non-`matches` operators treat `[` as a literal and are
not flagged.

## Tests

`TestValidateConfig_InvalidRegexGuardCondition` (internal/core):
- Positive: unclosed char class `[`, unclosed group `(` (when + unless), bare
  repetition `*`.
- Negative: valid regexes (`rm.*`, `.*`), and `[` under `contains`/`==` (literal,
  not flagged).

Verified with the guarded gate (`GOMEMLIMIT=4GiB go test -race -p 2 ./internal/core/`,
0 zombies); mutation-red confirmed the test guards the new logic. Full
`internal/core` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)