### PR TITLE
fix(tui): mypy ratchet — Protocol-type e2e session poller (#48)

### DIFF
--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -53,7 +53,6 @@ exclude = "prototypes"
 [[tool.mypy.overrides]]
 module = [
     "hookwise_tui.data",
-    "tests.test_terminal_e2e",
 ]
 ignore_errors = true
 

--- a/tui/tests/test_terminal_e2e.py
+++ b/tui/tests/test_terminal_e2e.py
@@ -19,7 +19,7 @@ import subprocess
 import time
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable
+from typing import Callable, Protocol
 
 import pytest
 
@@ -511,6 +511,21 @@ def capture_session_artifact(
     return artifact_path
 
 
+class _SessionLike(Protocol):
+    """Structural type for the terminal-harness session objects the Director polls.
+
+    Declared locally as a Protocol rather than importing TerminalSession because
+    terminal_harness is an untracked, local-only package (not present in CI), so
+    it cannot be imported for typing. Only the members the Director accesses on a
+    polled session are declared here.
+    """
+
+    @property
+    def is_alive(self) -> bool: ...
+
+    def get_screen_text(self) -> str: ...
+
+
 class DirectorPollLoop:
     """A Director-side polling loop that monitors multiple Actor sessions.
 
@@ -521,7 +536,7 @@ class DirectorPollLoop:
 
     def __init__(
         self,
-        sessions: dict[str, object],
+        sessions: dict[str, _SessionLike],
         poll_interval: float = 2.0,
         timeout: float = 300.0,
         on_completion: Callable[[PollResult], None] | None = None,


### PR DESCRIPTION
## What

Un-quarantines `tests.test_terminal_e2e` — the last **test-only** module
in the #48 mypy ratchet. `DirectorPollLoop._sessions` was typed
`dict[str, object]`, so `.is_alive` / `.get_screen_text()` tripped
`attr-defined` (3 errors).

## Fix

A local `_SessionLike` Protocol (`is_alive` property + `get_screen_text()`)
rather than importing `TerminalSession`. `terminal_harness` is an
untracked, local-only package (absent in CI), so a structural type keeps
the file type-checkable and importable in CI without depending on a
module that isn't there.

## Verification

- `mypy .` → Success: no issues found in 26 source files
- pytest outcome **byte-identical** with/without the change (stash-compared:
  120 passed; the 2 snapshot fails + 15 Claude-gated e2e errors are
  pre-existing local-environment artifacts, not introduced here — CI skips
  the Claude-gated tests via `@skipif_no_claude`)
- Annotation-only — zero behavior change

Quarantine now down to a single module: `data.py` (the Go→Python boundary
file — the substantive `union-attr` narrowing work, which deserves its own
careful PR).

Part of #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)