### PR TITLE
ci(tui): adopt and enforce ruff lint (#45)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,7 +74,7 @@ tasks:
     desc: "Lint Python TUI code with ruff"
     dir: tui
     cmds:
-      - "{{.TUI_VENV}}/ruff check . || true"
+      - "{{.TUI_VENV}}/ruff check ."
     sources:
       - "tui/**/*.py"
 

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -80,11 +80,11 @@ func (m *Hookwise) Check(ctx context.Context, src *dagger.Directory) error {
 		return err
 	})
 
-	// Python ruff lint (advisory — doesn't fail the build, matches Taskfile behavior)
+	// Python ruff lint (gating — fails the build on violations)
 	g.Go(func() error {
 		_, err := m.pythonContainer(src, "3.13").
-			WithExec([]string{"pip", "install", "--quiet", "ruff"}).
-			WithExec([]string{"sh", "-c", "ruff check . || true"}).
+			WithExec([]string{"pip", "install", "--quiet", "ruff==0.15.17"}).
+			WithExec([]string{"ruff", "check", "."}).
 			Sync(ctx)
 		return err
 	})

--- a/tui/hookwise_tui/data.py
+++ b/tui/hookwise_tui/data.py
@@ -505,7 +505,7 @@ def read_insights(
         start_time = session.get("start_time", "")
         if isinstance(start_time, str) and len(start_time) >= 10:
             try:
-                from datetime import datetime as _dt, timezone as _tz
+                from datetime import datetime as _dt
                 utc_dt = _dt.fromisoformat(start_time.replace("Z", "+00:00"))
                 local_dt = utc_dt.astimezone()
                 date_str = local_dt.strftime("%Y-%m-%d")

--- a/tui/hookwise_tui/tabs/dashboard.py
+++ b/tui/hookwise_tui/tabs/dashboard.py
@@ -135,9 +135,6 @@ class DashboardTab(Widget):
     def compose(self) -> ComposeResult:
         config = read_config()
 
-        enabled_count = sum(1 for f in FEATURES if _is_enabled(config, f))
-        total = len(FEATURES)
-
         yield Container(
             *[
                 FeatureCard(

--- a/tui/hookwise_tui/tabs/feeds.py
+++ b/tui/hookwise_tui/tabs/feeds.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 
 from textual.app import ComposeResult
-from textual.containers import Container, Horizontal, Vertical
+from textual.containers import Container
 from textual.widget import Widget
 from textual.widgets import Static
 

--- a/tui/hookwise_tui/tabs/recipes.py
+++ b/tui/hookwise_tui/tabs/recipes.py
@@ -51,7 +51,7 @@ class RecipesTab(Widget):
         includes = config.get("includes", [])
         if isinstance(includes, list) and includes:
             yield Static("Active Includes", classes="section-title")
-            with Static(classes="includes-section") as s:
+            with Static(classes="includes-section"):
                 pass
             for inc in includes:
                 yield Static(f"  [green]●[/green] {inc}")
@@ -73,7 +73,7 @@ class RecipesTab(Widget):
                 for recipe in categories[cat]:
                     status = "[green]●[/green]" if recipe.active else "[dim]○[/dim]"
                     label = f"{status} {recipe.name}"
-                    leaf = cat_node.add_leaf(label)
+                    cat_node.add_leaf(label)
                     if recipe.description:
                         cat_node.add_leaf(
                             f"  [dim italic]{recipe.description[:80]}[/dim italic]"

--- a/tui/hookwise_tui/widgets/feed_health.py
+++ b/tui/hookwise_tui/widgets/feed_health.py
@@ -3,7 +3,6 @@
 from datetime import datetime, timezone
 
 from textual.app import ComposeResult
-from textual.containers import Horizontal
 from textual.widget import Widget
 from textual.widgets import Static
 

--- a/tui/hookwise_tui/widgets/sparkline.py
+++ b/tui/hookwise_tui/widgets/sparkline.py
@@ -1,6 +1,5 @@
 """Sparkline widget for trend visualization using Rich Sparkline."""
 
-from rich.text import Text
 from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static

--- a/tui/hookwise_tui/widgets/weather_background.py
+++ b/tui/hookwise_tui/widgets/weather_background.py
@@ -16,7 +16,7 @@ from rich.text import Text as RichText
 from textual.reactive import reactive
 from textual.widget import Widget
 
-from hookwise_tui.widgets.weather_data import WeatherInfo, get_weather
+from hookwise_tui.widgets.weather_data import WeatherInfo
 
 
 # --- Particle Types ---

--- a/tui/hookwise_tui/widgets/weather_data.py
+++ b/tui/hookwise_tui/widgets/weather_data.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import urllib.request
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
 from hookwise_tui.data import read_cache

--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -22,7 +22,12 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-textual-snapshot>=1.0.0",
+    "ruff==0.15.17",
 ]
+
+[tool.ruff]
+exclude = ["prototypes", ".venv"]
+target-version = "py311"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tui/tests/test_app.py
+++ b/tui/tests/test_app.py
@@ -1,7 +1,6 @@
 """Tests for hookwise_tui.app — Textual pilot tests."""
 
 import pytest
-from textual.pilot import Pilot
 
 from hookwise_tui.app import HookwiseTUI
 
@@ -14,7 +13,7 @@ def app():
 class TestHookwiseTUI:
     async def test_app_launches(self, app):
         """App starts without error and shows header."""
-        async with app.run_test() as pilot:
+        async with app.run_test():
             assert app.title == "Hookwise"
             assert app.sub_title == "Claude Code Hooks Dashboard"
 
@@ -52,7 +51,7 @@ class TestHookwiseTUI:
 
     async def test_dashboard_has_feature_cards(self, app):
         """Dashboard tab contains FeatureCard widgets."""
-        async with app.run_test() as pilot:
+        async with app.run_test():
             from hookwise_tui.widgets.feature_card import FeatureCard
             cards = app.query(FeatureCard)
             # Should have at least the 7 features from dashboard

--- a/tui/tests/test_data.py
+++ b/tui/tests/test_data.py
@@ -4,19 +4,12 @@ import json
 import os
 import sqlite3
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import pytest
 import yaml
 
 from hookwise_tui.data import (
     AnalyticsData,
-    DaemonStatus,
-    DailySummary,
-    FeedHealth,
-    InsightsData,
-    InsightsSummary,
-    Recipe,
     _effective_config_path,
     is_fresh,
     read_analytics,

--- a/tui/tests/test_status_live_output.py
+++ b/tui/tests/test_status_live_output.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
-import pytest
 
 from hookwise_tui.tabs.status import StatusTab, _LAST_STATUS_OUTPUT_PATH, _LIVE_OUTPUT_MAX_AGE
 


### PR DESCRIPTION
## What

Turns the Python `ruff` lint from advisory into a **gating** check, and fixes the
pre-existing violations so the build stays green.

## Why

`lint:py` (Taskfile) and the dagger `check` both ran `ruff check . || true`
(advisory), **and ruff wasn't even installed in `tui/.venv`** — so the Python
lint was effectively a **silent no-op**. Real lint regressions could land
unnoticed (this is issue #45).

## Changes

- **Pin `ruff==0.15.17`** in `tui/pyproject.toml` dev deps and in the dagger
  install, so the locally-verified result matches what CI's freshly-installed
  ruff sees (no version-drift surprises when gating).
- **`[tool.ruff]` config**: `exclude = ["prototypes", ".venv"]` (scratch code
  shouldn't gate CI), `target-version = "py311"`, default E+F rules.
- **Flip advisory → gating**: drop `|| true` from `Taskfile.yml` (`lint:py`) and
  `dagger/main.go` (comment updated from "advisory" to "gating").
- **Fix all 29 violations** in shipped code (`hookwise_tui/` + `tests/`):
  - 19 F401 unused-import + 2 F541 f-string — auto-fixed (no `--unsafe-fixes`).
  - 6 F841 unused-variable — fixed by hand, classified by side effects:
    `cat_node.add_leaf(...)`, `with Static(...) as s`, `run_test() as pilot` kept
    the call/context and dropped only the unused binding; pure dead computations
    (`enabled_count`, `total` in dashboard) were deleted.
  - `prototypes/` (incl. the lone E741) excluded, not modified.

## Verification

- `ruff check .` (both the pinned `uvx ruff@0.15.17` and the venv ruff) →
  **All checks passed!**
- Full TUI pytest: **117 passed, 7 snapshots passed** (excl. `terminal_e2e`).
- **No snapshot `.raw` changed** — the compose-code fixes did not alter rendering.
- `dagger/` module `go build` + `go vet` clean.

Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)