### PR TITLE
feat(migration): make hookwise upgrade idempotent via a migration marker

### DIFF
--- a/internal/analytics/migration_state.go
+++ b/internal/analytics/migration_state.go
@@ -1,0 +1,43 @@
+package analytics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// metaKeyTSMigration marks that the one-time TypeScript->Go data migration has
+// been applied to this database. It is stored in the generic schema_meta
+// key-value table so `hookwise upgrade` can short-circuit on re-run, rather than
+// erroring on duplicate session primary keys and double-importing events.
+const metaKeyTSMigration = "ts_migration_done"
+
+// TSMigrationDone reports whether the TypeScript->Go data migration marker is
+// set on this database.
+func (d *DB) TSMigrationDone(ctx context.Context) (bool, error) {
+	var v string
+	err := d.QueryRow(ctx,
+		`SELECT meta_value FROM schema_meta WHERE meta_key = ?`, metaKeyTSMigration).Scan(&v)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("analytics: read migration marker: %w", err)
+	}
+	return true, nil
+}
+
+// MarkTSMigrationDone records the TypeScript->Go migration as complete, so a
+// subsequent `hookwise upgrade` is a no-op. Upserts on the meta_key so repeated
+// marks are harmless.
+func (d *DB) MarkTSMigrationDone(ctx context.Context, at time.Time) error {
+	_, err := d.Exec(ctx,
+		`INSERT INTO schema_meta (meta_key, meta_value) VALUES (?, ?)
+		 ON CONFLICT(meta_key) DO UPDATE SET meta_value = excluded.meta_value`,
+		metaKeyTSMigration, at.UTC().Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("analytics: set migration marker: %w", err)
+	}
+	return nil
+}

