### PR TITLE
fix(feeds): atomic write-back of refreshed calendar OAuth token

### DIFF
--- a/internal/feeds/producer_calendar.go
+++ b/internal/feeds/producer_calendar.go
@@ -126,12 +126,10 @@ func writeBackToken(tokenPath string, tok *oauth2.Token, cfg *oauth2.Config) {
 		ptf.Expiry = tok.Expiry.UTC().Format(time.RFC3339)
 	}
 
-	data, err := json.MarshalIndent(ptf, "", "  ")
-	if err != nil {
-		core.Logger().Debug("calendar: failed to marshal token for write-back", "error", err)
-		return
-	}
-	if err := os.WriteFile(tokenPath, data, 0600); err != nil {
+	// Atomic write (temp file + rename) so a crash or kill mid-write cannot
+	// truncate the credential file and force a full re-auth. AtomicWriteJSON
+	// also writes 0600, matching the prior permissions.
+	if err := core.AtomicWriteJSON(tokenPath, ptf); err != nil {
 		core.Logger().Debug("calendar: failed to write-back token", "error", err)
 	}
 }

--- a/internal/feeds/producer_calendar_test.go
+++ b/internal/feeds/producer_calendar_test.go
@@ -14,8 +14,55 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
 	"github.com/vishnujayvel/hookwise/internal/core"
 )
+
+// TestWriteBackToken_AtomicAndSecure pins the contract of writeBackToken (which
+// had no coverage): the refreshed OAuth token is persisted in the Python
+// google-auth format, with 0600 permissions (a credential file must never be
+// world-readable), and via an atomic write that leaves no partial/temp files.
+// The 0600 assertion is a real security-regression guard.
+func TestWriteBackToken_AtomicAndSecure(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token.json")
+
+	tok := &oauth2.Token{
+		AccessToken:  "access-xyz",
+		RefreshToken: "refresh-abc",
+		Expiry:       time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+	cfg := &oauth2.Config{
+		ClientID:     "cid",
+		ClientSecret: "secret",
+		Endpoint:     oauth2.Endpoint{TokenURL: "https://oauth2.example/token"},
+	}
+
+	writeBackToken(tokenPath, tok, cfg)
+
+	// Credential file must be 0600.
+	info, err := os.Stat(tokenPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "token file must be 0600")
+
+	// Round-trips as the Python google-auth token format with the right fields.
+	data, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	var ptf pythonTokenFile
+	require.NoError(t, json.Unmarshal(data, &ptf))
+	assert.Equal(t, "access-xyz", ptf.Token)
+	assert.Equal(t, "refresh-abc", ptf.RefreshToken)
+	assert.Equal(t, "cid", ptf.ClientID)
+	assert.Equal(t, "secret", ptf.ClientSecret)
+	assert.Equal(t, "https://oauth2.example/token", ptf.TokenURI)
+	assert.Equal(t, "2030-01-02T03:04:05Z", ptf.Expiry)
+
+	// Atomic write must leave no partial/temp files behind — only the token file.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "only the token file should remain (no .tmp-* leftovers)")
+}
 
 // calendarMockServer handles both the OAuth token endpoint and the Calendar
 // events endpoint on a single httptest.Server.


### PR DESCRIPTION
## The bug (robustness, credential path)

`writeBackToken` (`internal/feeds/producer_calendar.go`) persisted the
refreshed Google OAuth token with a **non-atomic** `os.WriteFile`. A crash
or kill mid-write truncates the credential file — after which the Python
`calendar-feed.py` can no longer load it and the user must perform a **full
re-auth**.

## Fix

Switches to `core.AtomicWriteJSON` (temp file + `rename`), which writes the
**same `0600`** permissions and the same indented JSON. A partial write can
never replace a good token file.

## Tests

`writeBackToken` had **no coverage**. Adds `TestWriteBackToken_AtomicAndSecure`
pinning:
- **`0600` permissions** — a security-regression guard for a credential file
- the Python google-auth field format (token/refresh/client_id/secret/uri/expiry)
- **no temp/partial files** left behind (atomicity)

Baseline-green on the old code, stays green after the refactor. **Mutation-proven**:
reverting to `os.WriteFile(..., 0644)` fails the `0600` assertion (`0x180` vs `0x1a4`).

## Provenance

Extracted from the stale, `CONFLICTING` PR #73 (`architecture-v2-part2`) — one
of its few genuinely-unmerged, non-obsolete fixes, re-implemented cleanly against
current `main`.

Guarded gate green (`internal/feeds`, `-race -p 2`, 0 zombies); `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)