### PR TITLE
ci(lint): adopt golangci-lint v2.12.2 (safe slice of #44)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+# golangci-lint configuration (v2 schema).
+#
+# errcheck is intentionally disabled for now: hookwise is fail-open (ARCH-1)
+# infrastructure where many unchecked errors are deliberate swallows (side
+# effects must never block dispatch). Enabling errcheck requires per-call
+# triage (intentional-swallow vs real-bug) and is a supervised follow-up — see
+# issue #44. The remaining standard linters (govet, staticcheck, unused,
+# ineffassign) replace the previous bare `go vet`.
+#
+# Pinned to golangci-lint v2.x: the module targets go 1.25, and the last v1
+# release (v1.64.8) is built with go1.24 and refuses to lint a go1.25 module.
+version: "2"
+run:
+  timeout: 5m
+linters:
+  default: standard
+  disable:
+    - errcheck

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,6 +51,13 @@ tasks:
     sources:
       - "**/*.go"
 
+  lint:go:
+    desc: "Run golangci-lint (requires: brew install golangci-lint). errcheck disabled — see .golangci.yml"
+    cmds:
+      - golangci-lint run ./...
+    sources:
+      - "**/*.go"
+
   compile:
     desc: "Verify all packages compile"
     cmds:

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -60,14 +60,18 @@ func (m *Hookwise) pythonContainer(src *dagger.Directory, pythonVersion string) 
 
 // ----- Tier 0: Check -----
 
-// Check runs fast pre-commit checks: go vet, go build, and ruff lint — all in parallel.
+// Check runs fast pre-commit checks: golangci-lint, go build, and ruff lint — all in parallel.
 func (m *Hookwise) Check(ctx context.Context, src *dagger.Directory) error {
 	var g errgroup.Group
 
-	// Go vet
+	// golangci-lint (replaces bare go vet; errcheck disabled — see .golangci.yml / #44).
+	// Pinned to v2.12.2 and installed via `go install` so it is built with the
+	// container's go1.25 toolchain — the last v1 release (v1.64.8) is built with
+	// go1.24 and refuses to lint this go1.25 module.
 	g.Go(func() error {
 		_, err := m.goContainer(src).
-			WithExec([]string{"go", "vet", "./..."}).
+			WithExec([]string{"go", "install", "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2"}).
+			WithExec([]string{"sh", "-c", "$(go env GOPATH)/bin/golangci-lint run ./..."}).
 			Sync(ctx)
 		return err
 	})

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -14,6 +14,7 @@ const allowedRoot = [
   ".coderabbit.yaml",
   ".gitignore",
   ".gitleaks.toml",
+  ".golangci.yml",
   ".goreleaser.yml",
   ".ls-lint.yml",
   ".mcp.json",

--- a/internal/analytics/state.go
+++ b/internal/analytics/state.go
@@ -353,10 +353,3 @@ func floatOrDefault(nf sql.NullFloat64, def float64) float64 {
 	return def
 }
 
-// intOrDefault returns the NullInt64 value as int or the default.
-func intOrDefault(ni sql.NullInt64, def int) int {
-	if ni.Valid {
-		return int(ni.Int64)
-	}
-	return def
-}

--- a/internal/arch/arch_test.go
+++ b/internal/arch/arch_test.go
@@ -53,16 +53,6 @@ func findModuleRoot(t *testing.T) string {
 	}
 }
 
-// hasImport checks if pkg directly imports the target import path.
-func hasImport(pkg *packages.Package, target string) bool {
-	for imp := range pkg.Imports {
-		if imp == target || strings.HasPrefix(imp, target+"/") {
-			return true
-		}
-	}
-	return false
-}
-
 // collectImports returns all direct imports for a package that match the prefix.
 func collectImports(pkg *packages.Package, prefix string) []string {
 	var matches []string

--- a/internal/core/warnings.go
+++ b/internal/core/warnings.go
@@ -105,12 +105,6 @@ func ReadWarnings(stateDir string) []Warning {
 	return active
 }
 
-// warningsFilePath returns the path to warnings.json for a given state dir.
-// Exported for testing convenience.
-func warningsFilePath(stateDir string) string {
-	return filepath.Join(stateDir, "state", "warnings.json")
-}
-
 // FormatWarningAge returns a human-readable age string for a warning timestamp.
 func FormatWarningAge(timestamp string) string {
 	ts, err := ParseTimeFlex(timestamp)

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -253,6 +253,7 @@ func TestLineOverBufferLimitNotFatal(t *testing.T) {
 func TestResultTypeIsPricingUsage(t *testing.T) {
 	result, err := transcript.SumUsage(testdataPath("single.jsonl"))
 	require.NoError(t, err)
+	//nolint:staticcheck // QF1011: the explicit type is the compile-time assertion under test.
 	var _ map[string]pricing.Usage = result
 	_ = result
 }


### PR DESCRIPTION
## What

Adopts golangci-lint as the **safe slice** of #44 — replacing the bare `go vet` in the dagger `Check` stage with golangci-lint's `standard` linter set (govet, staticcheck, unused, ineffassign).

`errcheck` stays **disabled** for now: hookwise is ARCH-1 fail-open infrastructure where many unchecked-error swallows are deliberate (side effects must never block dispatch). Enabling errcheck requires a per-call intentional-swallow-vs-bug triage and is a supervised follow-up — tracked in #44, documented in `.golangci.yml`.

## Why v2.12.2 and not v1.64.8

The last v1 release (v1.64.8) is built with **go1.24** and **refuses to lint this go1.25.5 module** (`the Go language version (go1.24)... is lower than the targeted Go version (1.25.5)`). Since the dagger container is `golang:1.25-bookworm`, a v1.64.8 pin would have gone **red in CI**. Pinned to **v2.12.2** (built with go1.25), installed via `go install ...@v2.12.2` so the binary is built with the container's own toolchain (the v2 install-script tarball failed checksum verification locally).

## Changes

- **3 dead funcs removed** (flagged by the `unused` linter): `hasImport` (internal/arch), `intOrDefault` (internal/analytics), `warningsFilePath` (internal/core).
- **`.golangci.yml`** (new) — v2 schema, `linters.default: standard` minus `errcheck`, 5m timeout, rationale inline.
- **`dagger/main.go`** — `Check`'s `go vet` goroutine → pinned golangci-lint v2.12.2 install + run. `go build` and `ruff` goroutines untouched.
- **`Taskfile.yml`** — opt-in `lint:go` task; existing `vet` left intact so `task test` still works without golangci-lint installed.
- **`transcript_test.go`** — targeted `//nolint:staticcheck` on the intentional compile-time type assertion (QF1011; the explicit type *is* the test).

## Verification

- `golangci-lint run ./...` (v2.12.2, go1.25.5) → **0 issues**
- Guarded gate green: `GOMEMLIMIT=4GiB go test -race -p 2` on internal/{arch,analytics,core,transcript}
- `cd dagger && go build ./...` + `go vet ./...` clean; 0 test zombies

Closes #44 (safe slice; errcheck enablement remains tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Integrated golangci-lint for comprehensive Go code quality analysis and enforcement
  * Added new linting task to build system configuration for automated package verification
  * Enhanced CI/CD pipeline with improved code quality checks running in parallel with existing verification steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->