### PR TITLE
feat(cost): enforce daily budget on PreToolUse when enforcement=enforce

### DIFF
--- a/cmd/hookwise/cmd_dispatch.go
+++ b/cmd/hookwise/cmd_dispatch.go
@@ -74,6 +74,18 @@ func newDispatchCmd() *cobra.Command {
 				// Run the three-phase dispatch engine
 				dispatchResult := core.Dispatch(ctx, eventType, payload, config)
 
+				// Budget enforcement (PreToolUse only, opt-in via
+				// cost_tracking.enforcement: enforce). A deny here is the hardest
+				// gate, so it overrides whatever dispatch decided. Off by default,
+				// so normal users incur no extra read. The DB read lives here in
+				// the command layer (not the pure engine) because core.Dispatch
+				// has no analytics dependency.
+				if eventType == core.EventPreToolUse {
+					if override := enforceBudget(ctx, config); override != nil {
+						dispatchResult = *override
+					}
+				}
+
 				if ctx.Err() == context.DeadlineExceeded {
 					elapsed := time.Since(dispatchStart)
 					core.Logger().Warn("dispatch timeout",
@@ -137,6 +149,61 @@ func newDispatchCmd() *cobra.Command {
 	cmd.Flags().StringVar(&projectDir, "project-dir", "", "Project directory (defaults to cwd)")
 
 	return cmd
+}
+
+// budgetDenyReason returns a non-empty deny reason when daily-budget enforcement
+// is active and today's spend has reached the budget, or "" otherwise. Pure: the
+// caller supplies today's total so this is trivially testable without a DB.
+//
+// Enforcement is opt-in — it only triggers when cost_tracking.enforcement is set
+// to "enforce" (the default is "warn", which never blocks). This is what makes
+// the cost-tracking recipe's advertised "budget enforcement" real (previously
+// the Enforcement field was defined, defaulted, and read nowhere).
+func budgetDenyReason(cc core.CostTrackingConfig, totalToday float64) string {
+	if !cc.Enabled || cc.Enforcement != "enforce" || cc.DailyBudget <= 0 {
+		return ""
+	}
+	if totalToday < cc.DailyBudget {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Daily budget reached: $%.2f spent today (budget $%.2f). Set cost_tracking.enforcement to \"warn\" to allow tool calls.",
+		totalToday, cc.DailyBudget,
+	)
+}
+
+// enforceBudget reads today's cost state and, when daily-budget enforcement is
+// active and exceeded, returns a PreToolUse "deny" override. Returns nil
+// (allow) on any error or when not over budget — fail-open per ARCH-1.
+//
+// The cheap gate is checked BEFORE opening the DB, so default (warn) users pay
+// no extra hot-path read. Only opt-in enforce users incur one singleton cost-
+// state read per PreToolUse.
+func enforceBudget(ctx context.Context, config core.HooksConfig) *core.DispatchResult {
+	cc := config.CostTracking
+	if !cc.Enabled || cc.Enforcement != "enforce" || cc.DailyBudget <= 0 {
+		return nil
+	}
+
+	db, err := analytics.Open(config.Analytics.DBPath)
+	if err != nil {
+		core.Logger().Warn("budget enforcement: failed to open DB (fail-open)", "error", err)
+		return nil
+	}
+	defer db.Close()
+
+	cs, err := db.ReadCostState(ctx)
+	if err != nil || cs == nil {
+		core.Logger().Warn("budget enforcement: failed to read cost state (fail-open)", "error", err)
+		return nil
+	}
+
+	reason := budgetDenyReason(cc, cs.TotalToday)
+	if reason == "" {
+		return nil
+	}
+	stdout := core.BuildPermissionDenyJSON(reason)
+	return &core.DispatchResult{Stdout: &stdout, ExitCode: 0}
 }
 
 // analyticsRecordTimeout bounds how long dispatch waits for the analytics write

--- a/cmd/hookwise/cmd_dispatch_budget_test.go
+++ b/cmd/hookwise/cmd_dispatch_budget_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/analytics"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// --- Pure policy tests: budgetDenyReason ---
+
+func TestBudgetDenyReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        core.CostTrackingConfig
+		totalToday float64
+		wantDeny   bool
+	}{
+		{
+			name:       "enforce + over budget -> deny",
+			cfg:        core.CostTrackingConfig{Enabled: true, Enforcement: "enforce", DailyBudget: 10},
+			totalToday: 12.50,
+			wantDeny:   true,
+		},
+		{
+			name:       "enforce + exactly at budget -> deny",
+			cfg:        core.CostTrackingConfig{Enabled: true, Enforcement: "enforce", DailyBudget: 10},
+			totalToday: 10,
+			wantDeny:   true,
+		},
+		{
+			name:       "enforce + under budget -> allow",
+			cfg:        core.CostTrackingConfig{Enabled: true, Enforcement: "enforce", DailyBudget: 10},
+			totalToday: 9.99,
+			wantDeny:   false,
+		},
+		{
+			name:       "warn + over budget -> allow (warn never blocks)",
+			cfg:        core.CostTrackingConfig{Enabled: true, Enforcement: "warn", DailyBudget: 10},
+			totalToday: 50,
+			wantDeny:   false,
+		},
+		{
+			name:       "disabled + over budget -> allow",
+			cfg:        core.CostTrackingConfig{Enabled: false, Enforcement: "enforce", DailyBudget: 10},
+			totalToday: 50,
+			wantDeny:   false,
+		},
+		{
+			name:       "zero budget -> allow (no budget configured)",
+			cfg:        core.CostTrackingConfig{Enabled: true, Enforcement: "enforce", DailyBudget: 0},
+			totalToday: 50,
+			wantDeny:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason := budgetDenyReason(tt.cfg, tt.totalToday)
+			if tt.wantDeny {
+				assert.NotEmpty(t, reason, "expected a deny reason")
+				assert.Contains(t, reason, "budget")
+			} else {
+				assert.Empty(t, reason, "expected no deny")
+			}
+		})
+	}
+}
+
+// --- DB-backed integration test: enforceBudget reads cost state and denies ---
+
+func TestEnforceBudget_OverBudget_DeniesWithPermissionJSON(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db, err := analytics.Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	// Seed cost state above the budget.
+	cs := &analytics.CostState{
+		DailyCosts:   map[string]float64{},
+		SessionCosts: map[string]float64{"s1": 18.0},
+		TotalToday:   18.0,
+	}
+	require.NoError(t, db.WriteCostState(ctx, cs))
+
+	config := core.GetDefaultConfig()
+	config.Analytics.DBPath = dbPath
+	config.CostTracking.Enabled = true
+	config.CostTracking.Enforcement = "enforce"
+	config.CostTracking.DailyBudget = 10
+
+	override := enforceBudget(ctx, config)
+	require.NotNil(t, override, "over-budget enforce must produce a deny override")
+	require.NotNil(t, override.Stdout)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(*override.Stdout), &parsed))
+	hso, ok := parsed["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok, "deny must use hookSpecificOutput permission format")
+	assert.Equal(t, "deny", hso["permissionDecision"])
+	assert.Equal(t, "PreToolUse", hso["hookEventName"])
+}
+
+func TestEnforceBudget_UnderBudget_NoOverride(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db, err := analytics.Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	require.NoError(t, db.WriteCostState(ctx, &analytics.CostState{
+		DailyCosts:   map[string]float64{},
+		SessionCosts: map[string]float64{"s1": 2.0},
+		TotalToday:   2.0,
+	}))
+
+	config := core.GetDefaultConfig()
+	config.Analytics.DBPath = dbPath
+	config.CostTracking.Enabled = true
+	config.CostTracking.Enforcement = "enforce"
+	config.CostTracking.DailyBudget = 10
+
+	assert.Nil(t, enforceBudget(ctx, config), "under budget must not override")
+}
+
+func TestEnforceBudget_WarnMode_NoOverride(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db, err := analytics.Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	require.NoError(t, db.WriteCostState(ctx, &analytics.CostState{
+		DailyCosts:   map[string]float64{},
+		SessionCosts: map[string]float64{"s1": 99.0},
+		TotalToday:   99.0,
+	}))
+
+	config := core.GetDefaultConfig()
+	config.Analytics.DBPath = dbPath
+	config.CostTracking.Enabled = true
+	config.CostTracking.Enforcement = "warn" // default: never blocks
+	config.CostTracking.DailyBudget = 10
+
+	assert.Nil(t, enforceBudget(ctx, config), "warn mode must never override even over budget")
+}

