### PR TITLE
feat(bridge): wire daemon feed cache into merged TUI cache

### DIFF
--- a/cmd/hookwise/cmd_daemon.go
+++ b/cmd/hookwise/cmd_daemon.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vishnujayvel/hookwise/internal/analytics"
+	"github.com/vishnujayvel/hookwise/internal/bridge"
 	"github.com/vishnujayvel/hookwise/internal/core"
 	"github.com/vishnujayvel/hookwise/internal/feeds"
 )
@@ -137,6 +138,19 @@ func newDaemonRunCmd() *cobra.Command {
 			if socketPath != "" {
 				daemon.SetSocketPath(socketPath)
 			}
+
+			// Wire the merged TUI cache regeneration. This lives in the cmd
+			// layer (not internal/feeds) because internal/bridge's test package
+			// imports internal/feeds, so a feeds→bridge import would cycle. After
+			// each producer writes its per-feed file, regenerate the single
+			// merged status-line-cache.json the Python TUI reads (audit #5).
+			daemon.SetPostPollHook(func(cacheDir string) {
+				outPath := filepath.Join(cacheDir, bridge.TUICacheFileName)
+				if err := bridge.WriteTUICacheTo(cacheDir, outPath); err != nil {
+					core.Logger().Error("daemon: TUI cache write error", "error", err)
+				}
+			})
+
 			if err := daemon.Start(); err != nil {
 				return fmt.Errorf("daemon: %w", err)
 			}

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -22,9 +22,19 @@ import (
 	"github.com/vishnujayvel/hookwise/internal/core"
 )
 
+// TUICacheFileName is the name of the merged TUI cache file that WriteTUICache
+// produces. It lives in the same directory as the per-feed envelopes, so
+// CollectFeedCache must exclude it by name — otherwise the merged output would
+// be re-ingested as a phantom "status-line-cache" feed and nest unboundedly on
+// every poll cycle.
+const TUICacheFileName = "status-line-cache.json"
+
 // CollectFeedCache reads all *.json files from cacheDir and merges them into
 // a single map keyed by feed name (the filename stem, e.g. "pulse" from
 // "pulse.json"). Each value is the parsed JSON content of that file.
+//
+// The merged TUI output file (TUICacheFileName) is excluded so that writing it
+// back into the same directory does not re-ingest it as a phantom feed.
 //
 // Files that cannot be read or contain invalid JSON are silently skipped.
 // An empty or nonexistent directory returns an empty (non-nil) map and no error.
@@ -46,6 +56,9 @@ func CollectFeedCache(cacheDir string) (map[string]interface{}, error) {
 		name := entry.Name()
 		if !strings.HasSuffix(name, ".json") {
 			continue
+		}
+		if name == TUICacheFileName {
+			continue // never re-ingest our own merged output
 		}
 
 		feedName := strings.TrimSuffix(name, ".json")

--- a/internal/bridge/bridge_test.go
+++ b/internal/bridge/bridge_test.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/core"
 	"github.com/vishnujayvel/hookwise/internal/feeds"
 )
 
@@ -25,6 +27,26 @@ func writeFeedFile(t *testing.T, dir, name string, data interface{}) {
 	require.NoError(t, err)
 	content = append(content, '\n')
 	require.NoError(t, os.WriteFile(filepath.Join(dir, name+".json"), content, 0o600))
+}
+
+// TestCollectFeedCache_ExcludesMergedTUICache guards against self-ingestion: the
+// merged TUI cache (status-line-cache.json) lives in the same directory as the
+// per-feed envelopes, so CollectFeedCache must NOT treat it as a feed. Otherwise
+// each merge cycle would nest the previous merged blob under a "status-line-cache"
+// key, growing the cache unboundedly.
+func TestCollectFeedCache_ExcludesMergedTUICache(t *testing.T) {
+	dir := t.TempDir()
+	writeFeedFile(t, dir, "weather", makeFeedEntry("weather", map[string]interface{}{"temp": 20}))
+	// The merged output file in the same dir must be ignored by collection.
+	writeFeedFile(t, dir, "status-line-cache", map[string]interface{}{
+		"weather": map[string]interface{}{"temp": 20, "updated_at": "x", "ttl_seconds": 300},
+	})
+
+	merged, err := CollectFeedCache(dir)
+	require.NoError(t, err)
+	assert.Contains(t, merged, "weather")
+	assert.NotContains(t, merged, "status-line-cache",
+		"the merged TUI cache must not be collected as a feed")
 }
 
 // makeFeedEntry builds a feed entry in the Go-envelope format produced by
@@ -991,4 +1013,73 @@ func TestIsEnvelopeFresh_YesterdayData(t *testing.T) {
 		},
 	}
 	assert.False(t, IsEnvelopeFresh(envelope), "yesterday's calendar data should be stale")
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: daemon poll → post-poll hook → merged TUI cache
+// ---------------------------------------------------------------------------
+
+// e2eProducer is a minimal feeds.Producer that emits a Go-envelope payload.
+type e2eProducer struct {
+	name string
+	data map[string]interface{}
+}
+
+func (p *e2eProducer) Name() string { return p.name }
+func (p *e2eProducer) Produce(_ context.Context) (interface{}, error) {
+	return map[string]interface{}{
+		"type":      p.name,
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"data":      p.data,
+	}, nil
+}
+
+// TestDaemonPostPollHook_WritesMergedTUICacheWithoutSelfKey wires the real
+// bridge.WriteTUICacheTo into a live daemon (as cmd/hookwise does) and asserts
+// the merged TUI cache is written with flattened keys AND contains no
+// "status-line-cache" self-key — proving the daemon→bridge seam is wired
+// (audit #5) and immune to self-ingestion.
+func TestDaemonPostPollHook_WritesMergedTUICacheWithoutSelfKey(t *testing.T) {
+	r := feeds.NewRegistry()
+	// Use an unknown feed name so isEnabled defaults true (fail-open).
+	r.Register(&e2eProducer{name: "e2efeed", data: map[string]interface{}{"temperature": float64(72)}})
+
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+
+	// Socket paths must be short (macOS 104-byte limit), so use /tmp.
+	sockDir, err := os.MkdirTemp("/tmp", "hw-br-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(sockDir) })
+
+	d := feeds.NewDaemon(core.DaemonConfig{}, core.FeedsConfig{}, r)
+	d.SetPIDFile(filepath.Join(tmpDir, "daemon.pid"))
+	d.SetCacheDir(cacheDir)
+	d.SetSocketPath(filepath.Join(sockDir, "d.sock"))
+
+	mergedPath := filepath.Join(cacheDir, TUICacheFileName)
+	d.SetPostPollHook(func(dir string) {
+		require.NoError(t, WriteTUICacheTo(dir, filepath.Join(dir, TUICacheFileName)))
+	})
+
+	require.NoError(t, d.Start())
+	time.Sleep(300 * time.Millisecond)
+	require.NoError(t, d.Stop())
+
+	// The merged TUI cache exists and is flattened.
+	raw, err := os.ReadFile(mergedPath)
+	require.NoError(t, err)
+	var merged map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &merged))
+
+	require.Contains(t, merged, "e2efeed", "the per-feed entry must be merged into the TUI cache")
+	entry, ok := merged["e2efeed"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, float64(72), entry["temperature"], "data fields must be spread to top level")
+	assert.Contains(t, entry, "updated_at", "flattened entry must have updated_at")
+	assert.Contains(t, entry, "ttl_seconds", "flattened entry must have ttl_seconds")
+
+	// Critically: the merged file must NOT re-ingest itself as a feed.
+	assert.NotContains(t, merged, "status-line-cache",
+		"the merged TUI cache must not contain itself as a feed (no self-ingestion)")
 }

