### PR TITLE
fix(hooks): scan user-level settings.local.json, drop dead projects glob

### DIFF
--- a/internal/hooks/paths.go
+++ b/internal/hooks/paths.go
@@ -4,23 +4,29 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 
 	"github.com/vishnujayvel/hookwise/internal/core"
 )
 
-// SettingsPaths returns the Claude Code settings files to scan for hooks, given
-// the .claude directory: the global settings.json (always listed, even if
-// absent — Scan tolerates missing files) plus every
-// projects/*/settings.local.json. Project paths are sorted for deterministic
-// output.
+// SettingsPaths returns the Claude Code user-level settings files to scan for
+// hooks, given the .claude directory: settings.json (shared) and
+// settings.local.json (personal overrides). Both are always listed even if
+// absent — Scan tolerates missing files. settings.json is kept first because
+// runWire targets paths[0] as the wire destination.
+//
+// Note: the previous implementation globbed
+// ~/.claude/projects/*/settings.local.json, but that directory holds
+// conversation transcripts (.jsonl), not settings, so the glob never matched in
+// production (its test invented an on-disk structure that does not exist — a
+// mock-confidence trap). Restoring the user-level settings.local.json scan
+// closes a real gap (personal hooks were unscanned). Project-local settings
+// discovery (<project>/.claude/settings{,.local}.json) needs real project
+// enumeration and is a separate follow-up.
 func SettingsPaths(claudeDir string) []string {
-	paths := []string{filepath.Join(claudeDir, "settings.json")}
-
-	matches, _ := filepath.Glob(filepath.Join(claudeDir, "projects", "*", "settings.local.json"))
-	sort.Strings(matches)
-	paths = append(paths, matches...)
-	return paths
+	return []string{
+		filepath.Join(claudeDir, "settings.json"),
+		filepath.Join(claudeDir, "settings.local.json"),
+	}
 }
 
 // DefaultSettingsPaths returns SettingsPaths for the Claude Code settings

--- a/internal/hooks/paths_test.go
+++ b/internal/hooks/paths_test.go
@@ -9,31 +9,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSettingsPaths_GlobalAndProjects(t *testing.T) {
+func TestSettingsPaths_GlobalAndLocal(t *testing.T) {
 	claude := t.TempDir()
-	// Global settings.
 	require.NoError(t, os.WriteFile(filepath.Join(claude, "settings.json"), []byte("{}"), 0o600))
-	// Two project settings.local.json files.
-	for _, proj := range []string{"projA", "projB"} {
-		dir := filepath.Join(claude, "projects", proj)
-		require.NoError(t, os.MkdirAll(dir, 0o750))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "settings.local.json"), []byte("{}"), 0o600))
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(claude, "settings.local.json"), []byte("{}"), 0o600))
 
 	paths := SettingsPaths(claude)
 
+	// Both user-level settings files are scanned: settings.json (shared) and
+	// settings.local.json (personal overrides) — the latter is a common place
+	// for hooks and was previously never scanned.
 	assert.Contains(t, paths, filepath.Join(claude, "settings.json"))
-	assert.Contains(t, paths, filepath.Join(claude, "projects", "projA", "settings.local.json"))
-	assert.Contains(t, paths, filepath.Join(claude, "projects", "projB", "settings.local.json"))
-	assert.Len(t, paths, 3)
+	assert.Contains(t, paths, filepath.Join(claude, "settings.local.json"))
+	assert.Equal(t, filepath.Join(claude, "settings.json"), paths[0],
+		"settings.json must stay first — runWire targets paths[0]")
+	assert.Len(t, paths, 2)
 }
 
-func TestSettingsPaths_GlobalAlwaysListedEvenIfAbsent(t *testing.T) {
+func TestSettingsPaths_DoesNotChaseProjectsTranscriptDir(t *testing.T) {
+	// Regression guard against the old mock-confidence glob: ~/.claude/projects/*/
+	// holds conversation transcripts (.jsonl), never settings.local.json, so a
+	// glob there matched nothing in production while its test invented a fictional
+	// structure. Even if such a file exists, SettingsPaths must NOT return it.
+	claude := t.TempDir()
+	dir := filepath.Join(claude, "projects", "encoded-project")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "settings.local.json"), []byte("{}"), 0o600))
+
+	paths := SettingsPaths(claude)
+
+	assert.NotContains(t, paths, filepath.Join(dir, "settings.local.json"),
+		"must not scan the projects/ transcript directory")
+	assert.Len(t, paths, 2)
+}
+
+func TestSettingsPaths_UserLevelAlwaysListedEvenIfAbsent(t *testing.T) {
 	claude := t.TempDir() // empty: no files
 	paths := SettingsPaths(claude)
-	// Global path is always returned (Scan tolerates it being missing).
-	require.Len(t, paths, 1)
+	// Both user-level paths are always returned (Scan tolerates missing files).
+	require.Len(t, paths, 2)
 	assert.Equal(t, filepath.Join(claude, "settings.json"), paths[0])
+	assert.Equal(t, filepath.Join(claude, "settings.local.json"), paths[1])
 }
 
 func TestDefaultSettingsPaths_HonorsClaudeDirEnv(t *testing.T) {


### PR DESCRIPTION
## What

Launch-remediation audit item #13. `SettingsPaths` globbed `~/.claude/projects/*/settings.local.json`, but that directory holds conversation **transcripts** (`.jsonl`), not settings — so the glob **never matched in production** and doctor's hook-safety scan covered nothing there. The test made it worse: it created a fictional `projects/<name>/settings.local.json` structure that doesn't exist on disk, so the suite stayed green while the scan was blind (a **mock-confidence trap**, the Bug #29 pattern).

Meanwhile the real user-level personal-hooks file — `~/.claude/settings.local.json` — was **never scanned at all**, which is exactly where an unsafe personal hook is most likely to live.

## Fix

- Scan both **user-level** files: `settings.json` (shared) + `settings.local.json` (personal overrides).
- Drop the never-matching `projects/*/settings.local.json` glob.
- `settings.json` stays `paths[0]`, so `runWire`'s wire target is unchanged.

## Tests

- `TestSettingsPaths_GlobalAndLocal` — both user-level files returned, `settings.json` first.
- `TestSettingsPaths_DoesNotChaseProjectsTranscriptDir` — **regression guard**: even if a `projects/<x>/settings.local.json` exists, it must NOT be returned.
- `TestSettingsPaths_UserLevelAlwaysListedEvenIfAbsent` — both always listed (Scan tolerates missing files).

## Verification

- `go build ./...` + `go vet` clean. Guarded gate: `internal/hooks` **and** `cmd/hookwise` (the `DefaultSettingsPaths` consumers — doctor/init) green under `-race -p 2` (0 zombies).

## Scope / follow-up

Proper **project-local** settings discovery (`<project>/.claude/settings{,.local}.json`) needs real project enumeration (the `~/.claude/projects/` dir names are an ambiguous lossy encoding of project paths) — left as a follow-up rather than building a fragile decoder here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)