### PR TITLE
ci(lint): adopt mypy as a gating baseline for the TUI (#48)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -90,6 +90,14 @@ tasks:
     sources:
       - "tui/**/*.py"
 
+  lint:types:
+    desc: "Type-check Python TUI code with mypy (baseline gating — see #48)"
+    dir: tui
+    cmds:
+      - "{{.TUI_VENV}}/python -m mypy ."
+    sources:
+      - "tui/**/*.py"
+
   staleness:
     desc: "Check if installed binary matches source HEAD"
     cmds:

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -60,8 +60,8 @@ func (m *Hookwise) pythonContainer(src *dagger.Directory, pythonVersion string) 
 
 // ----- Tier 0: Check -----
 
-// Check runs fast pre-commit checks: golangci-lint, go build, ruff lint, and
-// ls-lint naming conventions — all in parallel.
+// Check runs fast pre-commit checks: golangci-lint, go build, ruff lint,
+// ls-lint naming conventions, and mypy type checking — all in parallel.
 func (m *Hookwise) Check(ctx context.Context, src *dagger.Directory) error {
 	var g errgroup.Group
 
@@ -101,6 +101,16 @@ func (m *Hookwise) Check(ctx context.Context, src *dagger.Directory) error {
 	g.Go(func() error {
 		_, err := m.goContainer(src).
 			WithExec([]string{"sh", "-c", "ARCH=$(dpkg --print-architecture); curl -sSfL -o /usr/local/bin/ls-lint https://github.com/loeffel-io/ls-lint/releases/download/v2.3.1/ls-lint-linux-${ARCH} && chmod +x /usr/local/bin/ls-lint && ls-lint"}).
+			Sync(ctx)
+		return err
+	})
+
+	// Python mypy type check (#48). mypy==1.14.1 is pinned in tui/pyproject.toml
+	// dev deps, so pythonContainer's `.[dev]` install provides it. Gating on a
+	// documented per-module baseline (see [tool.mypy] in pyproject.toml).
+	g.Go(func() error {
+		_, err := m.pythonContainer(src, "3.13").
+			WithExec([]string{"python", "-m", "mypy", "."}).
 			Sync(ctx)
 		return err
 	})

--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -23,11 +23,45 @@ dev = [
     "pytest-asyncio>=0.24",
     "pytest-textual-snapshot>=1.0.0",
     "ruff==0.15.17",
+    "mypy==1.14.1",
+    "types-PyYAML>=6.0",
 ]
 
 [tool.ruff]
 exclude = ["prototypes", ".venv"]
 target-version = "py311"
+
+# mypy static type checking (#48).
+#
+# Adopted as a GATING baseline: the config passes on the current tree and so
+# guards every already-clean module plus all new code from new type errors —
+# the same staged shape used for ruff (#45) and golangci-lint (#44, errcheck
+# disabled). `disallow_untyped_defs` stays false (permissive start) per the #48
+# ratchet plan. The modules listed under the ignore_errors override below carry
+# a pre-existing error backlog (32 errors, mostly in the data.py Go→Python
+# boundary file); they are quarantined here and fixed incrementally — see #48
+# Phase 1. prototypes/ is excluded to match the ruff config (throwaway code).
+[tool.mypy]
+python_version = "3.11"
+warn_unused_configs = true
+disallow_untyped_defs = false
+ignore_missing_imports = true
+exclude = "prototypes"
+
+# Quarantined baseline — ratchet down one module at a time (#48 Phase 1),
+# starting with the data.py / boundary files mypy is most valuable for.
+[[tool.mypy.overrides]]
+module = [
+    "hookwise_tui.data",
+    "hookwise_tui.tabs.insights",
+    "hookwise_tui.tabs.analytics",
+    "hookwise_tui.tabs.dashboard",
+    "hookwise_tui.tabs.status",
+    "hookwise_tui.tabs.guards",
+    "hookwise_tui.widgets.weather_data",
+    "tests.test_terminal_e2e",
+]
+ignore_errors = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## What

Adopts [mypy](https://mypy.readthedocs.io/) 1.14.1 for the Python TUI (#48) — the last named lint item, following ruff (#45), golangci-lint (#44), and ls-lint (#47).

## Why a baseline, not a full sweep

Unlike the config-only adoptions, mypy on the untyped TUI surfaces a **real error backlog**: 41 errors / 12 files, of which 9 are in throwaway `prototypes/` (excluded to match ruff) → **32 real errors / 9 files**. The worst is `data.py` (21) — the Go→Python **boundary** file mypy is most valuable for, and the riskiest to fix (Anthropic SDK union types).

Sweeping all 32 fixes across the TUI in one PR would be a large, behavior-adjacent change to snapshot-sensitive code — not a small verifiable increment. So this adopts mypy as a **gating baseline** (config-only, **zero `.py` changes** → zero behavior/snapshot risk), exactly mirroring golangci-lint's documented `errcheck` disable:

- permissive base (`disallow_untyped_defs = false`), `prototypes` excluded, `ignore_missing_imports`
- per-module `ignore_errors` for the 8 dirty shipped/test modules, quarantined with a #48 Phase-1 ratchet note
- `types-PyYAML` added so `test_data.py`'s yaml import resolves (dropped from the quarantine list)

**Net effect:** gates the ~20 already-clean modules + **all new code** from new type errors. The error-fixing is tracked as the #48 Phase-1 ratchet (fix `data.py`/boundary first), each its own PR with the TUI test gate.

## Verification

- `mypy .` → **exit 0** ("Success: no issues found in 26 source files")
- Planted a bad return in the clean `app.py` → **exit 1** (`Incompatible return value type`); restored → clean. Confirms it gates clean modules + new code, not a no-op.
- `cd dagger && go build ./...` clean.

## Wiring

- `tui/pyproject.toml` — `[tool.mypy]` config + `mypy==1.14.1` / `types-PyYAML` dev deps.
- Taskfile `lint:types` + dagger `Check()` goroutine (mypy comes via `pythonContainer`'s `.[dev]` install).

Part of #48 (Phase 0: gating baseline; Phase 1 ratchet checklist commented on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)