### PR TITLE
fix(guards): doctor-warn on invalid glob in match pattern

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/gobwas/glob"
 	"gopkg.in/yaml.v3"
 )
 
@@ -423,6 +424,18 @@ func ValidateConfig(raw map[string]interface{}) ValidationResult {
 						Message:    "guard rule must have a 'match' string",
 						Suggestion: "Add match: 'tool_name:Bash' or similar glob pattern",
 					})
+				}
+				if match, ok := guard["match"]; ok && match != nil {
+					matchStr := fmt.Sprintf("%v", match)
+					if matchStr != "" && hasGlobChars(matchStr) {
+						if _, gErr := glob.Compile(matchStr); gErr != nil {
+							errors = append(errors, ValidationError{
+								Path:       fmt.Sprintf("guards[%d].match", i),
+								Message:    fmt.Sprintf("guard match %q is an invalid glob pattern: %v (the rule will never match any tool at runtime)", matchStr, gErr),
+								Suggestion: "Fix the glob pattern (e.g. close '[' and '{' groups), or use a plain tool name for an exact match",
+							})
+						}
+					}
 				}
 				action, actionOk := guard["action"]
 				if !actionOk || !isValidGuardAction(fmt.Sprintf("%v", action)) {

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -2079,3 +2079,79 @@ func TestGetDefaultConfig_StructIntegrity(t *testing.T) {
 		t.Errorf("expected struct, got %v", v.Kind())
 	}
 }
+
+// =============================================================================
+// Unit Tests: ValidateConfig — invalid glob in guard match
+// =============================================================================
+
+func TestValidateConfig_InvalidGlobMatch(t *testing.T) {
+	makeRaw := func(matchVal string) map[string]interface{} {
+		return map[string]interface{}{
+			"guards": []interface{}{
+				map[string]interface{}{
+					"match":  matchVal,
+					"action": "warn",
+					"reason": "x",
+				},
+			},
+		}
+	}
+
+	errorsForPath := func(raw map[string]interface{}, path string) []ValidationError {
+		result := ValidateConfig(raw)
+		var out []ValidationError
+		for _, e := range result.Errors {
+			if e.Path == path {
+				out = append(out, e)
+			}
+		}
+		return out
+	}
+
+	const path = "guards[0].match"
+
+	// Positive cases: invalid glob patterns that contain glob metacharacters must
+	// produce a ValidationError at guards[0].match mentioning "glob".
+	positiveCases := []struct {
+		label string
+		match string
+	}{
+		{"unclosed char class", "Bash["},
+		{"unclosed char class with content", "Edit[0-9"},
+	}
+	for _, tc := range positiveCases {
+		raw := makeRaw(tc.match)
+		errs := errorsForPath(raw, path)
+		var globErrs []ValidationError
+		for _, e := range errs {
+			if strings.Contains(e.Message, "glob") {
+				globErrs = append(globErrs, e)
+			}
+		}
+		if len(globErrs) == 0 {
+			t.Errorf("case=%q match=%q: expected ValidationError mentioning 'glob' at %q, got none (all errors at path: %v)", tc.label, tc.match, path, errs)
+		}
+	}
+
+	// Negative cases: valid patterns (plain exact or valid globs) must NOT produce
+	// a ValidationError mentioning "glob" at guards[0].match.
+	negativeCases := []struct {
+		label string
+		match string
+	}{
+		{"plain exact", "Bash"},
+		{"pipe in value (no glob metachar)", "Edit|Write"},
+		{"wildcard star", "*"},
+		{"prefix glob", "tool_*"},
+		{"valid brace group", "Bash{a,b}"},
+	}
+	for _, tc := range negativeCases {
+		raw := makeRaw(tc.match)
+		errs := errorsForPath(raw, path)
+		for _, e := range errs {
+			if strings.Contains(e.Message, "glob") {
+				t.Errorf("case=%q match=%q: expected no 'glob' error, got %q", tc.label, tc.match, e.Message)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

`hookwise doctor` now flags a guard whose `match` field is an **invalid glob
pattern** — e.g. `match: "Bash["`.

## Why

In `matchToolName` (guards.go), a `match` pattern that isn't an exact tool-name
hit and contains glob metacharacters is compiled with `glob.Compile`. An invalid
glob fails to compile, `matchToolName` returns false, and the guard **matches no
tool — silently never firing**. A `block` guard that doesn't protect.
`ValidateConfig` only checked that `match` was present/non-empty; it never
compiled the glob.

This completes guard-config validation at the doctor seam:
- match glob *(this PR)*
- when/unless malformed syntax (#161)
- empty substring value (#160)
- matches-operator regex (#162)

## Scope — validation-time only (non-behavior-changing)

The check lives in `ValidateConfig` (called by `cmd doctor`, **not** the dispatch
path). It compiles the glob only when the pattern contains glob metacharacters
(`* ? [ {`), faithfully mirroring `matchToolName` (plain patterns are exact-match
and never compiled). `guards.go` is untouched; runtime behavior is identical.

## Tests

`TestValidateConfig_InvalidGlobMatch` (internal/core):
- Positive: `Bash[`, `Edit[0-9` (unclosed char classes).
- Negative: `Bash` (plain), `Edit|Write`, `*`, `tool_*`, `Bash{a,b}` (all valid).

Verified with the guarded gate (`GOMEMLIMIT=4GiB go test -race -p 2 ./internal/core/`,
0 zombies); mutation-red confirmed the test guards the new logic. Full
`internal/core` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)