--- a/internal/analytics/migration_state_test.go
+++ b/internal/analytics/migration_state_test.go
@@ -1,0 +1,49 @@
+package analytics
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTSMigrationDone_FalseOnFreshDB(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "analytics.db"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	done, err := db.TSMigrationDone(context.Background())
+	require.NoError(t, err)
+	assert.False(t, done, "a fresh DB must report the migration as not done")
+}
+
+func TestMarkTSMigrationDone_ThenDoneIsTrue(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "analytics.db"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	require.NoError(t, db.MarkTSMigrationDone(ctx, time.Now()))
+
+	done, err := db.TSMigrationDone(ctx)
+	require.NoError(t, err)
+	assert.True(t, done, "after marking, the migration must report as done")
+}
+
+func TestMarkTSMigrationDone_Idempotent(t *testing.T) {
+	db, err := Open(filepath.Join(t.TempDir(), "analytics.db"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	// Marking twice must not error (upsert on meta_key).
+	require.NoError(t, db.MarkTSMigrationDone(ctx, time.Now()))
+	require.NoError(t, db.MarkTSMigrationDone(ctx, time.Now().Add(time.Hour)))
+
+	done, err := db.TSMigrationDone(ctx)
+	require.NoError(t, err)
+	assert.True(t, done)
+}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -52,6 +52,7 @@ type MigrationResult struct {
 	AuthorshipImported int
 	CostStateImported bool
 	ConfigValid      bool
+	AlreadyMigrated  bool
 	Errors           []string
 }
 
@@ -498,22 +499,47 @@ func Run(opts MigrationOpts) MigrationResult {
 		defer db.Close()
 	}
 
-	// Step 3: Migrate SQLite.
-	if result.SQLiteDetected {
-		fmt.Fprintln(w, "\nMigrating SQLite data...")
-		sessions, events, authorship, errs := MigrateSQLite(ctx, db, sqlitePath, opts.DryRun, w)
-		result.SessionsImported = sessions
-		result.EventsImported = events
-		result.AuthorshipImported = authorship
-		result.Errors = append(result.Errors, errs...)
+	// Idempotency guard: if a prior live run already migrated this DB, skip the
+	// data import. Re-importing would error on duplicate session primary keys
+	// (sessions.id is a TEXT PK) and double-count events (AUTOINCREMENT, no
+	// natural key). Dry-run never writes the marker, so it always previews the
+	// full import.
+	if !opts.DryRun && db != nil {
+		if done, derr := db.TSMigrationDone(ctx); derr == nil && done {
+			result.AlreadyMigrated = true
+		}
 	}
 
-	// Step 4: Migrate cost state.
-	if result.CostStateDetected {
-		fmt.Fprintln(w, "\nMigrating cost state...")
-		imported, errs := MigrateCostState(ctx, db, costStatePath, opts.DryRun, w)
-		result.CostStateImported = imported
-		result.Errors = append(result.Errors, errs...)
+	if result.AlreadyMigrated {
+		fmt.Fprintln(w, "\n  Already migrated — skipping data import (hookwise upgrade is idempotent).")
+	} else {
+		// Step 3: Migrate SQLite.
+		if result.SQLiteDetected {
+			fmt.Fprintln(w, "\nMigrating SQLite data...")
+			sessions, events, authorship, errs := MigrateSQLite(ctx, db, sqlitePath, opts.DryRun, w)
+			result.SessionsImported = sessions
+			result.EventsImported = events
+			result.AuthorshipImported = authorship
+			result.Errors = append(result.Errors, errs...)
+		}
+
+		// Step 4: Migrate cost state.
+		if result.CostStateDetected {
+			fmt.Fprintln(w, "\nMigrating cost state...")
+			imported, errs := MigrateCostState(ctx, db, costStatePath, opts.DryRun, w)
+			result.CostStateImported = imported
+			result.Errors = append(result.Errors, errs...)
+		}
+
+		// Record the idempotency marker after a live import pass so a re-run is a
+		// no-op. Marked regardless of per-row errors: re-importing the same rows
+		// would only re-trigger the same PK conflicts, so retry never helps.
+		if !opts.DryRun && db != nil {
+			if merr := db.MarkTSMigrationDone(ctx, time.Now()); merr != nil {
+				result.Errors = append(result.Errors,
+					fmt.Sprintf("failed to record migration marker: %v", merr))
+			}
+		}
 	}
 
 	// Step 5: Validate config.

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -567,6 +567,65 @@ func TestRun_LiveMigration(t *testing.T) {
 	assert.Contains(t, output, "hookwise upgrade")
 }
 
+// TestRun_Idempotent_SecondRunSkipsImport proves `hookwise upgrade` is safe to
+// re-run: the first run imports, the second is a no-op. Without the idempotency
+// marker the second run errored on duplicate session PKs (sessions.id is a TEXT
+// PK) and double-imported events (AUTOINCREMENT, no natural key).
+func TestRun_Idempotent_SecondRunSkipsImport(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise-state"))
+
+	hwDir := filepath.Join(tmpDir, ".hookwise")
+	require.NoError(t, os.MkdirAll(filepath.Join(hwDir, "state"), 0o700))
+
+	sqlitePath := filepath.Join(hwDir, "analytics.db")
+	sqliteDB := createTestSQLite(t, sqlitePath)
+	seedSQLiteData(t, sqliteDB, 2, 3, 2)
+	sqliteDB.Close()
+	createCostStateJSON(t, hwDir)
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "hookwise.yaml"),
+		[]byte("version: 1\nguards: []\n"), 0o644))
+
+	dataDir := filepath.Join(tmpDir, "data")
+	opts := MigrationOpts{HomeDir: tmpDir, DryRun: false, DoltDataDir: dataDir, ProjectDir: tmpDir}
+
+	// First run imports everything.
+	var buf1 bytes.Buffer
+	opts.Writer = &buf1
+	r1 := Run(opts)
+	require.Empty(t, r1.Errors)
+	require.Equal(t, 2, r1.SessionsImported)
+	require.Equal(t, 3, r1.EventsImported)
+
+	eventsAfter1 := countRows(t, dataDir, "events")
+
+	// Second run must be a no-op: no PK-conflict errors, nothing re-imported.
+	var buf2 bytes.Buffer
+	opts.Writer = &buf2
+	r2 := Run(opts)
+	assert.Empty(t, r2.Errors, "second upgrade must not error on duplicate session PKs")
+	assert.Equal(t, 0, r2.SessionsImported, "second upgrade must not re-import sessions")
+	assert.Equal(t, 0, r2.EventsImported, "second upgrade must not re-import events")
+	assert.True(t, r2.AlreadyMigrated, "second upgrade must report already-migrated")
+	assert.Contains(t, buf2.String(), "Already migrated")
+
+	// Events must not be duplicated.
+	assert.Equal(t, eventsAfter1, countRows(t, dataDir, "events"),
+		"a second upgrade must not duplicate events")
+}
+
+// countRows opens the target analytics DB and returns the row count of a table.
+func countRows(t *testing.T, dataDir, table string) int {
+	t.Helper()
+	db, err := analytics.Open(dataDir)
+	require.NoError(t, err)
+	defer db.Close()
+	var n int
+	require.NoError(t, db.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM "+table).Scan(&n))
+	return n
+}
+
 // ---------------------------------------------------------------------------
 // Test 17: Original SQLite file is not modified
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Launch-remediation audit item #14 (you chose **do #14 now**). Re-running `hookwise upgrade` errored **and** corrupted data: `StartSession` does a bare `INSERT` against `sessions.id` (a TEXT PK), so a second run returned a PK conflict per imported session (upgrade exited with errors), while events (`AUTOINCREMENT`, no natural key) silently **double-imported**.

## Change

Add a one-time TypeScript→Go migration marker stored in the **existing** generic `schema_meta` key-value table (**no schema change** — the table already existed unused). `Run()` now checks the marker after opening the analytics DB:

- **marker set** → skip the SQLite + cost-state import entirely (still validates config), report `AlreadyMigrated`, print "Already migrated — skipping…".
- **marker absent** → import as before, then record the marker after the live pass.

The marker is set regardless of per-row errors (re-importing the same rows would only re-trigger the same PK conflicts, so retry never helps). **Dry-run never writes the marker**, so `--dry-run` always previews the full import.

Why not change `StartSession`? It's shared with the live dispatch SessionStart path — out of bounds for a migration fix. The top-level marker keeps the change migration-path-only.

## Tests (TDD red→green)

- Analytics: `TSMigrationDone` (fresh=false), `MarkTSMigrationDone`→done=true, idempotent double-mark (upsert).
- **End-to-end**: `TestRun_Idempotent_SecondRunSkipsImport` runs `Run()` twice against a real SQLite source and asserts the second run is **error-free**, imports **0** sessions/events, reports `AlreadyMigrated`, and **does not duplicate events**. (This fails before the fix — bare-INSERT PK conflict + event dupes.)

## Verification

- `go build ./...` + `go vet` clean. Guarded gate: `internal/analytics` + `internal/migration` green under `-race -p 2` (0 zombies). Existing `TestRun_LiveMigration`/`TestRun_DryRunFull` still pass (single-run behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)