### PR TITLE
feat(feeds): wire custom feed producers into the daemon (#124)

### DIFF
--- a/cmd/hookwise/cmd_daemon.go
+++ b/cmd/hookwise/cmd_daemon.go
@@ -17,6 +17,27 @@ import (
 	"github.com/vishnujayvel/hookwise/internal/feeds"
 )
 
+// registerCustomFeeds registers user-defined custom feed producers (#124) from
+// config so the daemon polls them alongside the built-ins. Entries with an
+// empty name or command are skipped (a malformed entry must not register a
+// no-op producer). Enabled/interval gating happens in the daemon poll loop via
+// config.Feeds.Custom (mirroring how built-ins are gated), so producers are
+// registered here regardless of their Enabled flag. Returns the number
+// registered.
+func registerCustomFeeds(registry *feeds.Registry, customs []core.CustomFeedConfig) int {
+	count := 0
+	for _, c := range customs {
+		if c.Name == "" || c.Command == "" {
+			continue
+		}
+		registry.Register(feeds.NewCustomProducer(
+			c.Name, c.Command, time.Duration(c.TimeoutSeconds)*time.Second,
+		))
+		count++
+	}
+	return count
+}
+
 func newDaemonCmd() *cobra.Command {
 	daemonCmd := &cobra.Command{
 		Use:   "daemon",
@@ -110,6 +131,7 @@ func newDaemonRunCmd() *cobra.Command {
 
 			registry := feeds.NewRegistry()
 			feeds.RegisterBuiltins(registry)
+			registerCustomFeeds(registry, config.Feeds.Custom)
 
 			daemon := feeds.NewDaemon(config.Daemon, config.Feeds, registry)
 			if socketPath != "" {

--- a/cmd/hookwise/cmd_daemon_custom_test.go
+++ b/cmd/hookwise/cmd_daemon_custom_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vishnujayvel/hookwise/internal/core"
+	"github.com/vishnujayvel/hookwise/internal/feeds"
+)
+
+// registerCustomFeeds wires user-defined custom feeds (#124) into the daemon's
+// producer registry. Valid entries register regardless of their Enabled flag
+// (the poll loop gates enabled/interval); malformed entries (empty name or
+// command) are skipped so they don't register a no-op producer.
+func TestRegisterCustomFeeds_RegistersValidEntries(t *testing.T) {
+	r := feeds.NewRegistry()
+
+	n := registerCustomFeeds(r, []core.CustomFeedConfig{
+		{Name: "stocks", Command: `echo '{"ok":true}'`, IntervalSeconds: 120, Enabled: true},
+		{Name: "disabled-still-registered", Command: "echo {}", Enabled: false},
+		{Name: "", Command: "echo {}"},  // skipped: empty name
+		{Name: "no-cmd", Command: ""},   // skipped: empty command
+	})
+
+	assert.Equal(t, 2, n, "two valid entries registered (enabled flag does not gate registration)")
+
+	_, ok := r.Get("stocks")
+	assert.True(t, ok, "valid custom feed must be registered")
+
+	_, ok = r.Get("disabled-still-registered")
+	assert.True(t, ok, "disabled feeds are still registered; the daemon gates them at poll time")
+
+	_, ok = r.Get("no-cmd")
+	assert.False(t, ok, "empty-command entry must be skipped")
+}
+
+// An empty custom list is a no-op (the common case: no custom feeds configured).
+func TestRegisterCustomFeeds_EmptyList(t *testing.T) {
+	r := feeds.NewRegistry()
+	assert.Equal(t, 0, registerCustomFeeds(r, nil))
+	assert.Empty(t, r.All())
+}

--- a/internal/arch/producer_wiring_test.go
+++ b/internal/arch/producer_wiring_test.go
@@ -16,13 +16,11 @@ import (
 //
 // Entries are added deliberately, never to silence a freshly-introduced dead
 // producer. Each value is the tracking issue for wiring (or removing) it.
-var producerWiringAllowlist = map[string]string{
-	// CustomProducer is constructed via NewCustomProducer, but that constructor
-	// is currently called only from tests — custom feeds appear unwired from the
-	// daemon/config path. Tracked separately; do not remove until wiring is
-	// verified or the surface is removed.
-	"CustomProducer": "#124",
-}
+// Intentionally empty: CustomProducer was wired into the daemon/config path
+// (#124 — registerCustomFeeds in cmd/hookwise/cmd_daemon.go constructs each
+// config.Feeds.Custom entry via NewCustomProducer), so it no longer needs an
+// exception. Add an entry here only to track a deliberately-deferred wiring.
+var producerWiringAllowlist = map[string]string{}
 
 // TestArch_ProducerTypesAreWired enforces the WRITER AUDIT (#99) lesson for the
 // feed platform: a Producer type that is declared but never registered or

--- a/internal/feeds/feeds_test.go
+++ b/internal/feeds/feeds_test.go
@@ -521,6 +521,39 @@ func TestDaemon_IntervalFor(t *testing.T) {
 	assert.Equal(t, defaultInterval, d.intervalFor("project")) // 0 -> default
 }
 
+// A wired custom feed (#124) must be polled on its configured interval, not the
+// 60s default. intervalFor resolves a custom name via config.Feeds.Custom.
+func TestDaemon_IntervalFor_Custom(t *testing.T) {
+	r := NewRegistry()
+	d := NewDaemon(core.DaemonConfig{}, core.FeedsConfig{
+		Custom: []core.CustomFeedConfig{
+			{Name: "my-feed", Command: "echo {}", IntervalSeconds: 300, Enabled: true},
+			{Name: "no-interval", Command: "echo {}", Enabled: true},
+		},
+	}, r)
+
+	assert.Equal(t, 300*time.Second, d.intervalFor("my-feed"))
+	assert.Equal(t, defaultInterval, d.intervalFor("no-interval")) // 0 -> default
+	assert.Equal(t, defaultInterval, d.intervalFor("not-configured"))
+}
+
+// A custom feed's enabled flag must gate whether it runs (#124). isEnabled
+// resolves a custom name via config.Feeds.Custom; truly-unknown names stay
+// fail-open (enabled).
+func TestDaemon_IsEnabled_Custom(t *testing.T) {
+	r := NewRegistry()
+	d := NewDaemon(core.DaemonConfig{}, core.FeedsConfig{
+		Custom: []core.CustomFeedConfig{
+			{Name: "on", Command: "echo {}", Enabled: true},
+			{Name: "off", Command: "echo {}", Enabled: false},
+		},
+	}, r)
+
+	assert.True(t, d.isEnabled("on"))
+	assert.False(t, d.isEnabled("off"), "a custom feed with enabled:false must not run")
+	assert.True(t, d.isEnabled("truly-unknown"), "unknown feeds remain fail-open enabled")
+}
+
 // ---------------------------------------------------------------------------
 // Test 18: Custom producer default timeout
 // ---------------------------------------------------------------------------

--- a/internal/feeds/polling.go
+++ b/internal/feeds/polling.go
@@ -168,6 +168,14 @@ func (d *Daemon) intervalFor(name string) time.Duration {
 		seconds = d.feeds.Memories.IntervalSeconds
 	case "insights":
 		seconds = d.feeds.Insights.IntervalSeconds
+	default:
+		// Custom feeds (#124) carry their interval in config.Feeds.Custom.
+		for _, c := range d.feeds.Custom {
+			if c.Name == name {
+				seconds = c.IntervalSeconds
+				break
+			}
+		}
 	}
 
 	if seconds > 0 {
@@ -194,7 +202,13 @@ func (d *Daemon) isEnabled(name string) bool {
 	case "insights":
 		return d.feeds.Insights.Enabled
 	default:
-		// Unknown feeds (custom, etc.) are enabled by default (fail-open).
+		// Custom feeds (#124) carry their enabled flag in config.Feeds.Custom.
+		for _, c := range d.feeds.Custom {
+			if c.Name == name {
+				return c.Enabled
+			}
+		}
+		// Truly unknown feeds are enabled by default (fail-open).
 		return true
 	}
 }


### PR DESCRIPTION
Closes #124.

## Problem

`CustomProducer` fully worked (runs `sh -c`, parses JSON stdout, ARCH-3 envelope) and the config schema already parsed `feeds.custom: [{name, command, interval_seconds, enabled, timeout_seconds}]` — but `cmd_daemon.go` only called `RegisterBuiltins` and never read `config.Feeds.Custom`. A user's custom feed parsed cleanly yet **silently never ran**. `NewCustomProducer` had zero production callers.

## Fix (option: wire it, per maintainer decision)

Wired on the existing "register all, gate by config" pattern used for built-ins:

- **`cmd_daemon.go`** — `registerCustomFeeds()` constructs a `CustomProducer` for each `config.Feeds.Custom` entry (skipping empty name/command) right after `RegisterBuiltins`. Registered regardless of `enabled`, mirroring built-ins.
- **`polling.go`** — `intervalFor()` and `isEnabled()` default cases now resolve a custom feed name via `config.Feeds.Custom`, so a custom feed polls on its configured interval and is gated by its `enabled` flag. Truly-unknown names stay fail-open enabled (unchanged).

**ARCH-3 preserved:** `CustomProducer.Produce` returns the `{type,timestamp,data}` envelope the poll loop writes via `AtomicWriteJSON`, identical to built-ins; no DB access from the daemon.

**Arch-lint:** removes the now-satisfied `CustomProducer` entry from the producer-wiring allowlist (#124's "remove once wired" step) — `TestArch_ProducerTypesAreWired` now detects the production `NewCustomProducer` caller on its own (verified green).

## Tests (strict TDD)

- `TestDaemon_IntervalFor_Custom` / `TestDaemon_IsEnabled_Custom` — custom interval + enabled gating (were RED: 60s default / always-enabled).
- `TestRegisterCustomFeeds_RegistersValidEntries` / `_EmptyList` — registers valid entries, skips empty name/command.
- Full `internal/feeds`, `cmd/hookwise`, `internal/arch` green under `-race -p 2`.

> Note: `TestDaemon_ConcurrentStartOnlyOneWins` (a socket-bind race test, untouched by this PR) flaked once under full-package parallel load but is green 3/3 in isolation and on clean re-runs — pre-existing flake, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom feeds are now properly registered and configured from your settings.
  * Custom feeds now support enable/disable toggling and configurable polling intervals.

* **Tests**
  * Added comprehensive test coverage for custom feed registration and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->