### PR TITLE
chore(tui): adopt full mypy strict = true (gold standard)

### DIFF
--- a/tui/hookwise_tui/app.py
+++ b/tui/hookwise_tui/app.py
@@ -30,7 +30,7 @@ _CONDITION_TO_WEATHER = {
 }
 
 
-class HookwiseTUI(App):
+class HookwiseTUI(App[None]):
     """Hookwise — Claude Code hooks dashboard with animated weather background."""
 
     TITLE = "Hookwise"

--- a/tui/hookwise_tui/tabs/analytics.py
+++ b/tui/hookwise_tui/tabs/analytics.py
@@ -90,7 +90,7 @@ class AnalyticsTab(Widget):
         # Tool breakdown
         if data.tools:
             yield Static("Top Tools", classes="section-title")
-            table: DataTable = DataTable()
+            table: DataTable[str] = DataTable()
             table.add_columns("Tool", "Calls", "Lines +", "Lines -")
             for t in data.tools[:10]:
                 table.add_row(t.tool_name, str(t.count), str(t.lines_added), str(t.lines_removed))

--- a/tui/hookwise_tui/tabs/dashboard.py
+++ b/tui/hookwise_tui/tabs/dashboard.py
@@ -59,7 +59,7 @@ FEATURES: list[dict[str, Any]] = [
 ]
 
 
-def _is_enabled(config: dict, feature: dict) -> bool:
+def _is_enabled(config: dict[str, Any], feature: dict[str, Any]) -> bool:
     """Check if a feature is enabled in the config."""
     if feature["config_path"] is None:
         key = feature["key"]
@@ -83,7 +83,7 @@ def _is_enabled(config: dict, feature: dict) -> bool:
     return False
 
 
-def _get_detail(config: dict, feature: dict) -> str:
+def _get_detail(config: dict[str, Any], feature: dict[str, Any]) -> str:
     """Get extra detail text for a feature."""
     key = feature["key"]
     if key == "guards":

--- a/tui/hookwise_tui/tabs/guards.py
+++ b/tui/hookwise_tui/tabs/guards.py
@@ -64,7 +64,7 @@ class GuardsTab(Widget):
             )
 
         # Guard rules table
-        table: DataTable = DataTable()
+        table: DataTable[str] = DataTable()
         table.add_columns("#", "Match", "Action", "Reason", "Condition")
 
         for i, guard in enumerate(guards):

--- a/tui/hookwise_tui/tabs/recipes.py
+++ b/tui/hookwise_tui/tabs/recipes.py
@@ -4,7 +4,7 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static, Tree
 
-from hookwise_tui.data import read_config, read_recipes
+from hookwise_tui.data import Recipe, read_config, read_recipes
 
 
 class RecipesTab(Widget):
@@ -64,7 +64,7 @@ class RecipesTab(Widget):
             tree.root.expand()
 
             # Group by category
-            categories: dict[str, list] = {}
+            categories: dict[str, list[Recipe]] = {}
             for r in recipes:
                 categories.setdefault(r.category, []).append(r)
 

--- a/tui/hookwise_tui/tabs/status.py
+++ b/tui/hookwise_tui/tabs/status.py
@@ -6,6 +6,7 @@ import os
 import time
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from textual.app import ComposeResult
 from textual.containers import Container
@@ -202,7 +203,7 @@ class StatusTab(Widget):
                 yield SegmentRow(seg, seg in active_set, has_data)
 
     @staticmethod
-    def _segment_has_data(seg: str, cache: dict) -> bool:
+    def _segment_has_data(seg: str, cache: dict[str, Any]) -> bool:
         """Check if a segment has real data available in the cache."""
         if seg in STDIN_SEGMENTS:
             # These get data from live stdin; check if live output is fresh
@@ -353,7 +354,7 @@ class StatusTab(Widget):
     }
 
     @staticmethod
-    def _top_friction_tip(friction_counts: dict) -> str:
+    def _top_friction_tip(friction_counts: dict[str, Any]) -> str:
         """Find the top friction category and return its tip."""
         if not isinstance(friction_counts, dict):
             return ""
