### PR TITLE
docs(security): reconcile SECURITY.md with custom-feed shell execution

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ hookwise operates under the following trust boundaries:
 
 | Input | Trust Level | Rationale |
 |-------|-------------|-----------|
-| `hookwise.yaml` | **Trusted** | User-authored local config, equivalent to a Makefile or package.json scripts |
+| `hookwise.yaml` | **Trusted** | User-authored local config, equivalent to a Makefile or package.json scripts. Note: `feeds.custom` entries are executed via `sh -c` with the user's privileges (see Process Execution below) |
 | CLI arguments | **Trusted** | Provided by the local user |
 | Environment variables | **Trusted** | Set by the local user or system |
 | Claude Code hook payloads | **Semi-trusted** | JSON from Claude Code's hook system; parsed with Go's `encoding/json` (no code execution) |
@@ -49,8 +49,9 @@ The codebase enforces the following security practices by design:
 - **JSON-only deserialization** -- All external data is parsed with Go's `encoding/json`, which cannot execute code.
 
 ### Process Execution
-- **No `eval()` or dynamic code execution** -- Go's type system prevents this by design.
-- **`exec.Command` without shell** -- The dispatcher passes handler arguments as array elements, preventing shell injection.
+- **No code execution from untrusted or semi-trusted input** -- External API responses and Claude Code hook payloads are parsed as data only (`encoding/json`) and are never evaluated as code.
+- **Handler dispatch uses no shell** -- The dispatcher runs handler executables via `exec.Command` with arguments passed as array elements (not a shell string), so a hook payload cannot inject shell commands.
+- **Custom feeds run a shell *by design*, scoped to trusted config** -- The optional `feeds.custom` mechanism executes its configured `command` via `sh -c` (`internal/feeds/custom.go`). This is intentional and is scoped to the **Trusted** `hookwise.yaml` -- the same trust level as a Makefile target or an npm `scripts` entry. A custom feed command runs with your privileges, so only configure commands you would run yourself; treat a project's `hookwise.yaml` the way you would treat its build scripts before enabling custom feeds. hookwise never derives a shell command from any semi-trusted or untrusted input.
 
 ### File System
 - **Restrictive permissions** -- Database files use `0o600`; directories use `0o700` (owner-only).


### PR DESCRIPTION
## What

Launch-honesty fix (audit punch-list item #4). `SECURITY.md` claimed, without qualification:

- "**No `eval()` or dynamic code execution**"
- "**`exec.Command` without shell**"

Both are **false** in light of the optional `feeds.custom` mechanism, which runs its configured `command` via `exec.CommandContext(ctx, "sh", "-c", p.command)` (`internal/feeds/custom.go:45`). Shipping a security policy that affirmatively denies a real (if intentional) shell-execution path is the most damaging kind of dishonesty for a public launch.

## Fix (markdown only)

Reconcile the wording so the posture is **accurate, not alarmist** — the execution is intentional and already scoped to trusted config:

- **Trust Model row** for `hookwise.yaml` now notes that `feeds.custom` entries are executed via `sh -c` with the user's privileges.
- **Process Execution** bullets rewritten to: (a) keep the true guarantee — no code execution from semi-trusted/untrusted input, handler dispatch uses array-arg `exec.Command` with no shell; (b) honestly document that custom feeds run a shell **by design**, scoped to the already-**Trusted** `hookwise.yaml` (same trust level as a Makefile target or npm `scripts`), with guidance to treat a project's config like its build scripts.

No code change. The `hookwise.yaml`-is-Trusted framing was already in the Trust Model; this just removes the self-contradiction.

## Scope

Did **not** add a runtime gate for custom-feed execution — that's a product/security decision (the audit offered it as optional) and is left for the maintainer. This PR only makes the documented posture honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)