### PR TITLE
fix(guards): empty substring value no longer matches every field

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -474,7 +474,7 @@ func ValidateConfig(raw map[string]interface{}) ValidationResult {
 					if substringOps[parsed.Operator] && parsed.Value == "" {
 						errors = append(errors, ValidationError{
 							Path:       fmt.Sprintf("guards[%d].%s", i, condKey),
-							Message:    fmt.Sprintf("guard condition uses %q with an empty value, which matches every field (likely an unintended match-all)", parsed.Operator),
+							Message:    fmt.Sprintf("guard condition uses %q with an empty value; an empty substring is treated as a non-match and the rule will never fire (likely an accidental empty value)", parsed.Operator),
 							Suggestion: "Provide a non-empty substring value, or use a different operator if a catch-all is truly intended",
 						})
 					}

--- a/internal/core/guards.go
+++ b/internal/core/guards.go
@@ -116,6 +116,19 @@ func EvaluateCondition(expression string, data map[string]interface{}) *bool {
 		return &f
 	}
 
+	// An empty substring value makes Contains/HasPrefix/HasSuffix return true for
+	// every field, silently turning a narrow guard into a match-all (#147) — e.g.
+	// an accidentally-empty `command contains ""` would fire on every tool call.
+	// Neutralize it to a non-match. (== and matches are intentionally unaffected:
+	// `== ""` is a genuine emptiness test, and `matches ""` is a valid regex.)
+	if parsed.Value == "" {
+		switch parsed.Operator {
+		case "contains", "starts_with", "ends_with":
+			f := false
+			return &f
+		}
+	}
+
 	var result bool
 
 	switch parsed.Operator {

--- a/internal/core/guards_test.go
+++ b/internal/core/guards_test.go
@@ -238,6 +238,40 @@ func TestEvaluateCondition_ContainsNoMatch(t *testing.T) {
 	assert.False(t, *result)
 }
 
+// An empty substring value must NOT match every field (#147). strings.Contains/
+// HasPrefix/HasSuffix all return true for an empty needle, which would silently
+// turn a narrow guard into a match-all (e.g. an accidentally-empty `command
+// contains ""` blocking every tool call). Neutralize to a non-match instead.
+func TestEvaluateCondition_EmptyContains_DoesNotMatchAll(t *testing.T) {
+	data := map[string]interface{}{"command": "git pull"}
+	result := EvaluateCondition(`command contains ""`, data)
+	require.NotNil(t, result, "empty-value condition still parses; it just never matches")
+	assert.False(t, *result, `contains "" must not match every field`)
+}
+
+func TestEvaluateCondition_EmptyStartsWith_DoesNotMatchAll(t *testing.T) {
+	data := map[string]interface{}{"path": "/etc/passwd"}
+	result := EvaluateCondition(`path starts_with ""`, data)
+	require.NotNil(t, result)
+	assert.False(t, *result, `starts_with "" must not match every field`)
+}
+
+func TestEvaluateCondition_EmptyEndsWith_DoesNotMatchAll(t *testing.T) {
+	data := map[string]interface{}{"file": "config.env"}
+	result := EvaluateCondition(`file ends_with ""`, data)
+	require.NotNil(t, result)
+	assert.False(t, *result, `ends_with "" must not match every field`)
+}
+
+// == with an empty value is a genuine emptiness test and must be left intact:
+// it should still match a field that is actually empty.
+func TestEvaluateCondition_EmptyEquals_StillTestsEmptiness(t *testing.T) {
+	data := map[string]interface{}{"command": ""}
+	result := EvaluateCondition(`command == ""`, data)
+	require.NotNil(t, result)
+	assert.True(t, *result, `== "" must still match a genuinely empty field`)
+}
+
 func TestEvaluateCondition_StartsWith(t *testing.T) {
 	data := map[string]interface{}{
 		"path": "/etc/passwd",


### PR DESCRIPTION
Closes #147.

## Problem

A guard whose value is the empty string with operator `contains`, `starts_with`, or `ends_with` evaluated to **true for every present field** — `strings.Contains`/`HasPrefix`/`HasSuffix` all return `true` for an empty needle. An accidentally-empty value (config templating producing `command contains ""`) silently turns a narrow rule into a **match-all**; with `action: block` that blocks **every** tool call. A nasty day-one footgun.

## Decision

The config-load WARN for this already shipped (#160–#163), but it's validation-time only — at **runtime** the empty-substring guard still matched everything. Per maintainer decision: **neutralize at runtime** (rather than warn-only or reject-at-parse).

## Change

- `internal/core/guards.go` — `EvaluateCondition` returns `false` for an empty value on `contains`/`starts_with`/`ends_with`. `==` (`== ""` is a real emptiness test) and `matches` (`matches ""` is a valid regex) are intentionally **unaffected**.
- `internal/core/config.go` — WARN wording updated from "matches every field" to "treated as a non-match and the rule will never fire" so the validation message matches the new runtime semantics.

## Tests (strict TDD)

- `TestEvaluateCondition_Empty{Contains,StartsWith,EndsWith}_DoesNotMatchAll` — each resolves to `false` (were RED: previously `true`).
- `TestEvaluateCondition_EmptyEquals_StillTestsEmptiness` — `== ""` still matches a genuinely empty field (unaffected).
- Full `internal/core` passes under `-race -p 2`, including ARCH-6 contract parity; existing empty-value config-warn tests still pass (assert message contains "empty").

🤖 Generated with [Claude Code](https://claude.com/claude-code)