### PR TITLE
feat(dispatch): honor confirm/warn in handler-phase guards

### DIFF
--- a/internal/core/dispatcher.go
+++ b/internal/core/dispatcher.go
@@ -81,8 +81,10 @@ func Dispatch(ctx context.Context, eventType string, payload HookPayload, config
 		}
 	}
 
-	// Phase 1b: Handler-based guards (handlers with phase: "guard")
-	guardPhaseResult := executeGuardPhase(ctx, handlers, payload)
+	// Phase 1b: Handler-based guards (handlers with phase: "guard").
+	// A block/confirm decision is terminal; warn decisions accumulate into
+	// guardWarnContext and merge with the injected context below.
+	guardPhaseResult, guardWarnContext := executeGuardPhase(ctx, handlers, payload)
 	if guardPhaseResult != nil {
 		return *guardPhaseResult
 	}
@@ -93,8 +95,9 @@ func Dispatch(ctx context.Context, eventType string, payload HookPayload, config
 	// Phase 3: Side Effects (non-blocking goroutines)
 	fireSideEffects(ctx, handlers, payload)
 
-	// Merge warn context with Phase 2 context output
-	finalContext := mergeContext(warnContext, contextOutput)
+	// Merge warn context (declarative Phase 1a + handler-phase 1b) with the
+	// Phase 2 context output.
+	finalContext := mergeContext(mergeContext(warnContext, guardWarnContext), contextOutput)
 
 	// Build final result
 	if finalContext != "" {
@@ -107,13 +110,23 @@ func Dispatch(ctx context.Context, eventType string, payload HookPayload, config
 
 // --- Phase 1b: Guard Handlers ---
 
-// executeGuardPhase runs guard-phase handlers synchronously.
-// On first block decision, short-circuits and returns the block result.
-// Returns nil if no guard blocked.
-func executeGuardPhase(ctx context.Context, handlers []ResolvedHandler, payload HookPayload) *DispatchResult {
+// executeGuardPhase runs guard-phase handlers synchronously, honoring all three
+// guard decisions advertised to recipe authors (docs/guide/creating-a-recipe.md):
+//
+//   - block   → terminal; emits the handler block JSON ({"decision":"block"})
+//   - confirm → terminal; emits an "ask" permission decision (mirrors the
+//     declarative confirm guard in Phase 1a) so Claude Code prompts the user
+//   - warn    → non-terminal; the reason is accumulated and returned as warn
+//     context for the caller to merge into additionalContext
+//
+// It returns the terminal result (block/confirm) on the first such decision, or
+// nil with the accumulated warn context if no handler was terminal. Previously
+// only block was honored and confirm/warn were silently dropped.
+func executeGuardPhase(ctx context.Context, handlers []ResolvedHandler, payload HookPayload) (*DispatchResult, string) {
+	var warnContext string
 	for i := range handlers {
 		if ctx.Err() != nil {
-			return nil
+			return nil, warnContext
 		}
 		if handlers[i].Phase != PhaseGuard {
 			continue
@@ -127,23 +140,40 @@ func executeGuardPhase(ctx context.Context, handlers []ResolvedHandler, payload 
 			}()
 
 			hr := ExecuteHandler(ctx, handlers[i], payload)
+			if hr.Decision == nil {
+				return nil
+			}
 
-			if hr.Decision != nil && *hr.Decision == ActionBlock {
+			switch *hr.Decision {
+			case ActionBlock:
 				reason := "Blocked by guard rule"
 				if hr.Reason != nil {
 					reason = *hr.Reason
 				}
 				stdout := buildGuardBlockJSON(reason)
 				return &DispatchResult{Stdout: &stdout, ExitCode: 0}
+
+			case ActionConfirm:
+				reason := "Requires confirmation"
+				if hr.Reason != nil && *hr.Reason != "" {
+					reason = *hr.Reason
+				}
+				stdout := buildPermissionJSON("ask", reason)
+				return &DispatchResult{Stdout: &stdout, ExitCode: 0}
+
+			case ActionWarn:
+				if hr.Reason != nil && *hr.Reason != "" {
+					warnContext = mergeContext(warnContext, "Guard warning: "+*hr.Reason)
+				}
 			}
 			return nil
 		}()
 
 		if result != nil {
-			return result
+			return result, warnContext
 		}
 	}
-	return nil
+	return nil, warnContext
 }
 
 // --- Phase 2: Context Injection ---

--- a/internal/core/dispatcher_test.go
+++ b/internal/core/dispatcher_test.go
@@ -1061,6 +1061,106 @@ func TestIntegration_HandlerBasedGuard_Blocks(t *testing.T) {
 	assert.Equal(t, "inline guard blocked", output["reason"])
 }
 
+func TestIntegration_HandlerBasedGuard_Confirm_AskJSON(t *testing.T) {
+	// A guard-phase handler returning {"decision":"confirm"} must surface an
+	// "ask" permission decision, mirroring declarative confirm guards
+	// (dispatcher.go Phase 1a). Previously confirm was silently dropped even
+	// though docs/guide/creating-a-recipe.md advertises it as valid.
+	config := configWithHandlers([]CustomHandlerConfig{
+		{
+			Name:   "inline-confirm-guard",
+			Type:   "inline",
+			Events: []string{EventPreToolUse},
+			Phase:  "guard",
+			Action: map[string]interface{}{
+				"decision": "confirm",
+				"reason":   "please confirm this action",
+			},
+		},
+	})
+	payload := preToolUsePayload("Bash", nil)
+
+	result := Dispatch(context.Background(), EventPreToolUse, payload, config)
+
+	require.NotNil(t, result.Stdout, "confirm guard must produce stdout")
+	ho := parseHookOutput(t, result.Stdout)
+	assert.Equal(t, "ask", ho["permissionDecision"])
+	assert.Equal(t, "please confirm this action", ho["permissionDecisionReason"])
+}
+
+func TestIntegration_HandlerBasedGuard_Confirm_DefaultReason(t *testing.T) {
+	config := configWithHandlers([]CustomHandlerConfig{
+		{
+			Name:   "inline-confirm-guard",
+			Type:   "inline",
+			Events: []string{EventPreToolUse},
+			Phase:  "guard",
+			Action: map[string]interface{}{"decision": "confirm"},
+		},
+	})
+
+	result := Dispatch(context.Background(), EventPreToolUse, preToolUsePayload("Bash", nil), config)
+
+	require.NotNil(t, result.Stdout)
+	ho := parseHookOutput(t, result.Stdout)
+	assert.Equal(t, "ask", ho["permissionDecision"])
+	assert.Equal(t, "Requires confirmation", ho["permissionDecisionReason"])
+}
+
+func TestIntegration_HandlerBasedGuard_Warn_AdditionalContext(t *testing.T) {
+	// A guard-phase handler returning {"decision":"warn"} must inject its reason
+	// as additionalContext (not block, not ask), mirroring declarative warn.
+	config := configWithHandlers([]CustomHandlerConfig{
+		{
+			Name:   "inline-warn-guard",
+			Type:   "inline",
+			Events: []string{EventPreToolUse},
+			Phase:  "guard",
+			Action: map[string]interface{}{
+				"decision": "warn",
+				"reason":   "this looks risky",
+			},
+		},
+	})
+	payload := preToolUsePayload("Bash", nil)
+
+	result := Dispatch(context.Background(), EventPreToolUse, payload, config)
+
+	require.NotNil(t, result.Stdout, "warn guard must inject context")
+	ho := parseHookOutput(t, result.Stdout)
+	// Not a block/ask — context injection only.
+	assert.Nil(t, ho["permissionDecision"], "warn must not emit a permission decision")
+	assert.Contains(t, ho["additionalContext"], "this looks risky")
+}
+
+func TestIntegration_HandlerBasedGuard_Warn_DoesNotBlock(t *testing.T) {
+	// Warn is non-terminal: a warn handler followed by a context handler must
+	// let dispatch proceed and merge both into additionalContext.
+	config := configWithHandlers([]CustomHandlerConfig{
+		{
+			Name:   "warn-guard",
+			Type:   "inline",
+			Events: []string{EventPreToolUse},
+			Phase:  "guard",
+			Action: map[string]interface{}{"decision": "warn", "reason": "heads up"},
+		},
+		{
+			Name:   "ctx-handler",
+			Type:   "inline",
+			Events: []string{EventPreToolUse},
+			Phase:  "context",
+			Action: map[string]interface{}{"additionalContext": "extra info"},
+		},
+	})
+
+	result := Dispatch(context.Background(), EventPreToolUse, preToolUsePayload("Bash", nil), config)
+
+	require.NotNil(t, result.Stdout)
+	ho := parseHookOutput(t, result.Stdout)
+	assert.Contains(t, ho["additionalContext"], "heads up")
+	assert.Contains(t, ho["additionalContext"], "extra info")
+}
+
 func TestIntegration_DeclarativeGuardBeforeHandlerGuard(t *testing.T) {
 	config := configWithGuards([]GuardRuleConfig{
 		{Match: "Bash", Action: "block", Reason: "declarative block"},


### PR DESCRIPTION
## What

Launch-remediation audit item #1 (handler-phase guards drop confirm/warn). **You greenlit "implement both — make real."** This is the first of the two dispatch-path items.

`executeGuardPhase` (handlers with `phase: "guard"`) branched **only** on `decision == "block"`. A handler returning `{"decision":"confirm"}` or `{"decision":"warn"}` had its decision parsed into `HandlerResult.Decision` and then **silently discarded** — even though `docs/guide/creating-a-recipe.md:93` advertises `{"decision": "block | warn | confirm | null"}` as the valid handler output contract. Recipe authors following the docs got nothing for confirm/warn.

## Change

Extend `executeGuardPhase` to honor all three decisions, mirroring the declarative guard path (Phase 1a, `dispatcher.go:54-75`):

| decision | behavior |
|----------|----------|
| `block`   | terminal — `{"decision":"block","reason"}` (unchanged) |
| `confirm` | terminal — emits `permissionDecision: ask` so Claude Code prompts the user |
| `warn`    | non-terminal — reason accumulated and merged into `additionalContext` |

`executeGuardPhase` now returns `(*DispatchResult, warnContext)`; `Dispatch` merges the handler-phase warn context with the existing declarative warn context and Phase 2 output. The doc was already correct — this makes the **code** match the documented contract.

## Tests (TDD, red→green)

Four new integration tests on the real `Dispatch` path (confirmed RED before the change):
- `…Confirm_AskJSON` — confirm → `permissionDecision: ask` + reason
- `…Confirm_DefaultReason` — confirm with no reason → "Requires confirmation"
- `…Warn_AdditionalContext` — warn → context injection, **no** permission decision
- `…Warn_DoesNotBlock` — warn is non-terminal; merges with a downstream context handler

## Verification

- `go build ./...` + `go vet ./internal/core/` clean.
- Guarded gate: `internal/core` **and** `internal/contract` green under `-race -p 2` (0 zombie procs). **ARCH-6 byte parity preserved** — contract fixtures use `Handlers=nil`, so the handler-guard path isn't exercised by fixtures.

## Note

Like the existing handler-block path, confirm/warn guard handlers are intended for **PreToolUse**, where an `ask` permission decision is meaningful (matching the PreToolUse-only declarative guard phase). ARCH-1 fail-open and ARCH-5 first-match semantics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guard rules using confirmation decisions now properly trigger user approval prompts (previously ignored)
  * Guard-phase warning context is now correctly captured, merged, and propagated throughout request handling

* **New Features**
  * Guard rules can emit warnings that contribute contextual information to request processing without blocking execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->