### PR TITLE
fix(status-line): clearer warning segment label + output test

### DIFF
--- a/cmd/hookwise/cmd_status_line.go
+++ b/cmd/hookwise/cmd_status_line.go
@@ -202,9 +202,11 @@ func renderWarningSegment(stateDir string) string {
 	if len(warnings) == 0 {
 		return ""
 	}
-	// Most recent warning is last in the slice.
+	// Most recent warning is last in the slice. Label the count with a noun and
+	// parenthesise the source so "2 cost" can't be misread as a quantity (#181).
 	mostRecentSource := warnings[len(warnings)-1].Source
-	return fmt.Sprintf("%s\u26a0 %d %s%s", ansiYellow, len(warnings), mostRecentSource, ansiReset)
+	return fmt.Sprintf("%s\u26a0 %d warning%s (%s)%s",
+		ansiYellow, len(warnings), pluralS(len(warnings)), mostRecentSource, ansiReset)
 }
 
 // pluralS returns "s" when count != 1, "" otherwise.

--- a/cmd/hookwise/cmd_status_line_warning_test.go
+++ b/cmd/hookwise/cmd_status_line_warning_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// seedWarnings writes a warnings.json under <stateDir>/state/ with the given
+// (source) entries, each stamped fresh (now) so ReadWarnings' TTL keeps them
+// active. Returns the stateDir to pass to renderWarningSegment.
+func seedWarnings(t *testing.T, sources ...string) string {
+	t.Helper()
+	stateDir := t.TempDir()
+	dir := filepath.Join(stateDir, "state")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	warnings := make([]core.Warning, 0, len(sources))
+	for _, s := range sources {
+		warnings = append(warnings, core.Warning{Source: s, Message: "m", Timestamp: now})
+	}
+	data, err := json.Marshal(warnings)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "warnings.json"), data, 0o600))
+	return stateDir
+}
+
+// TestRenderWarningSegment pins the rendered status-line warning segment, which
+// previously had no output-test coverage (issue #181). It asserts:
+//   - no warnings  → empty segment;
+//   - one warning  → singular noun "warning" + the source in a labelled form;
+//   - N warnings   → count + plural "warnings" + the MOST RECENT source (last).
+//
+// The ANSI colour codes wrap the payload as a prefix/suffix, so the human-
+// readable core string appears verbatim and Contains assertions are exact.
+func TestRenderWarningSegment(t *testing.T) {
+	t.Run("no warnings renders empty", func(t *testing.T) {
+		stateDir := seedWarnings(t) // no entries
+		assert.Equal(t, "", renderWarningSegment(stateDir))
+	})
+
+	t.Run("missing file renders empty", func(t *testing.T) {
+		assert.Equal(t, "", renderWarningSegment(t.TempDir()))
+	})
+
+	t.Run("single warning uses singular noun", func(t *testing.T) {
+		stateDir := seedWarnings(t, "cost")
+		out := renderWarningSegment(stateDir)
+		assert.Contains(t, out, "⚠ 1 warning (cost)",
+			"single warning must read '⚠ 1 warning (cost)' (singular, labelled)")
+		assert.NotContains(t, out, "1 warnings",
+			"singular count must not pluralise the noun")
+	})
+
+	t.Run("multiple warnings pluralise and show most-recent source", func(t *testing.T) {
+		// 'memories' is appended last, so it is the most-recent source.
+		stateDir := seedWarnings(t, "cost", "weather", "memories")
+		out := renderWarningSegment(stateDir)
+		assert.Contains(t, out, "⚠ 3 warnings (memories)",
+			"multiple warnings must read '⚠ 3 warnings (<most-recent source>)'")
+		assert.NotContains(t, out, "(cost)",
+			"the segment must surface the most-recent source, not the oldest")
+	})
+}


### PR DESCRIPTION
Closes #181.

## What

`renderWarningSegment` rendered `⚠ 2 cost` — the warning count followed by the most-recent warning's bare *source*, with no noun. It reads ambiguously ("2 cost"? cost of 2?). Its sibling `renderNotificationSegment` already uses a labelled form + the `pluralS` helper.

This relabels the segment to `⚠ N warning(s) (source)` (e.g. `⚠ 1 warning (cost)`, `⚠ 3 warnings (memories)`) using the existing `pluralS` helper, and adds the **missing output test** — the segment previously had zero coverage.

## Test (TDD)

`cmd_status_line_warning_test.go` pins: no warnings → `""`, missing file → `""`, single → singular `warning` noun, N → plural + the most-recent source (last in slice). Written first, confirmed red on the old format, green after the fix.

## Safety

Pure rendering function — no daemon, no hot path, no SQLite writes, ARCH-1 fail-open unaffected. No contract fixture references the warning glyph.

## Verification

- Guarded gate green: `GOMEMLIMIT=4GiB go test -race -p 2 ./cmd/hookwise/`
- `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Warning count display now uses correct singular/plural wording based on the number of warnings present.
  * Warning source information is now included in parentheses for clearer attribution and context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->