### PR TITLE
chore(analytics): remove dead WriteFeedCacheJSON pair

### DIFF
--- a/internal/analytics/state.go
+++ b/internal/analytics/state.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/vishnujayvel/hookwise/internal/core"
@@ -309,23 +308,6 @@ func (d *DB) ReadAllFeedCache(ctx context.Context) (map[string]interface{}, erro
 		return nil, fmt.Errorf("analytics: feed_cache rows: %w", err)
 	}
 	return result, nil
-}
-
-// WriteFeedCacheJSON writes the feed cache data to the JSON bridge file
-// at ~/.hookwise/state/status-line-cache.json for the Python TUI (R9.1).
-//
-// The output format is: {"key1": <data>, "key2": <data>, ...}
-// This function respects ARCH-3: it is called from the dispatch process,
-// not the daemon.
-func WriteFeedCacheJSON(cacheData map[string]interface{}) error {
-	path := filepath.Join(core.GetStateDir(), "state", "status-line-cache.json")
-	return core.AtomicWriteJSON(path, cacheData)
-}
-
-// WriteFeedCacheJSONTo writes the feed cache data to a specified path.
-// This variant is used in tests to avoid writing to the real state directory.
-func WriteFeedCacheJSONTo(path string, cacheData map[string]interface{}) error {
-	return core.AtomicWriteJSON(path, cacheData)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/analytics/state_test.go
+++ b/internal/analytics/state_test.go
@@ -2,7 +2,6 @@ package analytics
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -315,89 +314,6 @@ func TestReadAllFeedCache_MultipleEntries(t *testing.T) {
 	sessionData, ok := all["session"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, true, sessionData["active"])
-}
-
-// Test 15: WriteFeedCacheJSON creates JSON file at correct path
-func TestWriteFeedCacheJSON_CreatesFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "hookwise-feed-json-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	outPath := filepath.Join(tmpDir, "status-line-cache.json")
-
-	cacheData := map[string]interface{}{
-		"weather": map[string]interface{}{"temp": float64(72)},
-		"costs":   map[string]interface{}{"total": float64(5.5)},
-	}
-
-	require.NoError(t, WriteFeedCacheJSONTo(outPath, cacheData))
-
-	// Verify file exists.
-	info, err := os.Stat(outPath)
-	require.NoError(t, err)
-	assert.True(t, info.Size() > 0)
-}
-
-// Test 16: WriteFeedCacheJSON file content matches expected format
-func TestWriteFeedCacheJSON_ContentFormat(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "hookwise-feed-json-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	outPath := filepath.Join(tmpDir, "status-line-cache.json")
-
-	cacheData := map[string]interface{}{
-		"weather": map[string]interface{}{
-			"temperature": float64(72),
-			"unit":        "F",
-		},
-		"session_info": map[string]interface{}{
-			"active":   true,
-			"duration": float64(300),
-		},
-	}
-
-	require.NoError(t, WriteFeedCacheJSONTo(outPath, cacheData))
-
-	// Read the file back and verify structure.
-	raw, err := os.ReadFile(outPath)
-	require.NoError(t, err)
-
-	var parsed map[string]interface{}
-	require.NoError(t, json.Unmarshal(raw, &parsed))
-
-	// Top-level keys should be the cache keys.
-	assert.Contains(t, parsed, "weather")
-	assert.Contains(t, parsed, "session_info")
-
-	// Verify nested structure.
-	weather, ok := parsed["weather"].(map[string]interface{})
-	require.True(t, ok, "weather should be a map")
-	assert.Equal(t, float64(72), weather["temperature"])
-	assert.Equal(t, "F", weather["unit"])
-
-	session, ok := parsed["session_info"].(map[string]interface{})
-	require.True(t, ok, "session_info should be a map")
-	assert.Equal(t, true, session["active"])
-	assert.Equal(t, float64(300), session["duration"])
-}
-
-// Test 17: WriteFeedCacheJSON with empty map creates valid JSON
-func TestWriteFeedCacheJSON_EmptyMap(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "hookwise-feed-json-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	outPath := filepath.Join(tmpDir, "status-line-cache.json")
-
-	require.NoError(t, WriteFeedCacheJSONTo(outPath, map[string]interface{}{}))
-
-	raw, err := os.ReadFile(outPath)
-	require.NoError(t, err)
-
-	var parsed map[string]interface{}
-	require.NoError(t, json.Unmarshal(raw, &parsed))
-	assert.Empty(t, parsed)
 }
 
 // Test 18: Feed cache overwrite replaces existing entry


### PR DESCRIPTION
## What

Removes `WriteFeedCacheJSON` and its test-only sibling `WriteFeedCacheJSONTo` from `internal/analytics/state.go`, plus the 3 orphaned `TestWriteFeedCacheJSON_*` tests and now-unused imports.

## Why

`WriteFeedCacheJSON` had **zero callers** anywhere (verified via grep across `internal/`, `cmd/`, `pkg/`, and the Python `tui/`). `WriteFeedCacheJSONTo` existed *only* to test it — it is a thin wrapper over `core.AtomicWriteJSON` and is called solely from `state_test.go`.

The live production writer of `status-line-cache.json` is `internal/bridge/bridge.go` (`WriteTUICache` → `FlattenForTUI` → `core.AtomicWriteJSON`), which has its own coverage. The analytics pair was fully superseded — most likely a leftover from before the bridge took over the TUI cache write.

Extracted from the stale architecture PR #73 (CONFLICTING) as a small, isolated cleanup.

## Coverage

No loss: the deleted tests pinned a format produced by a dead function. `core.AtomicWriteJSON` and `bridge.go` retain their own tests.

## Verification

- `go build ./...` + `go vet ./internal/analytics/` clean
- Guarded gate green: `GOMEMLIMIT=4GiB go test -race -p 2 -timeout 120s ./internal/analytics/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)