### PR TITLE
fix(feeds): map WMO snow showers (85/86) — were rendering as sunny/Unknown

### DIFF
--- a/internal/feeds/producer_weather.go
+++ b/internal/feeds/producer_weather.go
@@ -53,6 +53,8 @@ func wmoCodeToEmoji(code int) string {
 		return "\u2744\ufe0f" // snow
 	case code >= 80 && code <= 82:
 		return "\U0001f326\ufe0f" // sun behind rain cloud
+	case code >= 85 && code <= 86:
+		return "\u2744\ufe0f" // snow showers
 	case code >= 95 && code <= 99:
 		return "\u26c8\ufe0f" // thunderstorm
 	default:
@@ -83,6 +85,8 @@ func wmoCodeToDescription(code int) string {
 		return "Snow Grains"
 	case code >= 80 && code <= 82:
 		return "Showers"
+	case code >= 85 && code <= 86:
+		return "Snow Showers"
 	case code >= 95 && code <= 99:
 		return "Thunderstorm"
 	default:

--- a/internal/feeds/producer_weather_test.go
+++ b/internal/feeds/producer_weather_test.go
@@ -31,3 +31,81 @@ func TestWeatherProducer_FallbackNoCache_NilNumerics(t *testing.T) {
 	assert.Equal(t, "fahrenheit", data["temperatureUnit"])
 	assert.Equal(t, "Unavailable", data["description"])
 }
+
+// TestWmoCodeToEmoji pins the WMO weather-code → emoji mapping across every
+// standard Open-Meteo code. These functions are otherwise reached only via a live
+// HTTP call, so they had zero coverage. Codes 85/86 (snow showers) are the bug
+// this locks down: they previously fell through to the default sunny-ish icon.
+//
+// Rather than hardcode emoji byte sequences (variation-selector fragile), each
+// code is asserted to share the emoji of a reference code in its expected bucket
+// — both sides come from the same function, so the comparison is byte-exact.
+func TestWmoCodeToEmoji(t *testing.T) {
+	const (
+		refSunny   = 0
+		refPartly  = 1
+		refFog     = 45
+		refRain    = 51
+		refSnow    = 71
+		refShowers = 80
+		refThunder = 95
+		refDefault = 100
+	)
+	cases := []struct {
+		code int
+		ref  int
+	}{
+		{0, refSunny},
+		{1, refPartly}, {2, refPartly}, {3, refPartly},
+		{45, refFog}, {48, refFog},
+		{51, refRain}, {53, refRain}, {55, refRain},
+		{56, refRain}, {57, refRain},
+		{61, refRain}, {63, refRain}, {65, refRain},
+		{66, refRain}, {67, refRain},
+		{71, refSnow}, {73, refSnow}, {75, refSnow}, {77, refSnow},
+		{80, refShowers}, {81, refShowers}, {82, refShowers},
+		{85, refSnow}, {86, refSnow}, // snow showers — regression guard
+		{95, refThunder}, {96, refThunder}, {99, refThunder},
+		{-1, refDefault}, {1000, refDefault}, // out of range → default
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, wmoCodeToEmoji(tc.ref), wmoCodeToEmoji(tc.code),
+			"wmoCodeToEmoji(%d) should share the bucket of code %d", tc.code, tc.ref)
+	}
+
+	// The buckets must be genuinely distinct — otherwise the reference-equality
+	// checks above could pass trivially if everything returned one emoji. Spot-
+	// check that snow showers do NOT collapse into the default (the actual bug).
+	assert.NotEqual(t, wmoCodeToEmoji(refDefault), wmoCodeToEmoji(85),
+		"snow showers (85) must not render as the default sunny-ish icon")
+	assert.NotEqual(t, wmoCodeToEmoji(refSunny), wmoCodeToEmoji(refSnow),
+		"distinct buckets must yield distinct emoji")
+}
+
+// TestWmoCodeToDescription pins the WMO weather-code → label mapping across every
+// standard Open-Meteo code. Codes 85/86 (snow showers) previously returned
+// "Unknown"; this guards the fix.
+func TestWmoCodeToDescription(t *testing.T) {
+	cases := []struct {
+		code int
+		want string
+	}{
+		{0, "Clear"},
+		{1, "Partly Cloudy"}, {2, "Partly Cloudy"}, {3, "Partly Cloudy"},
+		{45, "Fog"}, {48, "Fog"},
+		{51, "Drizzle"}, {53, "Drizzle"}, {55, "Drizzle"},
+		{56, "Freezing Drizzle"}, {57, "Freezing Drizzle"},
+		{61, "Rain"}, {63, "Rain"}, {65, "Rain"},
+		{66, "Freezing Rain"}, {67, "Freezing Rain"},
+		{71, "Snow"}, {73, "Snow"}, {75, "Snow"},
+		{77, "Snow Grains"},
+		{80, "Showers"}, {81, "Showers"}, {82, "Showers"},
+		{85, "Snow Showers"}, {86, "Snow Showers"}, // regression guard
+		{95, "Thunderstorm"}, {96, "Thunderstorm"}, {99, "Thunderstorm"},
+		{-1, "Unknown"}, {100, "Unknown"}, // out of range → Unknown
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, wmoCodeToDescription(tc.code),
+			"wmoCodeToDescription(%d)", tc.code)
+	}
+}


### PR DESCRIPTION
## The bug

WMO codes **85/86 (snow showers)** — standard, commonly-returned Open-Meteo
codes — were unmapped in **both** `wmoCodeToEmoji` and
`wmoCodeToDescription` (`internal/feeds/producer_weather.go`). They fell
through to the `default` arm:

- `wmoCodeToEmoji(85)` → 🌤️ sun-behind-small-cloud (**reads as sunny**)
- `wmoCodeToDescription(85)` → **"Unknown"**

So during snow showers the weather feed rendered a partly-sunny icon and
"Unknown" text — a user-facing correctness bug.

## The fix

Adds `case code >= 85 && code <= 86` → snow emoji (`❄️`, matching
the existing 71–77 snow bucket exactly) / `"Snow Showers"` in both functions.

## Tests (TDD)

Both mapping functions had **zero coverage** — they're reached only via a
live HTTP call inside `Produce()`, which fails in CI and falls back before
hitting them. This adds comprehensive table-driven tests over every standard
WMO code in both:

- **emoji** test compares each code to a *reference code* in its expected
  bucket (e.g. `85` vs `71`-snow) — byte-exact and immune to the
  variation-selector fragility of hardcoding emoji literals; plus a spot-check
  that snow showers do **not** collapse into the default.
- **description** test uses plain ASCII literals.

Red on 85/86 first (the rest of the table pinned existing behavior green),
green after the fix.

## Verification

- Guarded gate green: `internal/feeds`, `-race -p 2`, 0 zombies
- `gofmt` + `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)