### PR TITLE
fix(analytics): upsert in EndSession so Stop-only sessions keep cost

### DIFF
--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -90,26 +90,40 @@ func (a *Analytics) StartSession(ctx context.Context, sessionID string, startedA
 	return nil
 }
 
-// EndSession updates the session row with end timestamp and summary stats.
-// If the session does not exist, the UPDATE is a no-op (0 rows affected),
-// which is treated as success (upsert-safe behaviour).
+// EndSession records the end timestamp and summary stats for a session,
+// upserting so the row is created when no prior StartSession fired (#169 —
+// the install-mid-session first-run case, where Stop arrives without a
+// matching SessionStart). Without the upsert, an UPDATE matched 0 rows and
+// the session's cost was silently dropped from `hookwise stats` while
+// cost_state still captured it, diverging the two cost views.
+//
+// On the INSERT path started_at falls back to endedAt (we don't know the real
+// start), yielding a 0-duration orphan rather than a lost session. On the
+// conflict path started_at is intentionally excluded from DO UPDATE SET so a
+// real prior start time is preserved.
 func (a *Analytics) EndSession(ctx context.Context, sessionID string, endedAt time.Time, stats SessionStats) error {
+	endedAtStr := endedAt.UTC().Format(time.RFC3339)
 	_, err := a.db.Exec(ctx,
-		`UPDATE sessions SET
-			ended_at = ?,
-			total_tool_calls = ?,
-			file_edits_count = ?,
-			ai_authored_lines = ?,
-			human_verified_lines = ?,
-			estimated_cost_usd = ?
-		WHERE id = ?`,
-		endedAt.UTC().Format(time.RFC3339),
+		`INSERT INTO sessions (
+			id, started_at, ended_at,
+			total_tool_calls, file_edits_count,
+			ai_authored_lines, human_verified_lines, estimated_cost_usd
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			ended_at = excluded.ended_at,
+			total_tool_calls = excluded.total_tool_calls,
+			file_edits_count = excluded.file_edits_count,
+			ai_authored_lines = excluded.ai_authored_lines,
+			human_verified_lines = excluded.human_verified_lines,
+			estimated_cost_usd = excluded.estimated_cost_usd`,
+		sessionID,
+		endedAtStr, // started_at fallback (INSERT path only)
+		endedAtStr,
 		stats.TotalToolCalls,
 		stats.FileEditsCount,
 		stats.AIAuthoredLines,
 		stats.HumanVerifiedLines,
 		stats.EstimatedCostUSD,
-		sessionID,
 	)
 	if err != nil {
 		return fmt.Errorf("analytics: end session: %w", err)

--- a/internal/analytics/analytics_test.go
+++ b/internal/analytics/analytics_test.go
@@ -440,24 +440,63 @@ func TestRecordEvent_MissingOptionalFields(t *testing.T) {
 // Test 11: EndSession for non-existent session (upsert-safe)
 // ---------------------------------------------------------------------------
 
-func TestEndSession_NonExistent_NoError(t *testing.T) {
+// EndSession on a session that was never started (no prior StartSession)
+// must UPSERT a row so the session's cost is not silently dropped from
+// `hookwise stats` (#169 — the install-mid-session first-run case). The
+// inserted row's started_at falls back to ended_at (we don't know the real
+// start), giving a 0-duration orphan rather than a lost session.
+func TestEndSession_NoPriorStart_UpsertsRowWithCost(t *testing.T) {
 	a, cleanup := testAnalytics(t)
 	defer cleanup()
 
 	ctx := context.Background()
 	end := time.Date(2025, 3, 6, 12, 0, 0, 0, time.UTC)
 
-	// Ending a session that was never started should not error.
-	err := a.EndSession(ctx, "does-not-exist", end, SessionStats{
-		TotalToolCalls: 5,
+	err := a.EndSession(ctx, "no-prior-start", end, SessionStats{
+		TotalToolCalls:   5,
+		EstimatedCostUSD: 0.42,
 	})
 	require.NoError(t, err)
 
-	// Verify nothing was inserted.
-	var count int
-	err = a.db.QueryRow(ctx, "SELECT COUNT(*) FROM sessions WHERE id = ?", "does-not-exist").Scan(&count)
+	var startedAt, endedAt string
+	var toolCalls int
+	var cost float64
+	err = a.db.QueryRow(ctx,
+		`SELECT started_at, ended_at, total_tool_calls, estimated_cost_usd
+		 FROM sessions WHERE id = ?`, "no-prior-start").
+		Scan(&startedAt, &endedAt, &toolCalls, &cost)
+	require.NoError(t, err, "EndSession without a prior start must insert a row")
+
+	// started_at falls back to ended_at (0-duration orphan), cost preserved.
+	assert.Equal(t, "2025-03-06T12:00:00Z", startedAt)
+	assert.Equal(t, "2025-03-06T12:00:00Z", endedAt)
+	assert.Equal(t, 5, toolCalls)
+	assert.InDelta(t, 0.42, cost, 0.001)
+}
+
+// When a prior StartSession row exists, EndSession's upsert must NOT clobber
+// the real started_at with ended_at — the conflict path preserves it.
+func TestEndSession_PreservesStartedAtOnUpsert(t *testing.T) {
+	a, cleanup := testAnalytics(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	start := time.Date(2025, 3, 6, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 3, 6, 10, 15, 0, 0, time.UTC)
+
+	require.NoError(t, a.StartSession(ctx, "has-start", start))
+	require.NoError(t, a.EndSession(ctx, "has-start", end, SessionStats{EstimatedCostUSD: 1.5}))
+
+	var startedAt, endedAt string
+	var cost float64
+	err := a.db.QueryRow(ctx,
+		"SELECT started_at, ended_at, estimated_cost_usd FROM sessions WHERE id = ?", "has-start").
+		Scan(&startedAt, &endedAt, &cost)
 	require.NoError(t, err)
-	assert.Equal(t, 0, count)
+
+	assert.Equal(t, "2025-03-06T09:00:00Z", startedAt, "real start time must be preserved, not overwritten by ended_at")
+	assert.Equal(t, "2025-03-06T10:15:00Z", endedAt)
+	assert.InDelta(t, 1.5, cost, 0.001)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #169.

## Problem

`EndSession` was a bare `UPDATE sessions SET ... WHERE id = ?`. When **no prior `StartSession` row exists**, the UPDATE matches 0 rows and the session's cost is **silently dropped from `hookwise stats`** — while `cost_state` still captures it, so the two cost views diverge.

Realistic trigger (launch-relevant): a user **installs hookwise mid-session**, keeps working, and the first `Stop` has no matching `SessionStart` → that session's cost never shows in `stats`. Day-one `$0.00` looks broken.

## Fix (option A, per maintainer decision)

`INSERT ... ON CONFLICT(id) DO UPDATE`:
- **Insert path** (no prior row): `started_at` falls back to `ended_at` → a 0-duration orphan row rather than a lost session, with the cost preserved.
- **Conflict path** (prior `StartSession` exists): `started_at` is intentionally **excluded** from `DO UPDATE SET`, so the real start time is never clobbered.

## Tests (strict TDD, real SQLite — not mocked)

- `TestEndSession_NoPriorStart_UpsertsRowWithCost` — the gap: a row is now created with the cost; `started_at == ended_at`. (Was RED before the fix.)
- `TestEndSession_PreservesStartedAtOnUpsert` — the conflict path keeps the real `started_at`.
- Full `internal/analytics` package passes under `-race -p 2` (no session-count/duration aggregate regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session tracking to handle cases where session endpoints are recorded without corresponding start events, ensuring cost data is captured reliably.
  * Enhanced session record persistence to preserve original start times when sessions already exist, preventing incorrect time calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->