### PR TITLE
fix(weather): emit "set location" on unset coords, not silent SF

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -98,8 +98,10 @@ func GetDefaultConfig() HooksConfig {
 			Weather: WeatherFeedConfig{
 				Enabled:         false,
 				IntervalSeconds: 600,
-				Latitude:        37.7749,
-				Longitude:       -122.4194,
+				// Latitude/Longitude deliberately left unset (0,0): a user who
+				// enables weather without coordinates gets an actionable "set
+				// location" signal rather than silent San Francisco weather
+				// (audit NICE-TO-HAVE #15).
 				TemperatureUnit: "fahrenheit",
 			},
 			Memories: MemoriesFeedConfig{

--- a/internal/feeds/producer_weather.go
+++ b/internal/feeds/producer_weather.go
@@ -99,12 +99,13 @@ func (p *WeatherProducer) Produce(ctx context.Context) (interface{}, error) {
 	cfg := p.feedsCfg.Weather
 	p.mu.Unlock()
 
-	// Default coordinates (San Francisco) if not configured.
+	// No coordinates configured: emit an actionable "set your location" signal
+	// rather than silently fetching San Francisco weather, which would read as a
+	// real reading the user never asked for (audit NICE-TO-HAVE #15).
 	lat := cfg.Latitude
 	lon := cfg.Longitude
 	if lat == 0 && lon == 0 {
-		lat = 37.7749
-		lon = -122.4194
+		return p.unconfiguredResult(), nil
 	}
 
 	tempUnit := "fahrenheit"
@@ -189,6 +190,29 @@ func (p *WeatherProducer) fallbackResult(reason string) map[string]interface{} {
 		"weatherCode":     nil,
 		"emoji":           "\U0001f324\ufe0f",
 		"description":     "Unavailable",
+	})
+}
+
+// unconfiguredResult signals that the weather feed is enabled but no coordinates
+// are set, so the producer cannot fetch real data. It is distinct from
+// fallbackResult ("Unavailable", a transient API failure) so the user sees an
+// actionable "set your location" message rather than silent San Francisco
+// weather. Numerics are nil so consumers render "--" instead of a literal 0.
+func (p *WeatherProducer) unconfiguredResult() map[string]interface{} {
+	p.mu.Lock()
+	unit := "fahrenheit"
+	if p.feedsCfg.Weather.TemperatureUnit == "celsius" {
+		unit = "celsius"
+	}
+	p.mu.Unlock()
+
+	return NewEnvelope("weather", map[string]interface{}{
+		"temperature":     nil,
+		"temperatureUnit": unit,
+		"windSpeed":       nil,
+		"weatherCode":     nil,
+		"emoji":           "\U0001f4cd", // 📍 round pushpin — prompt to set a location
+		"description":     "Set location",
 	})
 }
 

--- a/internal/feeds/producer_weather_test.go
+++ b/internal/feeds/producer_weather_test.go
@@ -1,10 +1,13 @@
 package feeds
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/core"
 )
 
 // TestWeatherProducer_FallbackNoCache_NilNumerics pins the documented contract of
@@ -30,6 +33,49 @@ func TestWeatherProducer_FallbackNoCache_NilNumerics(t *testing.T) {
 	// The unit label is descriptive, not a numeric reading — it stays populated.
 	assert.Equal(t, "fahrenheit", data["temperatureUnit"])
 	assert.Equal(t, "Unavailable", data["description"])
+}
+
+// TestWeatherProducer_UnconfiguredCoords_NoSilentSF pins audit NICE-TO-HAVE #15:
+// when weather is enabled but no coordinates are configured (lat==0 && lon==0),
+// the producer must emit an actionable "set your location" envelope rather than
+// silently fetching San Francisco weather (which reads as a real reading the user
+// never asked for). Numerics are nil so the TUI renders "--", and the description
+// is distinct from the generic API-down "Unavailable" so the user knows to act.
+// Produce must short-circuit BEFORE any HTTP call: the failing client below would
+// error if reached, proving no network fetch happens for unset coordinates.
+func TestWeatherProducer_UnconfiguredCoords_NoSilentSF(t *testing.T) {
+	p := &WeatherProducer{
+		client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatalf("Produce must not hit the network when coordinates are unset")
+			return nil, nil
+		})},
+	}
+	// feedsCfg left zero-valued: Latitude==0, Longitude==0.
+
+	env, err := p.Produce(context.Background())
+	require.NoError(t, err)
+	data, ok := env.(map[string]interface{})["data"].(map[string]interface{})
+	require.True(t, ok, "envelope must carry a data map")
+
+	assert.Nil(t, data["temperature"], "temperature must be nil when location is unset")
+	assert.Nil(t, data["windSpeed"], "windSpeed must be nil when location is unset")
+	assert.Nil(t, data["weatherCode"], "weatherCode must be nil when location is unset")
+	assert.Equal(t, "Set location", data["description"],
+		"unset coordinates must surface an actionable message, not silent SF weather")
+}
+
+// roundTripFunc adapts a function to http.RoundTripper for hermetic client tests.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// TestGetDefaultConfig_WeatherCoordsUnset guards that the default config no longer
+// bakes in San Francisco coordinates — a fresh user who enables weather without
+// setting coords hits the honest "set location" path, not silent SF weather.
+func TestGetDefaultConfig_WeatherCoordsUnset(t *testing.T) {
+	cfg := core.GetDefaultConfig()
+	assert.Zero(t, cfg.Feeds.Weather.Latitude, "default weather latitude must be unset (not SF)")
+	assert.Zero(t, cfg.Feeds.Weather.Longitude, "default weather longitude must be unset (not SF)")
 }
 
 // TestWmoCodeToEmoji pins the WMO weather-code → emoji mapping across every


### PR DESCRIPTION
## What

Audit **NICE-TO-HAVE #15**. A user who enables the weather feed without configuring coordinates silently got **San Francisco** weather — a real-looking reading they never asked for, with no indication it was a placeholder.

## Root cause (two layers)

1. `GetDefaultConfig()` baked SF coords into `WeatherFeedConfig`.
2. `producer_weather.go` had a *second* `lat==0 && lon==0 → SF` fallback.

Because the config default supplied SF, the producer's own zero-check never even fired for default-config users — they always got SF.

## Fix

- Remove SF coords from `GetDefaultConfig` (leave `0,0` unset).
- `producer_weather.go` now returns a new `unconfiguredResult()` on zero coords: actionable `description: "Set location"` + 📍 emoji + **nil** numerics (TUI renders `--`), distinct from the transient API-down `"Unavailable"`. `Produce` short-circuits **before any HTTP call**.

## Safety

- Weather is **off by default**, so no fresh user is affected. The change only turns silently-wrong SF data into an honest, actionable signal.
- Pure feed-producer logic — **not** daemon coordination, **not** the PostToolUse hot path, **not** a feature.
- **No contract fixtures** reference weather coords → ARCH-6 byte-parity intact. No `GetDefaultConfig` test asserted the SF default (the only `Weather.Latitude` assertion is a user-override loading test).

## Tests (strict TDD, red→green verified)

- `TestWeatherProducer_UnconfiguredCoords_NoSilentSF` — hermetic failing-client `RoundTripper` proves **no network fetch** on unset coords; asserts nil numerics + `"Set location"`.
- `TestGetDefaultConfig_WeatherCoordsUnset` — guards the default no longer bakes in SF.

Gate green (`-race -p 2`, 0 zombies): feeds, core, contract, cmd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Weather feed no longer silently defaults to a specific location when coordinates are unconfigured. Users are now prompted to set their location instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->