### PR TITLE
fix(tui): mypy ratchet — clear data.py, finish Phase 1 (#48)

### DIFF
--- a/tui/hookwise_tui/data.py
+++ b/tui/hookwise_tui/data.py
@@ -483,8 +483,8 @@ def read_insights(
         lines = session.get("lines_added", 0)
         dur = session.get("duration_minutes", 0)
 
-        total_messages += msgs if isinstance(msgs, (int, float)) else 0
-        total_lines += lines if isinstance(lines, (int, float)) else 0
+        total_messages += int(msgs) if isinstance(msgs, (int, float)) else 0
+        total_lines += int(lines) if isinstance(lines, (int, float)) else 0
         total_duration += dur if isinstance(dur, (int, float)) else 0
 
         # Tool counts
@@ -513,8 +513,8 @@ def read_insights(
                 date_str = start_time[:10]
             active_dates.add(date_str)
             daily_sessions[date_str] += 1
-            daily_messages[date_str] += msgs if isinstance(msgs, (int, float)) else 0
-            daily_lines[date_str] += lines if isinstance(lines, (int, float)) else 0
+            daily_messages[date_str] += int(msgs) if isinstance(msgs, (int, float)) else 0
+            daily_lines[date_str] += int(lines) if isinstance(lines, (int, float)) else 0
 
     # Read facets for friction
     friction_counts: Counter[str] = Counter()
@@ -533,7 +533,8 @@ def read_insights(
     avg_duration = total_duration / len(valid_sessions) if valid_sessions else 0
     top_tools = tool_counts.most_common(10)
     peak_hour_utc = max(range(24), key=lambda h: hour_counts[h]) if any(hour_counts) else 0
-    local_offset_hours = datetime.now().astimezone().utcoffset().total_seconds() / 3600
+    _utc_offset = datetime.now().astimezone().utcoffset()
+    local_offset_hours = _utc_offset.total_seconds() / 3600 if _utc_offset is not None else 0.0
     peak_hour = int((peak_hour_utc + local_offset_hours + 24) % 24)
     friction_total = sum(friction_counts.values())
 
@@ -609,6 +610,7 @@ def generate_insights_summary(
     # Generate with Claude API
     try:
         from anthropic import Anthropic
+        from anthropic.types import TextBlock
 
         client = Anthropic()
 
@@ -634,7 +636,10 @@ Respond in exactly this JSON format:
 
         if not response.content:
             return None
-        text = response.content[0].text.strip()
+        block = response.content[0]
+        if not isinstance(block, TextBlock):
+            return None
+        text = block.text.strip()
         # Strip markdown code fences if present
         if text.startswith("```"):
             text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
@@ -691,7 +696,7 @@ def read_recipes(config: dict[str, Any]) -> list[Recipe]:
             if isinstance(inc, str):
                 active_includes.add(inc)
 
-    results = []
+    results: list[Recipe] = []
     if not recipes_dir.is_dir():
         return results
 

--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -34,27 +34,19 @@ target-version = "py311"
 # mypy static type checking (#48).
 #
 # Adopted as a GATING baseline: the config passes on the current tree and so
-# guards every already-clean module plus all new code from new type errors —
-# the same staged shape used for ruff (#45) and golangci-lint (#44, errcheck
-# disabled). `disallow_untyped_defs` stays false (permissive start) per the #48
-# ratchet plan. The modules listed under the ignore_errors override below carry
-# a pre-existing error backlog (32 errors, mostly in the data.py Go→Python
-# boundary file); they are quarantined here and fixed incrementally — see #48
-# Phase 1. prototypes/ is excluded to match the ruff config (throwaway code).
+# guards every module plus all new code from new type errors — the same staged
+# shape used for ruff (#45) and golangci-lint (#44, errcheck disabled).
+# `disallow_untyped_defs` stays false (permissive start) per the #48 ratchet
+# plan. The #48 Phase 1 quarantine is now FULLY CLEARED: every module type-checks
+# clean, including the data.py Go→Python boundary file (union-attr narrowing on
+# Anthropic SDK block types) — so there is no longer an ignore_errors override.
+# prototypes/ is excluded to match the ruff config (throwaway code).
 [tool.mypy]
 python_version = "3.11"
 warn_unused_configs = true
 disallow_untyped_defs = false
 ignore_missing_imports = true
 exclude = "prototypes"
-
-# Quarantined baseline — ratchet down one module at a time (#48 Phase 1),
-# starting with the data.py / boundary files mypy is most valuable for.
-[[tool.mypy.overrides]]
-module = [
-    "hookwise_tui.data",
-]
-ignore_errors = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## What

Un-quarantines the **last** module, `hookwise_tui.data` (the Go→Python
boundary file, 17 mypy errors), and removes the now-empty `ignore_errors`
override. This completes **Phase 1** of #48 (fix existing errors + enforce
on new files): every TUI module type-checks clean and the mypy gate is now
a full ratchet with **zero exemptions**.

Phase 2 (`disallow_untyped_defs` on `data.py`/`bridge.py`) and Phase 3
(strict mode) remain — so this is `Part of #48`, not a close.

## Fixes (all real narrowing — no blanket ignores)

- **counts**: `int(msgs)` / `int(lines)` so the `Counter[str]` (int values)
  stays int — matches the existing `int(count)` pattern two lines down.
- **utcoffset**: capture the `timedelta | None` and guard `is not None`
  before `.total_seconds()` (an aware datetime never yields None in
  practice; `else 0.0`).
- **Anthropic block**: `isinstance(block, TextBlock)` narrowing (import
  `anthropic.types.TextBlock`) before `.text`; a non-text first block now
  returns `None` gracefully — previously a latent `AttributeError`.
- **annotation**: `results: list[Recipe] = []` in `read_recipes`.

## Verification

- `mypy .` → Success: no issues found in 26 source files (zero quarantine)
- `ruff check` clean
- pytest baseline **byte-identical** with/without the change (120 passed;
  the 2 snapshot fails + 15 Claude-gated e2e errors are pre-existing
  local-env artifacts — CI skips the Claude-gated tests)
- Behavior-preserving on the real data path; the new `None` branches are
  dead in practice and only add graceful degradation.

Part of #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)