@@ -370,7 +371,7 @@ class StatusTab(Widget):
         return f"{human_name} \u2192 {tip}" if tip else human_name
 
     @staticmethod
-    def _render_segment(seg: str, cache: dict) -> str:
+    def _render_segment(seg: str, cache: dict[str, Any]) -> str:
         """Render a segment from cache data with real rendering logic."""
         # Segments that need live stdin data — skip in cache-only mode
         if seg in STDIN_SEGMENTS:

--- a/tui/pyproject.toml
+++ b/tui/pyproject.toml
@@ -44,10 +44,12 @@ target-version = "py311"
 # drained the per-module test quarantine one file at a time (#187–#193); the
 # override block is now gone, so EVERY module (production AND test) is strict.
 # New code cannot regress. prototypes/ is excluded (throwaway code).
+# Full strict = true (gold standard) enabled — all strict checks now pass,
+# including disallow_any_generics (bare generics must carry type parameters).
 [tool.mypy]
 python_version = "3.11"
 warn_unused_configs = true
-disallow_untyped_defs = true
+strict = true
 ignore_missing_imports = true
 exclude = "prototypes"
 

--- a/tui/tests/test_terminal_e2e.py
+++ b/tui/tests/test_terminal_e2e.py
@@ -384,7 +384,7 @@ class PollResult:
 
 # Shell prompt patterns that indicate Claude Code has finished and returned
 # to the input prompt (the React/Ink ">" prompt or a shell prompt).
-COMPLETION_PATTERNS: list[re.Pattern] = [
+COMPLETION_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"^\s*>\s*$", re.MULTILINE),   # Claude Code empty input prompt
     re.compile(r"\$\s*$", re.MULTILINE),       # Shell prompt returned
 ]
@@ -401,7 +401,7 @@ OUTPUT_COMPLETION_MARKERS: list[str] = [
 # These patterns identify hard failures (crashes, panics, missing commands)
 # vs. transient issues (rate limits, timeouts) that may be retryable.
 
-ERROR_PATTERNS: list[re.Pattern] = [
+ERROR_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"Traceback \(most recent call last\)", re.IGNORECASE),
     re.compile(r"panic:", re.IGNORECASE),
     re.compile(r"FATAL|fatal error", re.IGNORECASE),
@@ -413,7 +413,7 @@ ERROR_PATTERNS: list[re.Pattern] = [
 ]
 
 # Patterns that indicate a transient/retryable issue (not a hard error)
-TRANSIENT_PATTERNS: list[re.Pattern] = [
+TRANSIENT_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"rate limit", re.IGNORECASE),
     re.compile(r"timeout", re.IGNORECASE),
     re.compile(r"connection refused", re.IGNORECASE),


### PR DESCRIPTION
Follows #48 (which got the TUI to `disallow_untyped_defs` across every module). This takes it to full `strict = true`.

## What

Scoping showed `mypy --strict` adds **exactly 12 `[type-arg]` errors** (bare generics) and nothing else — every other strict check (implicit-optional, return-any, unused-ignores, strict-equality, untyped-calls/decorators…) was already clean. So this fixes the 12 and flips `disallow_untyped_defs = true` → `strict = true`.

## Fixes (precise params, `Any` only where genuinely heterogeneous)

| Site | Param |
|---|---|
| `app.py` | `App[None]` (`run()` returns None) |
| `analytics.py`, `guards.py` | `DataTable[str]` (all cells are `str(...)`) |
| `recipes.py` | `dict[str, list[Recipe]]` (imported `Recipe`) |
| `dashboard.py`, `status.py` | `dict[str, Any]` (YAML config / cache / friction dicts) |
| `test_terminal_e2e.py` | `list[re.Pattern[str]]` |

Pure type-parameter annotations + two imports — **no runtime logic changed**.

## Verification

- `mypy` strict clean (26 files)
- `ruff` clean
- **Full TUI suite: 117 passed incl. 7 snapshots** (20 PTY-only e2e deselected) → behavior-preserving on the production tab/app changes

After this, `Any`-leakage, implicit `Optional`, and unused `# type: ignore`s are all CI failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal code quality and type safety validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->