### PR TITLE
ci: add nightly validate workflow (chaos + mutation tiers) (#123)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,33 @@
+name: Nightly Validate
+
+# The required per-PR `CI` workflow runs only Tier 0 (vet/compile/lint) + Tier 1
+# (unit/contract/arch/PBT/TUI) via `dagger call test`. The chaos (integration)
+# and mutation tiers are expensive — mutation runs the suite per mutant — so
+# they are unsuitable for a per-PR gate. This scheduled workflow runs the full
+# `dagger call validate` (Tier 2: integration/chaos + mutation + snapshots)
+# once a day so regressions in failure-mode handling or a weakened
+# mutant-killing suite surface as a failed run, instead of merging green
+# unnoticed (#123). Resource-safety (retro-009) is handled inside the Dagger
+# pipeline (-p 2 + GOMEMLIMIT), not here.
+
+on:
+  schedule:
+    # 02:00 UTC daily.
+    - cron: "0 2 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Dagger Validate (Tier 2 — chaos + mutation + snapshots)
+        uses: dagger/dagger-for-github@v8.4.0
+        with:
+          verb: call
+          args: validate --src=.
+          version: "v0.20.1"


### PR DESCRIPTION
Closes #123.

## Problem

The required per-PR `CI` workflow invokes `dagger call test` = Tier 0 (vet/compile/lint) + Tier 1 (unit/contract/arch/PBT/TUI) only. The chaos (`//go:build integration`) and mutation (`//go:build mutation`) tiers exist (`internal/chaos/`, `internal/mutation/`) and `dagger validate` runs them — but CI never calls it. So regressions in failure-mode handling, or a weakened suite that stops killing mutants, can merge green. The project advertises testing rigor that CI doesn't enforce.

## Fix (nightly, per maintainer decision)

mutation is expensive (runs the suite per mutant), so it's a poor per-PR gate. This adds a **scheduled** workflow (`.github/workflows/nightly.yml`) that runs the full `dagger call validate` (Tier 2: integration/chaos + mutation + snapshots) at **02:00 UTC daily**, plus `workflow_dispatch` for manual runs. A chaos or kill-rate regression now surfaces as a failed nightly run.

- **Per-PR latency unchanged** — schedule-only trigger, no `pull_request` hook.
- **Resource-safety (retro-009)** — `-p 2` + `GOMEMLIMIT` are enforced inside the Dagger pipeline, not the workflow.
- Mirrors the existing `ci.yml` structure exactly (same `dagger/dagger-for-github@v8.4.0`, `version: v0.20.1`), swapping `test` → `validate` on a schedule.

## Verification

- YAML parses cleanly; `args: validate --src=.` matches the existing `Hookwise.Validate` Dagger function (`dagger/main.go:198`, which gates on `Test` then runs integration/chaos + mutation + TUI snapshots).
- Satisfies acceptance (b): a scheduled workflow runs mutation testing and surfaces kill-rate regressions.

> Can't exercise a scheduled run pre-merge; the workflow is structurally identical to the working per-PR pipeline, only the verb target and trigger differ. First real run is the next 02:00 UTC tick (or a manual `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated nightly validation workflow that runs daily at 02:00 UTC with manual trigger capability and 60-minute timeout limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->