### PR TITLE
fix(tui): mypy ratchet — type dashboard FEATURES (#48)

### DIFF
--- a/tui/hookwise_tui/tabs/dashboard.py
+++ b/tui/hookwise_tui/tabs/dashboard.py
@@ -1,5 +1,7 @@
 """Dashboard tab — Overview grid with feature cards."""
 
+from typing import Any
+
 from textual.app import ComposeResult
 from textual.containers import Container
 from textual.widget import Widget
@@ -8,8 +10,10 @@ from hookwise_tui.data import read_config
 from hookwise_tui.widgets.feature_card import FeatureCard
 
 
-# Feature descriptions for every hookwise feature
-FEATURES = [
+# Feature descriptions for every hookwise feature.
+# dict[str, Any]: values are heterogeneous (str title/description, tuple|None
+# config_path), so Any keeps the literal permissive while the keys stay typed.
+FEATURES: list[dict[str, Any]] = [
     {
         "key": "analytics",
         "title": "Analytics",

--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -53,7 +53,6 @@ exclude = "prototypes"
 [[tool.mypy.overrides]]
 module = [
     "hookwise_tui.data",
-    "hookwise_tui.tabs.dashboard",
     "tests.test_terminal_e2e",
 ]
 ignore_errors = true


### PR DESCRIPTION
## What

Un-quarantines `hookwise_tui.tabs.dashboard` for the #48 mypy ratchet.

`dashboard.py` carried 4 mypy errors: `FEATURES` was inferred as
`list[object]` because its dict values are heterogeneous (str
title/description, `tuple[str,str] | None` config_path), so every
`feature["key"]` / `feature["config_path"]` access tripped
index/arg-type errors. Annotating `FEATURES: list[dict[str, Any]]`
clears all 4 — the literal stays permissive while the keys stay typed.
No helper-signature churn (`_is_enabled`/`_get_detail`/`FeatureCard`
unchanged).

## Verification

- `mypy .` → Success: no issues found in 26 source files (dashboard now checked)
- Full TUI pytest → 117 passed, 7 snapshots, 20 deselected
- Annotation-only — zero behavior change

Quarantine now down to `data.py` (the substantive Go→Python boundary
file) + `test_terminal_e2e.py`.

Part of #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)