### PR TITLE
chore(tui): mypy-strict test_app.py, drop from quarantine (#48)

### DIFF
--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -56,7 +56,6 @@ exclude = "prototypes"
 # is fully strict; only these test files stay permissive.
 [[tool.mypy.overrides]]
 module = [
-    "tests.test_app",
     "tests.test_data",
     "tests.test_snapshots",
     "tests.test_status_live_output",

--- a/tui/tests/test_app.py
+++ b/tui/tests/test_app.py
@@ -1,27 +1,29 @@
 """Tests for hookwise_tui.app — Textual pilot tests."""
 
 import pytest
+from textual.widgets import TabbedContent
 
 from hookwise_tui.app import HookwiseTUI
 
 
 @pytest.fixture
-def app():
+def app() -> HookwiseTUI:
     return HookwiseTUI()
 
 
 class TestHookwiseTUI:
-    async def test_app_launches(self, app):
+    async def test_app_launches(self, app: HookwiseTUI) -> None:
         """App starts without error and shows header."""
         async with app.run_test():
             assert app.title == "Hookwise"
             assert app.sub_title == "Claude Code Hooks Dashboard"
 
-    async def test_tab_switching_with_keys(self, app):
+    async def test_tab_switching_with_keys(self, app: HookwiseTUI) -> None:
         """Number keys switch between tabs."""
         async with app.run_test() as pilot:
-            # Default is first tab (Dashboard)
-            tabs = app.query_one("TabbedContent")
+            # Default is first tab (Dashboard). Query by type so the result is
+            # a typed TabbedContent (with .active), not a bare Widget.
+            tabs = app.query_one(TabbedContent)
             assert tabs.active == "dashboard"
 
             await pilot.press("2")
@@ -36,20 +38,20 @@ class TestHookwiseTUI:
             await pilot.press("1")
             assert tabs.active == "dashboard"
 
-    async def test_quit_key(self, app):
+    async def test_quit_key(self, app: HookwiseTUI) -> None:
         """q key exits the app."""
         async with app.run_test() as pilot:
             await pilot.press("q")
             # App should be in exit state after pressing q
 
-    async def test_all_tabs_render(self, app):
+    async def test_all_tabs_render(self, app: HookwiseTUI) -> None:
         """Each tab renders without crashing."""
         async with app.run_test() as pilot:
             for key in ["1", "2", "3", "4", "5", "6", "7"]:
                 await pilot.press(key)
                 # No exception = tab renders fine
 
-    async def test_dashboard_has_feature_cards(self, app):
+    async def test_dashboard_has_feature_cards(self, app: HookwiseTUI) -> None:
         """Dashboard tab contains FeatureCard widgets."""
         async with app.run_test():
             from hookwise_tui.widgets.feature_card import FeatureCard
@@ -57,7 +59,7 @@ class TestHookwiseTUI:
             # Should have at least the 7 features from dashboard
             assert len(list(cards)) >= 1
 
-    async def test_feeds_tab_has_timer(self, app):
+    async def test_feeds_tab_has_timer(self, app: HookwiseTUI) -> None:
         """Feeds tab shows refresh timer."""
         async with app.run_test() as pilot:
             await pilot.press("4")


### PR DESCRIPTION
Refs #48 (incremental — one quarantined module per PR).

## What

`#48` Phase 3 left 7 legacy TUI test modules behind a `disallow_untyped_defs = false` override in `tui/pyproject.toml`. This annotates the smallest (`tests/test_app.py`, 7 defs) and removes it from the override, shrinking the quarantine to 6.

- fixture `app() -> HookwiseTUI`
- six `async def test_*(self, app: HookwiseTUI) -> None`

## Strict typing caught a real issue

`app.query_one("TabbedContent")` returns a bare `Widget`, which has no `.active` attribute (5 `attr-defined` errors under strict). Fixed with the typed overload `app.query_one(TabbedContent)` (import from `textual.widgets`) — the correct fix, not a `# type: ignore`.

## Why now

The "frozen quarantine has zero guarding value" assumption is fragile: any edit to a quarantined file slips untyped defs through unguarded. Draining it one module per PR closes that gap and removes a config special-case.

## Verification

- `mypy` strict clean on `test_app.py` **and** full project (26 files)
- `ruff` clean
- `pytest tests/test_app.py` 6/6 — annotations + typed query are behavior-preserving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for quit functionality, tab rendering, and dashboard elements.
  * Improved type annotations across the test suite to strengthen type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->