### PR TITLE
chore(tui): mypy-strict test_weather.py + remove quarantine (closes #48)

### DIFF
--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -38,27 +38,18 @@ target-version = "py311"
 # shape used for ruff (#45) and golangci-lint (#44, errcheck disabled).
 # Ratchet history (#48): Phase 1 cleared the error backlog (no ignore_errors
 # override remains); Phase 2 enabled `disallow_untyped_defs` on the data.py
-# boundary module. Phase 3 (this config) flips `disallow_untyped_defs = true` at
-# the TOP LEVEL, so ALL production source (hookwise_tui/**, 18 files) now requires
-# full annotation — including the Go→JSON→Python seam where Bug #29 lived. The
-# only remaining permissive scope is the test modules listed in the override
-# below, which still carry untyped test defs (~150) and are ratcheted separately.
-# New production code cannot regress. prototypes/ is excluded (throwaway code).
+# boundary module. Phase 3 flipped `disallow_untyped_defs = true` at the TOP
+# LEVEL, so ALL production source (hookwise_tui/**) requires full annotation —
+# including the Go→JSON→Python seam where Bug #29 lived. The Phase-3 tail then
+# drained the per-module test quarantine one file at a time (#187–#193); the
+# override block is now gone, so EVERY module (production AND test) is strict.
+# New code cannot regress. prototypes/ is excluded (throwaway code).
 [tool.mypy]
 python_version = "3.11"
 warn_unused_configs = true
 disallow_untyped_defs = true
 ignore_missing_imports = true
 exclude = "prototypes"
-
-# Test modules with a remaining untyped-def backlog — quarantined from the
-# strict gate and annotated incrementally (#48 Phase 3 tail). Production source
-# is fully strict; only these test files stay permissive.
-[[tool.mypy.overrides]]
-module = [
-    "tests.test_weather",
-]
-disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tui/tests/test_weather.py
+++ b/tui/tests/test_weather.py
@@ -1,5 +1,9 @@
 """Tests for weather background widget and weather data bridge."""
 
+from __future__ import annotations
+
+from typing import Any
+
 from hookwise_tui.widgets.weather_data import (
     WEATHER_CODE_MAP,
     VALID_CONDITIONS,
@@ -18,35 +22,35 @@ from hookwise_tui.widgets.weather_background import (
 
 
 class TestWeatherInfo:
-    def test_display_condition(self):
+    def test_display_condition(self) -> None:
         info = WeatherInfo(
             city="Seattle", condition="rain", code=61,
             temp_c=9, temp_f=48, wind_speed=12,
         )
         assert info.display_condition == "Rain"
 
-    def test_display_condition_clear(self):
+    def test_display_condition_clear(self) -> None:
         info = WeatherInfo(
             city="LA", condition="clear", code=0,
             temp_c=25, temp_f=77, wind_speed=5,
         )
         assert info.display_condition == "Clear"
 
-    def test_display_condition_heavy_rain(self):
+    def test_display_condition_heavy_rain(self) -> None:
         info = WeatherInfo(
             city="Portland", condition="heavy_rain", code=65,
             temp_c=7, temp_f=45, wind_speed=20,
         )
         assert info.display_condition == "Heavy Rain"
 
-    def test_condition_emoji(self):
+    def test_condition_emoji(self) -> None:
         info = WeatherInfo(
             city="Seattle", condition="rain", code=61,
             temp_c=9, temp_f=48, wind_speed=12,
         )
         assert info.condition_emoji != ""
 
-    def test_condition_emoji_snow(self):
+    def test_condition_emoji_snow(self) -> None:
         info = WeatherInfo(
             city="Denver", condition="snow", code=71,
             temp_c=-2, temp_f=28, wind_speed=10,
@@ -58,32 +62,32 @@ class TestWeatherInfo:
 
 
 class TestWeatherCodeMap:
-    def test_clear_codes(self):
+    def test_clear_codes(self) -> None:
         assert WEATHER_CODE_MAP[0] == "clear"
         assert WEATHER_CODE_MAP[1] == "clear"
 
-    def test_rain_codes(self):
+    def test_rain_codes(self) -> None:
         assert WEATHER_CODE_MAP[61] == "rain"
         assert WEATHER_CODE_MAP[63] == "rain"
         assert WEATHER_CODE_MAP[65] == "heavy_rain"
 
-    def test_snow_codes(self):
+    def test_snow_codes(self) -> None:
         assert WEATHER_CODE_MAP[71] == "snow"
         assert WEATHER_CODE_MAP[75] == "heavy_snow"
 
-    def test_thunderstorm_codes(self):
+    def test_thunderstorm_codes(self) -> None:
         assert WEATHER_CODE_MAP[95] == "thunderstorm"
         assert WEATHER_CODE_MAP[99] == "thunderstorm"
 
-    def test_drizzle_codes(self):
+    def test_drizzle_codes(self) -> None:
         assert WEATHER_CODE_MAP[51] == "drizzle"
         assert WEATHER_CODE_MAP[53] == "drizzle"
 
-    def test_fog_codes(self):
+    def test_fog_codes(self) -> None:
         assert WEATHER_CODE_MAP[45] == "fog"
         assert WEATHER_CODE_MAP[48] == "fog"
 
-    def test_all_conditions_are_valid(self):
+    def test_all_conditions_are_valid(self) -> None:
         for code, condition in WEATHER_CODE_MAP.items():
             assert condition in VALID_CONDITIONS, (
                 f"Code {code} maps to '{condition}' which is not in VALID_CONDITIONS"
@@ -94,7 +98,7 @@ class TestWeatherCodeMap:
 
 
 class TestReadWeatherFromCache:
-    def test_reads_weather_from_cache(self):
+    def test_reads_weather_from_cache(self) -> None:
         cache = {
             "weather": {
                 "city": "Seattle",
@@ -113,26 +117,26 @@ class TestReadWeatherFromCache:
         assert result.temp_c == 9.0
         assert result.temp_f == 48.0
 
-    def test_returns_none_when_no_weather_key(self):
+    def test_returns_none_when_no_weather_key(self) -> None:
         cache = {"pulse": {"updated_at": "2026-01-01T00:00:00Z"}}
         result = read_weather_from_cache(cache)
         assert result is None
 
-    def test_returns_none_when_weather_not_dict(self):
+    def test_returns_none_when_weather_not_dict(self) -> None:
         cache = {"weather": "rain"}
         result = read_weather_from_cache(cache)
         assert result is None
 
-    def test_returns_none_when_empty_cache(self):
+    def test_returns_none_when_empty_cache(self) -> None:
         result = read_weather_from_cache({})
         assert result is None
 
-    def test_returns_none_when_empty_weather_entry(self):
-        cache = {"weather": {}}
+    def test_returns_none_when_empty_weather_entry(self) -> None:
+        cache: dict[str, Any] = {"weather": {}}
         result = read_weather_from_cache(cache)
         assert result is None
 
-    def test_normalizes_invalid_condition(self):
+    def test_normalizes_invalid_condition(self) -> None:
         cache = {
             "weather": {
                 "city": "Narnia",
@@ -147,7 +151,7 @@ class TestReadWeatherFromCache:
         assert result is not None
         assert result.condition == "rain"  # Falls back to code mapping
 
-    def test_reads_producer_camelcase_schema(self):
+    def test_reads_producer_camelcase_schema(self) -> None:
         """Test reading weather data from the TS producer's camelCase schema."""
         cache = {
             "weather": {
@@ -168,7 +172,7 @@ class TestReadWeatherFromCache:
         assert result.wind_speed == 5.0
         assert result.city == "Local"
 
-    def test_reads_producer_celsius_schema(self):
+    def test_reads_producer_celsius_schema(self) -> None:
         """Test reading celsius weather data from the TS producer."""
         cache = {
             "weather": {
@@ -187,7 +191,7 @@ class TestReadWeatherFromCache:
         assert result.temp_f == 68  # 20*9/5+32 rounded
         assert result.wind_speed == 15.0
 
-    def test_handles_missing_fields_gracefully(self):
+    def test_handles_missing_fields_gracefully(self) -> None:
         cache = {
             "weather": {
                 "city": "Seattle",
@@ -207,7 +211,7 @@ class TestReadWeatherFromCache:
 
 
 class TestParticleTypes:
-    def test_particle_creation(self):
+    def test_particle_creation(self) -> None:
         p = _Particle(x=10.0, y=5.0, char="|", speed=1.0, drift=0.1, opacity=2, layer=1)
         assert p.x == 10.0
         assert p.y == 5.0
@@ -217,20 +221,20 @@ class TestParticleTypes:
         assert p.opacity == 2
         assert p.layer == 1
 
-    def test_particle_defaults(self):
+    def test_particle_defaults(self) -> None:
         p = _Particle(x=0, y=0, char=".", speed=0.5)
         assert p.drift == 0.0
         assert p.opacity == 2
         assert p.layer == 0
 
-    def test_splash_creation(self):
+    def test_splash_creation(self) -> None:
         s = _Splash(x=10.0, y=20.0)
         assert s.x == 10.0
         assert s.y == 20.0
         assert s.life == 0
         assert 3 <= s.max_life <= 6
 
-    def test_cloud_creation(self):
+    def test_cloud_creation(self) -> None:
         c = _Cloud(x=5.0, y=1.0, speed=0.05, shape_idx=0)
         assert c.x == 5.0
         assert c.y == 1.0
@@ -238,7 +242,7 @@ class TestParticleTypes:
         assert len(c.shape) > 0
         assert c.width > 0
 
-    def test_cloud_shape_wrapping(self):
+    def test_cloud_shape_wrapping(self) -> None:
         # Shape index wraps around
         c1 = _Cloud(x=0, y=0, speed=0.05, shape_idx=0)
         c2 = _Cloud(x=0, y=0, speed=0.05, shape_idx=len(_Cloud.SHAPES))
@@ -249,7 +253,7 @@ class TestParticleTypes:
 
 
 class TestWeatherBackground:
-    def test_widget_renders_without_crash(self):
+    def test_widget_renders_without_crash(self) -> None:
         """Widget renders with default rain weather."""
         from rich.text import Text as RichText
         bg = WeatherBackground()
@@ -261,7 +265,7 @@ class TestWeatherBackground:
         assert isinstance(result, RichText)
         assert len(str(result)) > 0
 
-    def test_widget_renders_all_weather_types(self):
+    def test_widget_renders_all_weather_types(self) -> None:
         """Every weather condition renders without error."""
         from rich.text import Text as RichText
         for condition in VALID_CONDITIONS:
@@ -274,7 +278,7 @@ class TestWeatherBackground:
             result = bg.render()
             assert isinstance(result, RichText), f"Failed for condition: {condition}"
 
-    def test_spawn_particles_rain(self):
+    def test_spawn_particles_rain(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -285,7 +289,7 @@ class TestWeatherBackground:
         layers = {p.layer for p in bg.particles}
         assert len(layers) > 1
 
-    def test_spawn_particles_snow(self):
+    def test_spawn_particles_snow(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -293,7 +297,7 @@ class TestWeatherBackground:
         bg._spawn_particles()
         assert len(bg.particles) > 0
 
-    def test_spawn_particles_clear(self):
+    def test_spawn_particles_clear(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -302,7 +306,7 @@ class TestWeatherBackground:
         # Clear has twinkling stars and dust motes
         assert len(bg.particles) > 0
 
-    def test_spawn_particles_fog(self):
+    def test_spawn_particles_fog(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -310,7 +314,7 @@ class TestWeatherBackground:
         bg._spawn_particles()
         assert len(bg.particles) > 0
 
-    def test_spawn_particles_thunderstorm(self):
+    def test_spawn_particles_thunderstorm(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -319,7 +323,7 @@ class TestWeatherBackground:
         # Thunderstorm should be dense
         assert len(bg.particles) > 80
 
-    def test_spawn_particles_heavy_rain(self):
+    def test_spawn_particles_heavy_rain(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -327,7 +331,7 @@ class TestWeatherBackground:
         bg._spawn_particles()
         assert len(bg.particles) > 80
 
-    def test_spawn_clouds(self):
+    def test_spawn_clouds(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -335,7 +339,7 @@ class TestWeatherBackground:
         bg._spawn_clouds()
         assert len(bg.clouds) >= 2
 
-    def test_spawn_clouds_clear(self):
+    def test_spawn_clouds_clear(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -343,7 +347,7 @@ class TestWeatherBackground:
         bg._spawn_clouds()
         assert len(bg.clouds) == 1
 
-    def test_spawn_clouds_fog(self):
+    def test_spawn_clouds_fog(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -351,7 +355,7 @@ class TestWeatherBackground:
         bg._spawn_clouds()
         assert len(bg.clouds) == 6
 
-    def test_weather_change_respawns(self):
+    def test_weather_change_respawns(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -366,7 +370,7 @@ class TestWeatherBackground:
         # but the particles themselves should be different types)
         assert bg._wind == 0.0  # Wind resets on weather change
 
-    def test_tick_updates_frame(self):
+    def test_tick_updates_frame(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -376,7 +380,7 @@ class TestWeatherBackground:
         bg._tick()
         assert bg.frame == initial_frame + 1
 
-    def test_render_produces_richtext(self):
+    def test_render_produces_richtext(self) -> None:
         from rich.text import Text as RichText
         bg = WeatherBackground()
         bg._width = 40
@@ -386,7 +390,7 @@ class TestWeatherBackground:
         result = bg.render()
         assert isinstance(result, RichText)
 
-    def test_render_empty_dimensions(self):
+    def test_render_empty_dimensions(self) -> None:
         from rich.text import Text as RichText
         bg = WeatherBackground()
         bg._width = 0
@@ -395,7 +399,7 @@ class TestWeatherBackground:
         assert isinstance(result, RichText)
         assert str(result) == ""
 
-    def test_lightning_only_in_thunderstorm(self):
+    def test_lightning_only_in_thunderstorm(self) -> None:
         bg = WeatherBackground()
         bg._width = 80
         bg._height = 24
@@ -406,7 +410,7 @@ class TestWeatherBackground:
             bg._tick()
         assert bg._lightning_flash == 0  # Rain doesn't have lightning
 
-    def test_splash_lifecycle(self):
+    def test_splash_lifecycle(self) -> None:
         # Test that splashes are created with life=0 and age each tick
         splash = _Splash(40.0, 23.0)
         assert splash.life == 0
@@ -434,7 +438,7 @@ class TestWeatherBackground:
 
 
 class TestAppWeatherIntegration:
-    async def test_app_launches_with_weather_bg(self):
+    async def test_app_launches_with_weather_bg(self) -> None:
         """App starts with weather background widget."""
         from hookwise_tui.app import HookwiseTUI
         app = HookwiseTUI()
@@ -443,7 +447,7 @@ class TestAppWeatherIntegration:
             bg = app.query_one("#weather-bg", WeatherBackground)
             assert bg is not None
 
-    async def test_weather_cycle_key(self):
+    async def test_weather_cycle_key(self) -> None:
         """'w' key cycles through weather conditions."""
         from hookwise_tui.app import HookwiseTUI
         app = HookwiseTUI()
@@ -460,19 +464,20 @@ class TestAppWeatherIntegration:
             assert new_weather in VALID_CONDITIONS or new_weather == "sun"
             assert new_weather != initial_weather
 
-    async def test_tab_switching_still_works(self):
+    async def test_tab_switching_still_works(self) -> None:
         """Tab switching works with weather background present."""
+        from textual.widgets import TabbedContent
         from hookwise_tui.app import HookwiseTUI
         app = HookwiseTUI()
         async with app.run_test() as pilot:
-            tabs = app.query_one("TabbedContent")
+            tabs = app.query_one(TabbedContent)
             assert tabs.active == "dashboard"
             await pilot.press("2")
             assert tabs.active == "guards"
             await pilot.press("7")
             assert tabs.active == "status"
 
-    async def test_content_layer_exists(self):
+    async def test_content_layer_exists(self) -> None:
         """Content layer container is present above the weather background."""
         from hookwise_tui.app import HookwiseTUI
         app = HookwiseTUI()


### PR DESCRIPTION
**Closes #48** — the final module of the mypy quarantine drain (follows #187–#192).

## What

1. Annotates the final 47 defs in `tui/tests/test_weather.py` (all `-> None`).
2. Removes the last entry from the `disallow_untyped_defs = false` override — and **deletes the now-empty override block entirely**, plus rewrites the top-level ratchet comment.

mypy strict (`disallow_untyped_defs = true`) now applies **uniformly to every module, production and test**. No permissive scope remains.

## Two real fixes (no type-ignores)

1. `cache: dict[str, Any]` annotation on an ambiguous `{}` literal mypy couldn't infer.
2. `query_one("TabbedContent")` → `query_one(TabbedContent)` — the string selector returns a bare `Widget` (no `.active`); the typed form returns `TabbedContent`. No subclasses → behavior-preserving (same fix class as #187).

## Verification

- Full-project `mypy` clean (26 files) **after** removing the override block
- Every previously-quarantined module still strict-clean
- `ruff check tests/` clean
- `pytest tests/test_weather.py` → 47/47

## #48 retrospective

The earlier "frozen quarantine = zero guarding value" assessment was wrong: draining it (#187–#193) caught **4 real widget-typing bugs** (`query_one` returning a bare `Widget`) and removed a config special-case. Every TUI test file is now type-checked, so future edits can't silently introduce untyped defs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)