### PR TITLE
fix(tui): mypy ratchet — un-quarantine 3 trivial modules (#48)

### DIFF
--- a/tui/hookwise_tui/tabs/guards.py
+++ b/tui/hookwise_tui/tabs/guards.py
@@ -64,7 +64,7 @@ class GuardsTab(Widget):
             )
 
         # Guard rules table
-        table = DataTable()
+        table: DataTable = DataTable()
         table.add_columns("#", "Match", "Action", "Reason", "Condition")
 
         for i, guard in enumerate(guards):

--- a/tui/hookwise_tui/tabs/status.py
+++ b/tui/hookwise_tui/tabs/status.py
@@ -358,7 +358,7 @@ class StatusTab(Widget):
         if not isinstance(friction_counts, dict):
             return ""
         top_cat = ""
-        top_count = 0
+        top_count: float = 0
         for cat, count in friction_counts.items():
             if isinstance(count, (int, float)) and count > top_count:
                 top_cat = cat

--- a/tui/hookwise_tui/widgets/weather_data.py
+++ b/tui/hookwise_tui/widgets/weather_data.py
@@ -127,7 +127,11 @@ def read_weather_from_cache(
     if not condition and not temperature and not code:
         return None
 
-    # Compute temp_c/temp_f from the single temperature + unit, or from legacy fields
+    # Compute temp_c/temp_f from the single temperature + unit, or from legacy fields.
+    # Declared float: round() yields int in some branches, _safe_float yields float
+    # in others — the variables hold either, so pin them to float.
+    temp_c: float
+    temp_f: float
     if temp_unit == "celsius":
         temp_c = _safe_float(temperature) if temperature else _safe_float(weather_entry.get("temp_c"))
         temp_f = round(temp_c * 9 / 5 + 32)

--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -56,9 +56,6 @@ module = [
     "hookwise_tui.tabs.insights",
     "hookwise_tui.tabs.analytics",
     "hookwise_tui.tabs.dashboard",
-    "hookwise_tui.tabs.status",
-    "hookwise_tui.tabs.guards",
-    "hookwise_tui.widgets.weather_data",
     "tests.test_terminal_e2e",
 ]
 ignore_errors = true


### PR DESCRIPTION
## What

First **Phase-1 ratchet** step of the mypy baseline (#48): fix the pure type-annotation errors in the 3 lowest-risk quarantined modules and remove them from the `ignore_errors` list, so mypy now type-checks them.

| Module | Error | Fix |
|--------|-------|-----|
| `widgets/weather_data.py` | `temp_f` inferred `int` (from `round()` at first assignment) then assigned `float` | declare `temp_c: float` / `temp_f: float` |
| `tabs/guards.py` | `DataTable()` is generic, needs a type | annotate `table: DataTable` |
| `tabs/status.py` | `top_count = 0` inferred `int`, then assigned `int \| float` | annotate `top_count: float` |

**All annotation-only — zero runtime behavior change** (Python type hints are erased at runtime; `round()` still returns the same value, comparisons are identical).

## Verification

- `mypy .` → **clean** (26 files; the 3 modules now actively checked, not ignored).
- Full TUI pytest → **117 passed, 7 snapshots unchanged**, 20 e2e deselected. Annotations can't change rendering, confirmed by the green snapshots.

## Remaining quarantine (future ratchet PRs)

`data.py` (21 — the Go→Python boundary prize), `insights`/`analytics` (SparklineWidget `Sequence` widening), `dashboard` (`object` indexing), `test_terminal_e2e`. Tracked on #48's Phase-1 checklist.

Part of #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)