### PR TITLE
chore: gitignore private reports (audit, dev-journal, design)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@ screenshots/01-before-after-results.png
 # Social media drafts (unpublished, internal only)
 docs/social-media-drafts.md
 
+# Private reports & internal working docs (never publish — keep out of git)
+docs/audit/
+docs/dev-journal.md
+docs/design/
+
 # Excalidraw
 excalidraw.log
 


### PR DESCRIPTION
## What

Adds explicit `.gitignore` rules for private/internal working docs:
- `docs/audit/` — architecture audit (HTML deck + supporting .md)
- `docs/dev-journal.md` — internal autonomous-loop journal
- `docs/design/` — working design notes

## Why

These files were **untracked but not ignored**, so a careless `git add docs/` (or `git add -A`) could sweep them into a commit. They're internal-only and should never be published. Ignoring them makes accidental staging impossible.

## Verification

`git check-ignore` now matches all three paths; no previously-tracked files are affected (none of these were ever committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude additional internal documentation and working files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->