### PR TITLE
chore(tui): mypy Phase 3 — global strict on all production source (#48)

### DIFF
--- a/tui/hookwise_tui/app.py
+++ b/tui/hookwise_tui/app.py
@@ -3,6 +3,7 @@
 import atexit
 import os
 from pathlib import Path
+from typing import Any
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -54,7 +55,7 @@ class HookwiseTUI(App):
         "snow", "heavy_snow", "sun", "fog", "cloudy",
     ]
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._weather_index = 0
 

--- a/tui/hookwise_tui/widgets/feature_card.py
+++ b/tui/hookwise_tui/widgets/feature_card.py
@@ -1,5 +1,7 @@
 """Reusable feature card widget — title, description, enabled badge."""
 
+from typing import Any
+
 from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.widget import Widget
@@ -57,7 +59,7 @@ class FeatureCard(Widget):
         description: str,
         enabled: bool = False,
         detail: str = "",
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self._title = title

--- a/tui/hookwise_tui/widgets/feed_health.py
+++ b/tui/hookwise_tui/widgets/feed_health.py
@@ -1,6 +1,7 @@
 """Feed health indicator widget."""
 
 from datetime import datetime, timezone
+from typing import Any
 
 from textual.app import ComposeResult
 from textual.widget import Widget
@@ -53,7 +54,7 @@ class FeedHealthWidget(Widget):
     }
     """
 
-    def __init__(self, feed: FeedHealth, **kwargs) -> None:
+    def __init__(self, feed: FeedHealth, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._feed = feed
 

--- a/tui/hookwise_tui/widgets/sparkline.py
+++ b/tui/hookwise_tui/widgets/sparkline.py
@@ -1,6 +1,7 @@
 """Sparkline widget for trend visualization using Rich Sparkline."""
 
 from collections.abc import Sequence
+from typing import Any
 
 from textual.app import ComposeResult
 from textual.widget import Widget
@@ -62,7 +63,7 @@ class SparklineWidget(Widget):
         label: str,
         values: Sequence[int | float],
         current_value: str = "",
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self._label = label

--- a/tui/hookwise_tui/widgets/weather_background.py
+++ b/tui/hookwise_tui/widgets/weather_background.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import math
 import random
+from typing import Any
 
 from rich.text import Text as RichText
 from textual.reactive import reactive
@@ -98,7 +99,7 @@ class WeatherBackground(Widget):
     weather: reactive[str] = reactive("rain")
     frame: reactive[int] = reactive(0)
 
-    def __init__(self, weather_info: WeatherInfo | None = None, **kwargs):
+    def __init__(self, weather_info: WeatherInfo | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.particles: list[_Particle] = []
         self.splashes: list[_Splash] = []

--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -36,29 +36,35 @@ target-version = "py311"
 # Adopted as a GATING baseline: the config passes on the current tree and so
 # guards every module plus all new code from new type errors — the same staged
 # shape used for ruff (#45) and golangci-lint (#44, errcheck disabled).
-# `disallow_untyped_defs` stays false at the top level (permissive start) per the
-# #48 ratchet plan. Phase 1 is FULLY CLEARED: every module type-checks clean,
-# including the data.py Go→Python boundary file (union-attr narrowing on Anthropic
-# SDK block types) — so there is no longer an ignore_errors override.
-#
-# Phase 2 (#48): `disallow_untyped_defs = true` is now enabled for the data.py
-# boundary module via the override below — every function there is already fully
-# annotated, so this locks that in and rejects any new untyped def in the file
-# mypy is most valuable for (the Go→JSON→Python seam, cf. Bug #29). The Python TUI
-# has no bridge.py (the bridge is Go: internal/bridge/), so data.py is the whole
-# boundary scope. Phase 3 (global strict) waits on the test suite (~144 untyped
-# test defs). prototypes/ is excluded to match the ruff config (throwaway code).
+# Ratchet history (#48): Phase 1 cleared the error backlog (no ignore_errors
+# override remains); Phase 2 enabled `disallow_untyped_defs` on the data.py
+# boundary module. Phase 3 (this config) flips `disallow_untyped_defs = true` at
+# the TOP LEVEL, so ALL production source (hookwise_tui/**, 18 files) now requires
+# full annotation — including the Go→JSON→Python seam where Bug #29 lived. The
+# only remaining permissive scope is the test modules listed in the override
+# below, which still carry untyped test defs (~150) and are ratcheted separately.
+# New production code cannot regress. prototypes/ is excluded (throwaway code).
 [tool.mypy]
 python_version = "3.11"
 warn_unused_configs = true
-disallow_untyped_defs = false
+disallow_untyped_defs = true
 ignore_missing_imports = true
 exclude = "prototypes"
 
-# Phase 2 ratchet: enforce full annotation on the boundary module (#48).
+# Test modules with a remaining untyped-def backlog — quarantined from the
+# strict gate and annotated incrementally (#48 Phase 3 tail). Production source
+# is fully strict; only these test files stay permissive.
 [[tool.mypy.overrides]]
-module = "hookwise_tui.data"
-disallow_untyped_defs = true
+module = [
+    "tests.test_app",
+    "tests.test_data",
+    "tests.test_snapshots",
+    "tests.test_status_live_output",
+    "tests.test_status_segments",
+    "tests.test_terminal_e2e",
+    "tests.test_weather",
+]
+disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## What

Flips the top-level mypy `disallow_untyped_defs = true`. **All production
source** (`hookwise_tui/**`, 18 files) now requires full annotation —
including the Go→JSON→Python seam where Bug #29 lived. Only **7 test
modules** with a remaining untyped backlog stay permissive via a
per-module override, so production code can no longer regress.

This extends the strict gate from just `data.py` (Phase 2) to the entire
source tree.

## The 5 source fixes

All five untyped defs were forwarded `**kwargs` on textual `__init__`s
(`sparkline`, `feature_card`, `feed_health`, `weather_background`, `app`).

Annotated `**kwargs: Any` — **not** `object`: textual ships `py.typed`, so
its `Widget`/`App.__init__` are *typed*, and unpacking a `dict[str, object]`
into them fails `arg-type` ("expected `str | None` / `bool` /
`type[Driver]`"). `Any` is what's compatible with a typed super's params.
(The strict gate itself caught the `object` mistake.)

## Verification

- `mypy .` → Success: no issues found in 26 source files
- **Ratchet-bite proven**: an untyped def added to a source widget fails
  `no-untyped-def`
- `ruff check` clean
- pytest baseline **byte-identical** (120 passed) — annotation-only

Remaining tail: annotate the 7 quarantined test modules (~150 defs) to
reach full-tree strict. Tracked on #48.

Part of #48 (Phase 3 — source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code type safety across the application through improved type annotations.
  * Updated development type-checking configuration to enforce stricter typing standards for better code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->