--- a/internal/feeds/daemon.go
+++ b/internal/feeds/daemon.go
@@ -41,6 +41,15 @@ type Daemon struct {
 	idleTimer       *time.Timer
 	idleMu          sync.Mutex
 	idleTimeoutOverride time.Duration // test-only: overrides InactivityTimeoutMinutes
+
+	// postPollHook, if set, runs after each producer writes its per-feed cache
+	// file. It receives the cache directory. The cmd layer wires this to
+	// bridge.WriteTUICacheTo so the merged TUI cache is regenerated whenever a
+	// feed updates. It lives here (not as a direct feeds→bridge import) because
+	// internal/bridge's test package imports internal/feeds, so a feeds→bridge
+	// import would cycle (mirrors the ARCH-3 reason the snapshot scheduler lives
+	// in cmd: feeds cannot import analytics either).
+	postPollHook func(cacheDir string)
 }
 
 // NewDaemon creates a new daemon with the given configuration and registry.
@@ -77,6 +86,14 @@ func (d *Daemon) SetSocketPath(path string) {
 // (used in tests to speed up execution).
 func (d *Daemon) SetStaggerOffset(offset time.Duration) {
 	d.staggerOffset = offset
+}
+
+// SetPostPollHook registers a callback invoked after each producer writes its
+// per-feed cache file, receiving the cache directory. The cmd layer wires this
+// to regenerate the merged TUI cache (bridge.WriteTUICacheTo). Must be called
+// before Start().
+func (d *Daemon) SetPostPollHook(fn func(cacheDir string)) {
+	d.postPollHook = fn
 }
 
 // SetIdleTimeout overrides the idle timeout duration (used in tests).

--- a/internal/feeds/feeds_test.go
+++ b/internal/feeds/feeds_test.go
@@ -258,6 +258,35 @@ func TestDaemon_PollFeedWritesCache(t *testing.T) {
 	assert.Equal(t, "F", parsed["unit"])
 }
 
+// TestDaemon_PostPollHookFiresWithCacheDir verifies the post-poll hook runs
+// after a producer writes its per-feed cache, receiving the cache directory.
+// This is the seam the cmd layer uses to regenerate the merged TUI cache
+// (audit #5) without a feeds→bridge import.
+func TestDaemon_PostPollHookFiresWithCacheDir(t *testing.T) {
+	r := NewRegistry()
+	mp := newMockProducer("weather", map[string]interface{}{"temperature": 72})
+	r.Register(mp)
+
+	d, tmpDir := newTestDaemon(t, r)
+	d.feeds.Weather.Enabled = true
+	cacheDir := filepath.Join(tmpDir, "cache")
+	d.SetCacheDir(cacheDir)
+
+	var hookCalls atomic.Int64
+	var gotDir atomic.Value
+	d.SetPostPollHook(func(dir string) {
+		hookCalls.Add(1)
+		gotDir.Store(dir)
+	})
+
+	require.NoError(t, d.Start())
+	time.Sleep(300 * time.Millisecond)
+	require.NoError(t, d.Stop())
+
+	assert.Positive(t, hookCalls.Load(), "post-poll hook should fire at least once")
+	assert.Equal(t, cacheDir, gotDir.Load(), "hook should receive the cache directory")
+}
+
 // ---------------------------------------------------------------------------
 // Test 7: Staggered start timing
 // ---------------------------------------------------------------------------

--- a/internal/feeds/polling.go
+++ b/internal/feeds/polling.go
@@ -108,6 +108,13 @@ func (d *Daemon) runProducer(ctx context.Context, p Producer, interval time.Dura
 	if err := core.AtomicWriteJSON(cachePath, data); err != nil {
 		core.Logger().Error("feeds: cache write error", "producer", p.Name(), "error", err)
 	}
+
+	// Regenerate the merged TUI cache so the Python TUI sees the fresh feed.
+	// Wired by the cmd layer (bridge.WriteTUICacheTo) to avoid a feeds→bridge
+	// import cycle. Panics are already covered by this function's recover().
+	if d.postPollHook != nil {
+		d.postPollHook(d.cacheDir)
+	}
 }
 
 // runAllFeeds launches goroutines for all registered producers with


### PR DESCRIPTION
## What

Wires the Go daemon's per-feed cache into the single merged `status-line-cache.json` that the Python TUI reads, fixing **audit #5** (TUI feed tabs render empty).

## Why

`bridge.WriteTUICache` had **zero non-test callers** — nothing produced the merged cache from live feed envelopes, so the TUI feed tabs were always empty. The adapter existed but was never wired.

## Changes

1. **Self-ingestion guard** — `CollectFeedCache` now skips the merged output file by name (new `bridge.TUICacheFileName`). The merged file lives in the **same directory** as per-feed envelopes, so without this guard each merge cycle would re-ingest the prior merged blob under a phantom `status-line-cache` key and grow the cache unboundedly.
2. **Daemon wiring via post-poll hook** — added `Daemon.SetPostPollHook`, fired after each producer writes its per-feed file. `cmd_daemon.go` wires it to `bridge.WriteTUICacheTo`.

### Why the hook lives in the cmd layer (not a direct `feeds → bridge` import)

`internal/bridge`'s test package (`package bridge`) imports `internal/feeds`, so a `feeds → bridge` import would create a cycle. This is the same reason the ARCH-3 snapshot scheduler lives in `cmd` (feeds can't import analytics either). The cmd layer imports both and bridges them.

## Safety

- **Concurrency-safe:** `AtomicWriteJSON` uses a random temp suffix + atomic rename; `.tmp-*` files are skipped by the `.json` filter; the merged file is excluded by name. Concurrent producer goroutines invoking the hook can't clobber each other.
- **ARCH-1/3/7 preserved:** hook panics are covered by the existing `runProducer` recover; still JSON-cache-only (no DB writes); non-blocking.

## Tests

- `feeds`: `TestDaemon_PostPollHookFiresWithCacheDir` — hook fires after a poll with the cache dir.
- `bridge`: `TestCollectFeedCache_ExcludesMergedTUICache` — self-ingestion guard.
- `bridge`: `TestDaemonPostPollHook_WritesMergedTUICacheWithoutSelfKey` — **end-to-end**: live daemon + real `WriteTUICacheTo` → merged cache has flattened keys AND no `status-line-cache` self-key.

Gate green (`-race -p 2`): bridge, feeds, **arch** (no new import-graph violation), cmd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)