### PR TITLE
docs(tech-stack): clarify TUI snapshots don't gate CI

### DIFF
--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -107,11 +107,18 @@ pkg/hookwise/testing/   # Test utility exports (hwtesting)
 
 | Tool | Type | Prevents |
 |------|------|----------|
-| **pytest-textual-snapshot** | TUI visual regression (SVG snapshots) | Layout bugs |
+| **pytest-textual-snapshot** | TUI visual regression (SVG snapshots) | Layout bugs (local-only — see note) |
 | **go/packages** (internal/arch) | Architecture linting (import graph rules) | Package dependency violations |
 | **pgregory.net/rapid** (internal/proptest) | Property-based testing (random input generation) | Scoring invariant violations |
 | **internal/mutation** | Mutation testing (3 operators, 93.3% kill rate) | Weak test assertions |
 | **internal/chaos** | Chaos/failure mode testing (12+ scenarios) | Unhandled failure paths |
+
+> **Snapshot tests do not gate CI.** Container rendering (terminal size, fonts)
+> differs from local macOS, so committed baselines won't match in CI; the dagger
+> pipeline runs snapshots with `--snapshot-update`, which regenerates rather than
+> asserts. They catch regressions only when run locally and diffed by a human.
+> Making visual regressions fail CI (committed container-rendered baselines) is a
+> roadmap item — see `docs/roadmap.md`.
 
 ## Layer 5: Documentation
 


### PR DESCRIPTION
## What

Launch-remediation audit item #12 (honesty form). The "Advanced Testing Tiers" table in `docs/tech-stack.md` listed `pytest-textual-snapshot` as preventing **"Layout bugs"** with no qualification — reading like an enforced visual-regression safety net.

In reality the dagger pipeline runs snapshots with `--snapshot-update` (container rendering differs from local macOS, so committed baselines won't match), which **regenerates** baselines rather than asserting them — a rendering regression can never fail CI. The dagger code comments already say this (`dagger/main.go:222`, `:336`) and `docs/roadmap.md` lists CI-gating as a future item; this makes the public tech-stack doc honest too.

## Change

Doc-only: append a note to the table that snapshots are a **local-only** check, that the dagger pipeline regenerates rather than asserts, and that making visual regressions fail CI (committed container-rendered baselines) is a roadmap item.

## Why doc-only (not "make CI assert")

The audit offered two paths; I took the honesty one deliberately. Committing container-rendered baselines and dropping `--snapshot-update` would make CI assert, but the repo has a documented history of snapshot flakiness across Python versions / container rendering — forcing assertions risks flaky CI failures. The honest, zero-risk fix is to stop the doc from implying enforcement that doesn't exist; actual gating stays a roadmap item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)