### PR TITLE
ci(lint): adopt ls-lint v2.3.1 for naming conventions (#47)

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,0 +1,26 @@
+# ls-lint — file/folder naming conventions (#47).
+#
+# Scope is deliberately conservative: it enforces snake_case on the source
+# trees that are already 100% uniform (Go under cmd/internal/pkg, Python under
+# tui), so it locks in the existing convention and only catches FUTURE drift.
+# The repo root is intentionally NOT enforced — it legitimately mixes styles
+# (UPPERCASE docs like README.md, kebab dotfiles, Taskfile.yml) and codifying
+# that churn adds risk without value.
+ls:
+  cmd:
+    .go: snake_case
+  internal:
+    .go: snake_case
+  pkg:
+    .go: snake_case
+  tui:
+    .py: snake_case
+
+ignore:
+  - .git
+  - .venv
+  - node_modules
+  - vendor
+  - testdata
+  - .dagger
+  - tui/.venv

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,6 +58,11 @@ tasks:
     sources:
       - "**/*.go"
 
+  lint:files:
+    desc: "Check file/folder naming conventions with ls-lint (requires: brew install ls-lint)"
+    cmds:
+      - ls-lint
+
   compile:
     desc: "Verify all packages compile"
     cmds:

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -60,7 +60,8 @@ func (m *Hookwise) pythonContainer(src *dagger.Directory, pythonVersion string) 
 
 // ----- Tier 0: Check -----
 
-// Check runs fast pre-commit checks: golangci-lint, go build, and ruff lint — all in parallel.
+// Check runs fast pre-commit checks: golangci-lint, go build, ruff lint, and
+// ls-lint naming conventions — all in parallel.
 func (m *Hookwise) Check(ctx context.Context, src *dagger.Directory) error {
 	var g errgroup.Group
 
@@ -89,6 +90,17 @@ func (m *Hookwise) Check(ctx context.Context, src *dagger.Directory) error {
 		_, err := m.pythonContainer(src, "3.13").
 			WithExec([]string{"pip", "install", "--quiet", "ruff==0.15.17"}).
 			WithExec([]string{"ruff", "check", "."}).
+			Sync(ctx)
+		return err
+	})
+
+	// ls-lint file/folder naming conventions (#47). Pinned to v2.3.1; downloads
+	// the prebuilt binary matching the container architecture (dpkg arch names
+	// align with the release asset suffixes: amd64 / arm64). ls-lint reads
+	// .ls-lint.yml from the working dir by default.
+	g.Go(func() error {
+		_, err := m.goContainer(src).
+			WithExec([]string{"sh", "-c", "ARCH=$(dpkg --print-architecture); curl -sSfL -o /usr/local/bin/ls-lint https://github.com/loeffel-io/ls-lint/releases/download/v2.3.1/ls-lint-linux-${ARCH} && chmod +x /usr/local/bin/ls-lint && ls-lint"}).
 			Sync(ctx)
 		return err
 	})


### PR DESCRIPTION
## What

Adopts [ls-lint](https://ls-lint.org/) v2.3.1 to enforce file/folder naming conventions (#47), following the same **conservative staged adoption** used for ruff (#45) and golangci-lint (#44).

## Scope — codify reality, catch future drift

Enforces `snake_case` only on the source trees that are **already 100% uniform**:
- `.go` under `cmd/`, `internal/`, `pkg/`
- `.py` under `tui/`

The repo **root is intentionally NOT enforced** — it legitimately mixes styles (UPPERCASE `README.md`/`CLAUDE.md`, kebab dotfiles, `Taskfile.yml`), so codifying that churn would add risk without value. The issue's proposed root rules were deliberately dropped.

This means the config **passes on the current tree today** and only fails on **future** naming drift.

## Verification

- `ls-lint` → **exit 0** (clean) on the current tree.
- Planted `internal/core/BadName.go` → **exit 1**, `failed for .go rules: snakecase` — confirms it's a real gate, not a silent no-op.
- `cd dagger && go build ./...` clean.

## Wiring

- **dagger `Check()`** — new parallel goroutine; downloads the pinned v2.3.1 binary matching the container arch (`dpkg --print-architecture` → amd64/arm64, aligning with the release asset suffixes). ls-lint reads `.ls-lint.yml` from the workdir by default.
- **Taskfile `lint:files`** — local opt-in task (`brew install ls-lint`).
- `.ls-lint.yml` was already in the danger root allowlist, so no dangerfile change needed.

Note: `go install` doesn't work for the ls-lint v2 module (main pkg isn't at a go-installable path), so the prebuilt release binary is used — mirroring how dagger pins golangci-lint.

Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)