--- a/internal/core/dispatcher.go
+++ b/internal/core/dispatcher.go
@@ -290,6 +290,14 @@ func buildPermissionJSON(decision, reason string) string {
 	return string(b)
 }
 
+// BuildPermissionDenyJSON builds the PreToolUse "deny" permission JSON, byte-
+// identical to a declarative block guard's output. Exported so the command
+// layer can emit a deny for cost-budget enforcement (which needs the analytics
+// DB and therefore cannot live inside the pure dispatch engine).
+func BuildPermissionDenyJSON(reason string) string {
+	return buildPermissionJSON("deny", reason)
+}
+
 // buildContextJSON builds the JSON output for additionalContext injection.
 func buildContextJSON(contextStr string) string {
 	type hookOutput struct {


### PR DESCRIPTION
## What

Launch-remediation audit item #2 (the second dispatch-path item — **you greenlit "implement both, make real"**). `CostTracking.Enforcement` was defined, defaulted to `"warn"`, parse-tested, and **read nowhere** — the cost path only emitted a notification and never blocked, while `recipes/compliance/cost-tracking/README.md` markets "budget enforcement". This wires it up for real.

When `cost_tracking.enforcement: enforce` (opt-in; default `warn` never blocks) **and** today's spend ≥ `cost_tracking.daily_budget`, a **PreToolUse** event now returns a `deny` permission decision, so Claude Code refuses the tool call.

## Design (hot-path-safe, pure engine untouched)

- `core.Dispatch` stays **DB-agnostic**. New exported `core.BuildPermissionDenyJSON` emits byte-identical deny JSON (same as a declarative block guard).
- The budget read lives in the **command layer** (`cmd_dispatch.go`), where the analytics DB is already in use. `enforceBudget()` checks the cheap gate (`enabled && enforcement=="enforce" && budget>0`) **before** opening the DB — so default (warn) users incur **zero** extra hot-path work; only opt-in enforce users pay one singleton cost-state read per PreToolUse.
- **Fail-open (ARCH-1)**: any DB open/read error → allow.
- The override is applied only on `EventPreToolUse` and is the hardest gate, overriding whatever dispatch decided.

## Tests (TDD red→green)

- Pure table-driven `budgetDenyReason`: enforce/warn/disabled/zero-budget × under/at/over.
- DB-backed `enforceBudget` integration: seed cost state → assert deny permission JSON (over) / no override (under, warn-mode).

## Live verification (temp binary, not installed over PATH)

End-to-end through the real binary:
1. `dispatch Stop` over an $18 transcript (1M in + 1M out sonnet) → cost port writes cost state.
2. `dispatch PreToolUse` with `enforce` + `daily_budget: 10` →
   ```json
   {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Daily budget reached: $18.00 spent today (budget $10.00). Set cost_tracking.enforcement to \"warn\" to allow tool calls."}}
   ```
3. Flipping to `warn` → allow (no stdout). This also incidentally confirms the cost-port chain (Stop → cost state → stats) is live.

## Verification

- `go build ./...` + `go vet` clean. Guarded gate: `cmd/hookwise` + `internal/core` green under `-race -p 2` (0 zombies). ARCH-6 contract fixtures disable cost tracking, so parity is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)