### PR TITLE
feat(fleet): pure cross-session fleet-status aggregator

### DIFF
--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -1,0 +1,95 @@
+// Package fleet computes a cross-session "fleet status" snapshot from the live
+// state of multiple Claude Code sessions — the read-side aggregation behind a
+// status-line badge such as "run:2 done:1 blk:1".
+//
+// It is pure and has zero dependencies on storage, dispatch, or the daemon: it
+// takes a set of session records plus a clock and a staleness window and returns
+// counts. The write side (recording a session's status + heartbeat) and the
+// status-line wiring live elsewhere; this package is the load-bearing, fully
+// unit-tested core (the "Model D" snapshot — see issue #211).
+//
+// Liveness rule: a session whose heartbeat is older than the staleness window is
+// treated as crashed/abandoned and excluded from every count, so a badge never
+// reports work that is no longer happening.
+package fleet
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Status is a session's current lifecycle state.
+type Status string
+
+const (
+	// StatusRunning: the session is mid-turn / actively working.
+	StatusRunning Status = "running"
+	// StatusDone: the session finished its last turn (Stop seam).
+	StatusDone Status = "done"
+	// StatusBlocked: the session is waiting on the user (a guard confirm, a
+	// permission prompt) or surfaced an error.
+	StatusBlocked Status = "blocked"
+)
+
+// Session is a point-in-time record of one session's state, as persisted by the
+// write side.
+type Session struct {
+	ID            string
+	Status        Status
+	LastHeartbeat time.Time
+}
+
+// Snapshot is the aggregated, staleness-filtered fleet state.
+type Snapshot struct {
+	Running int
+	Done    int
+	Blocked int
+	Other   int // sessions with an unrecognised status string
+	Total   int // live (non-stale) sessions across all statuses
+}
+
+// Aggregate computes a Snapshot from sessions as of now, excluding any whose
+// heartbeat is older than staleness (age strictly greater than staleness is
+// stale; age == staleness is still live). A nil/empty slice yields the zero
+// Snapshot.
+func Aggregate(sessions []Session, now time.Time, staleness time.Duration) Snapshot {
+	var s Snapshot
+	for _, sess := range sessions {
+		age := now.Sub(sess.LastHeartbeat)
+		if age > staleness {
+			continue // crashed/abandoned — not part of the live fleet
+		}
+		s.Total++
+		switch sess.Status {
+		case StatusRunning:
+			s.Running++
+		case StatusDone:
+			s.Done++
+		case StatusBlocked:
+			s.Blocked++
+		default:
+			s.Other++
+		}
+	}
+	return s
+}
+
+// Badge renders a compact, terminal-safe status-line fragment, e.g.
+// "run:2 done:1 blk:1". Categories with a zero count are omitted; a Snapshot
+// with no live sessions renders the empty string. Only the three canonical
+// states are surfaced — Other counts toward Total but is intentionally not shown
+// (an unknown status is a write-side bug, not something to advertise).
+func (s Snapshot) Badge() string {
+	parts := make([]string, 0, 3)
+	if s.Running > 0 {
+		parts = append(parts, "run:"+strconv.Itoa(s.Running))
+	}
+	if s.Done > 0 {
+		parts = append(parts, "done:"+strconv.Itoa(s.Done))
+	}
+	if s.Blocked > 0 {
+		parts = append(parts, "blk:"+strconv.Itoa(s.Blocked))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -1,0 +1,82 @@
+package fleet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fixed reference time so tests are deterministic.
+var now = time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+
+const staleness = 2 * time.Minute
+
+func sess(id string, status Status, ageSeconds int) Session {
+	return Session{ID: id, Status: status, LastHeartbeat: now.Add(-time.Duration(ageSeconds) * time.Second)}
+}
+
+func TestAggregate_Empty(t *testing.T) {
+	s := Aggregate(nil, now, staleness)
+	assert.Equal(t, Snapshot{}, s)
+	assert.Equal(t, 0, s.Total)
+	assert.Equal(t, "", s.Badge(), "no sessions renders nothing")
+}
+
+func TestAggregate_MixedFresh(t *testing.T) {
+	s := Aggregate([]Session{
+		sess("a", StatusRunning, 5),
+		sess("b", StatusRunning, 10),
+		sess("c", StatusDone, 1),
+		sess("d", StatusBlocked, 3),
+	}, now, staleness)
+
+	assert.Equal(t, 2, s.Running)
+	assert.Equal(t, 1, s.Done)
+	assert.Equal(t, 1, s.Blocked)
+	assert.Equal(t, 0, s.Other)
+	assert.Equal(t, 4, s.Total)
+	assert.Equal(t, "run:2 done:1 blk:1", s.Badge())
+}
+
+// A session whose heartbeat is older than the staleness window is treated as
+// crashed/abandoned and excluded from every count (the Model D liveness rule).
+func TestAggregate_StaleExcluded(t *testing.T) {
+	s := Aggregate([]Session{
+		sess("live", StatusRunning, 30),
+		sess("crashed", StatusRunning, 600), // 10m old, staleness is 2m
+	}, now, staleness)
+
+	assert.Equal(t, 1, s.Running, "stale session must not be counted")
+	assert.Equal(t, 1, s.Total)
+	assert.Equal(t, "run:1", s.Badge())
+}
+
+// A session exactly at the staleness boundary is still live (boundary is
+// exclusive on the stale side: age == staleness counts as fresh).
+func TestAggregate_BoundaryIsFresh(t *testing.T) {
+	s := Aggregate([]Session{sess("edge", StatusRunning, int(staleness.Seconds()))}, now, staleness)
+	assert.Equal(t, 1, s.Running)
+	assert.Equal(t, 1, s.Total)
+}
+
+// Unknown/unrecognised status strings are tallied under Other and counted in
+// Total (so the badge's Total never undercounts), but are not shown in the
+// compact badge, which only surfaces the three canonical states.
+func TestAggregate_UnknownStatusToOther(t *testing.T) {
+	s := Aggregate([]Session{
+		sess("x", Status("frobnicating"), 5),
+		sess("y", StatusDone, 5),
+	}, now, staleness)
+
+	assert.Equal(t, 1, s.Other)
+	assert.Equal(t, 1, s.Done)
+	assert.Equal(t, 2, s.Total)
+	assert.Equal(t, "done:1", s.Badge(), "unknown statuses are excluded from the compact badge")
+}
+
+func TestBadge_OmitsZeroCategories(t *testing.T) {
+	assert.Equal(t, "done:3", Snapshot{Done: 3, Total: 3}.Badge())
+	assert.Equal(t, "run:1 blk:2", Snapshot{Running: 1, Blocked: 2, Total: 3}.Badge())
+	assert.Equal(t, "", Snapshot{}.Badge())
+}


### PR DESCRIPTION
## What

First increment of the **Model D fleet badge** — cross-session status visible in the status line (design record: #211). A pure `internal/fleet` package, fully unit-tested, **zero wiring / zero behavior change**.

- `Aggregate([]Session, now, staleness) Snapshot` — counts live sessions by status.
- `Snapshot.Badge()` — compact status-line fragment, e.g. `"run:2 done:1 blk:1"`.

## Why this slice first

Mirrors the cost port's pure-first ordering (`pricing` → `transcript` → wire). This PR commits to no behavior change and is trivially revertable — it's just the load-bearing aggregation logic. The write side (record status+heartbeat on the Stop/SessionStart seam) and read side (`renderFleetSegment`) follow as **separate PRs**.

## Design decisions baked in

- **Liveness rule (Model D):** a session whose heartbeat is older than the staleness window is treated as crashed/abandoned and excluded from every count — the badge never reports work that's no longer happening. Boundary `age == staleness` is fresh.
- **Unknown status → `Other`:** counted in `Total` (so it never undercounts) but omitted from the compact badge (an unknown status is a write-side bug, not something to advertise).
- **ASCII badge format** (`run:/done:/blk:`), not emoji — deliberately sidesteps the variation-selector fragility that previously bit the weather feed. Glyph styling, if any, is a render-layer choice deferred to the status-line PR.

## Tests (strict TDD, red→green verified)

`internal/fleet/fleet_test.go`: empty, mixed-fresh, stale-excluded, boundary-is-fresh, unknown-status-to-Other, badge-omits-zero-categories.

Gate green: `internal/fleet` `-race -p 2`, 0 zombies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fleet session status aggregation with support for tracking running, done, and blocked states
  * Implemented staleness filtering to automatically exclude inactive sessions
  * Added compact, terminal-friendly status badge display

* **Tests**
  * Added comprehensive test coverage for session aggregation and status reporting logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->