### PR TITLE
test(core): harden EventTypes registry against silent swap

### DIFF
--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -34,6 +34,56 @@ func TestEventTypesCount(t *testing.T) {
 	}
 }
 
+// TestEventTypesRegistryComplete guards the EventTypes registry against a silent
+// corruption that the count + partial-enumeration tests above miss: a *swap*
+// (dropping one constant and padding length with a duplicate of another) keeps
+// len==13 and leaves TestIsEventType green while making IsEventType reject a real
+// event. Since IsEventType gates dispatch event validation, that regression must
+// not pass silently. This asserts the registry is exactly the set of named
+// Event* constants — no drop, no duplicate, no foreign entry.
+func TestEventTypesRegistryComplete(t *testing.T) {
+	allConsts := []string{
+		EventUserPromptSubmit,
+		EventPreToolUse,
+		EventPostToolUse,
+		EventPostToolUseFailure,
+		EventNotification,
+		EventStop,
+		EventSubagentStart,
+		EventSubagentStop,
+		EventPreCompact,
+		EventSessionStart,
+		EventSessionEnd,
+		EventPermissionRequest,
+		EventSetup,
+	}
+
+	// Every named constant must be recognized — catches a constant dropped from
+	// the EventTypes slice (even if length is padded back with a duplicate).
+	for _, c := range allConsts {
+		if !IsEventType(c) {
+			t.Errorf("named event constant %q is not in the EventTypes registry", c)
+		}
+	}
+
+	// EventTypes must contain no duplicates and no entry outside the const set —
+	// catches a duplicate-paste or a stray/foreign value.
+	seen := make(map[string]struct{}, len(EventTypes))
+	constSet := make(map[string]struct{}, len(allConsts))
+	for _, c := range allConsts {
+		constSet[c] = struct{}{}
+	}
+	for _, et := range EventTypes {
+		if _, dup := seen[et]; dup {
+			t.Errorf("EventTypes contains duplicate entry %q", et)
+		}
+		seen[et] = struct{}{}
+		if _, ok := constSet[et]; !ok {
+			t.Errorf("EventTypes contains %q which is not a named Event* constant", et)
+		}
+	}
+}
+
 func TestHookPayloadIsValid(t *testing.T) {
 	valid := HookPayload{SessionID: "abc-123"}
 	if !valid.IsValidPayload() {


### PR DESCRIPTION
## What

`internal/core/types_test.go` checks `len(EventTypes)==13` and enumerates
only **6 of the 13** event constants. That leaves a real silent-regression
gap: a **swap** — dropping a constant (e.g. `EventStop`) and padding length
back with a duplicate of another — keeps `len==13` and leaves both existing
tests green, while `IsEventType("Stop")` then silently returns `false`.

`IsEventType` gates dispatch **event validation**, so a dropped event type
must not pass CI silently.

## Fix

Adds `TestEventTypesRegistryComplete`:
- every named `Event*` constant must be recognized by the registry (catches a drop)
- no duplicate entries (catches the padding)
- no entry outside the named-constant set (catches a foreign value)

## Verification (mutation-proven)

Applied the exact swap (drop `EventStop`, duplicate `EventSetup`, `len` stays 13):
- ✅ `TestEventTypesRegistryComplete` **fails** with 2 precise errors (`"Stop" not in registry`, `duplicate entry "Setup"`)
- ✅ `TestEventTypesCount` and `TestIsEventType` **both still pass** under the mutation — demonstrating exactly the gap this closes

Test-only, zero production change. Guarded gate green (`internal/core`, `-race -p 2`, 0 zombies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)