### PR TITLE
fix(handlers): doctor-warn on invalid handler event names (#164)

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -529,8 +529,28 @@ func ValidateConfig(raw map[string]interface{}) ValidationResult {
 					errors = append(errors, ValidationError{
 						Path:       fmt.Sprintf("handlers[%d].events", i),
 						Message:    "handler must specify events",
-						Suggestion: "Set events: ['PreToolUse'] or events: '*'",
+						Suggestion: "Set events to one or more of: " + strings.Join(EventTypes, ", "),
 					})
+				}
+				if ev, ok := handler["events"]; ok && ev != nil {
+					var eventVals []string
+					switch t := ev.(type) {
+					case string:
+						eventVals = []string{t}
+					case []interface{}:
+						for _, e := range t {
+							eventVals = append(eventVals, fmt.Sprintf("%v", e))
+						}
+					}
+					for _, e := range eventVals {
+						if !IsEventType(e) {
+							errors = append(errors, ValidationError{
+								Path:       fmt.Sprintf("handlers[%d].events", i),
+								Message:    fmt.Sprintf("handler lists %q, which is not a valid event (the handler will never fire for it)", e),
+								Suggestion: "Use one of: " + strings.Join(EventTypes, ", "),
+							})
+						}
+					}
 				}
 			}
 		}

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -2155,3 +2155,91 @@ func TestValidateConfig_InvalidGlobMatch(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateConfig_InvalidHandlerEvents(t *testing.T) {
+	makeRaw := func(eventsVal interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"handlers": []interface{}{
+				map[string]interface{}{
+					"name":   "h",
+					"type":   "builtin",
+					"events": eventsVal,
+				},
+			},
+		}
+	}
+
+	errorsForPath := func(raw map[string]interface{}, path string) []ValidationError {
+		result := ValidateConfig(raw)
+		var out []ValidationError
+		for _, e := range result.Errors {
+			if e.Path == path {
+				out = append(out, e)
+			}
+		}
+		return out
+	}
+
+	const path = "handlers[0].events"
+
+	// Positive cases: invalid event names must produce a ValidationError at
+	// handlers[0].events whose Message contains the bad token.
+	positiveCases := []struct {
+		label     string
+		eventsVal interface{}
+		badToken  string
+	}{
+		{"typo in slice", []interface{}{"PreToolUze"}, "PreToolUze"},
+		{"dead wildcard", []interface{}{"*"}, "*"},
+		{"scalar string typo", "PreToolUze", "PreToolUze"},
+	}
+	for _, tc := range positiveCases {
+		raw := makeRaw(tc.eventsVal)
+		errs := errorsForPath(raw, path)
+		var found bool
+		for _, e := range errs {
+			if strings.Contains(e.Message, tc.badToken) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("case=%q: expected ValidationError at %q mentioning %q, got errors: %v", tc.label, path, tc.badToken, errs)
+		}
+	}
+
+	// Mixed case: one valid event + one invalid; must flag the invalid one (Foo).
+	{
+		raw := makeRaw([]interface{}{"PreToolUse", "Foo"})
+		errs := errorsForPath(raw, path)
+		var found bool
+		for _, e := range errs {
+			if strings.Contains(e.Message, "Foo") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("mixed case: expected ValidationError at %q mentioning %q, got errors: %v", path, "Foo", errs)
+		}
+	}
+
+	// Negative cases: valid event names must NOT produce any error at handlers[0].events.
+	negativeCases := []struct {
+		label     string
+		eventsVal interface{}
+	}{
+		{"single valid slice", []interface{}{"PreToolUse"}},
+		{"multiple valid slice", []interface{}{"PreToolUse", "Stop", "SessionEnd"}},
+		{"scalar valid string", "Stop"},
+	}
+	for _, tc := range negativeCases {
+		raw := makeRaw(tc.eventsVal)
+		errs := errorsForPath(raw, path)
+		for _, e := range errs {
+			if strings.Contains(e.Message, "not a valid event") {
+				t.Errorf("case=%q: expected no invalid-event error at %q, got %q", tc.label, path, e.Message)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

`hookwise doctor` now flags a handler whose `events` list contains a name that
isn't a real Claude Code event — e.g. `events: [PreToolUze]` (typo) or the
advertised-but-unimplemented `events: ['*']`.

## Why

`ResolvedHandler.HasEvent` (types.go) is an exact-match loop, so a handler with
a bad event name **never fires** — a silently-dead coaching / notification /
analytics handler. `ValidateConfig` only checked that `events` was *present*,
never that the names were valid, even though `EventTypes` + `IsEventType()`
already exist.

Recon also found that `events: '*'` is **advertised** in the validation
suggestion text but **unimplemented** in `HasEvent` (no wildcard branch, no
expansion), so `*` is itself silently dead. This PR:
- flags any handler event not in `EventTypes` (including `*`, since it's dead);
- drops the misleading `'*'` from the presence-check suggestion.

The decision to *implement* `*` as a real wildcard vs. keep rejecting it is a
runtime-behavior change, tracked separately as **#164** (supervised).

## Scope — validation-time only (non-behavior-changing)

The check lives in `ValidateConfig` (called by `cmd doctor`, **not** the dispatch
path). `HasEvent` / dispatcher are untouched; a handler with a bad event was
already dead — doctor just becomes honest about it. Same silent-dead-config
class as the guard-condition validation (#160–#163), different subsystem.

## Tests

`TestValidateConfig_InvalidHandlerEvents` (internal/core):
- Positive: slice typo `PreToolUze`, dead `*`, scalar-string typo, mixed
  valid+invalid (`[PreToolUse, Foo]` → flags `Foo`).
- Negative: valid single/multi events and scalar `Stop`.

Verified with the guarded gate (`GOMEMLIMIT=4GiB go test -race -p 2 ./internal/core/`,
0 zombies); mutation-red confirmed the test guards the new logic; end-to-end
`hookwise doctor` smoke test confirms the warnings surface (and a valid sibling
event is not flagged). Full `internal/core` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)