### PR TITLE
feat(statusline): cross-session fleet badge (Model D render)

### DIFF
--- a/cmd/hookwise/cmd_status_line.go
+++ b/cmd/hookwise/cmd_status_line.go
@@ -137,6 +137,14 @@ func runStatusLine(cmd *cobra.Command, projectDir string) error {
 		segments = append(segments, warnSegment)
 	}
 
+	// Surface a cross-session fleet badge when 2+ sessions are live (#211).
+	// Self-suppresses for a solo session, so it adds nothing for single-session
+	// users. Read-only and fail-open.
+	fleetSegment := renderFleetSegment(config.Analytics.DBPath, time.Now().UTC(), fleetStalenessWindow)
+	if fleetSegment != "" {
+		segments = append(segments, fleetSegment)
+	}
+
 	line := strings.Join(segments, ansiGray+delimiter+ansiReset)
 	fmt.Fprintln(cmd.OutOrStdout(), line)
 

--- a/cmd/hookwise/cmd_status_line_fleet.go
+++ b/cmd/hookwise/cmd_status_line_fleet.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/vishnujayvel/hookwise/internal/analytics"
+	"github.com/vishnujayvel/hookwise/internal/fleet"
+)
+
+// fleetStalenessWindow bounds which sessions count as part of the live fleet.
+// A session with no activity (start, end, or event) within this window is
+// treated as crashed/abandoned and excluded — the badge only reflects work that
+// is genuinely current. Mirrors the feed-cache TTL philosophy.
+const fleetStalenessWindow = 15 * time.Minute
+
+// renderFleetSegment renders a cross-session fleet badge (e.g. "fleet run:2
+// done:1") from the live sessions recorded in the analytics DB at dbPath — the
+// read side of the Model D fleet board (#211). Fail-open: any error (missing DB,
+// query failure) yields an empty segment, so the status line never breaks.
+func renderFleetSegment(dbPath string, now time.Time, staleness time.Duration) string {
+	db, err := analytics.Open(dbPath)
+	if err != nil {
+		return ""
+	}
+	defer db.Close()
+	return fleetBadge(analytics.NewAnalytics(db), now, staleness)
+}
+
+// fleetBadge is the testable core: it reads live sessions, aggregates them, and
+// renders the badge. It returns "" when fewer than two sessions are live — a
+// solo session is not a fleet, and a constant "run:1" would be noise rather than
+// signal (precise self-exclusion would need the current session_id from the
+// status-line stdin payload, a follow-up).
+func fleetBadge(a *analytics.Analytics, now time.Time, staleness time.Duration) string {
+	live, err := a.RecentSessions(context.Background(), now.Add(-staleness))
+	if err != nil {
+		return ""
+	}
+
+	sessions := make([]fleet.Session, 0, len(live))
+	for _, s := range live {
+		status := fleet.StatusRunning
+		if s.Ended {
+			status = fleet.StatusDone
+		}
+		sessions = append(sessions, fleet.Session{
+			ID:            s.ID,
+			Status:        status,
+			LastHeartbeat: s.LastActivity,
+		})
+	}
+
+	snap := fleet.Aggregate(sessions, now, staleness)
+	if snap.Total < 2 {
+		return "" // not a fleet — suppress solo-session noise
+	}
+	badge := snap.Badge()
+	if badge == "" {
+		return ""
+	}
+	return ansiCyan + "fleet " + badge + ansiReset
+}

--- a/cmd/hookwise/cmd_status_line_fleet_test.go
+++ b/cmd/hookwise/cmd_status_line_fleet_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/analytics"
+)
+
+// seedFleetDB returns an open Analytics over a temp DB plus its path.
+func seedFleetDB(t *testing.T) (*analytics.Analytics, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "analytics.db")
+	db, err := analytics.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return analytics.NewAnalytics(db), path
+}
+
+var fleetNow = time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+
+const fleetStale = 15 * time.Minute
+
+func TestFleetBadge_SoloSuppressed(t *testing.T) {
+	a, _ := seedFleetDB(t)
+	ctx := context.Background()
+	// A single live session is not a fleet — a "run:1" badge would be pure noise.
+	require.NoError(t, a.StartSession(ctx, "solo", fleetNow.Add(-1*time.Minute)))
+
+	assert.Equal(t, "", fleetBadge(a, fleetNow, fleetStale))
+}
+
+func TestFleetBadge_Empty(t *testing.T) {
+	a, _ := seedFleetDB(t)
+	assert.Equal(t, "", fleetBadge(a, fleetNow, fleetStale))
+}
+
+func TestFleetBadge_TwoRunning(t *testing.T) {
+	a, _ := seedFleetDB(t)
+	ctx := context.Background()
+	require.NoError(t, a.StartSession(ctx, "s1", fleetNow.Add(-1*time.Minute)))
+	require.NoError(t, a.StartSession(ctx, "s2", fleetNow.Add(-2*time.Minute)))
+
+	got := fleetBadge(a, fleetNow, fleetStale)
+	assert.Contains(t, got, "fleet ")
+	assert.Contains(t, got, "run:2")
+}
+
+func TestFleetBadge_RunningPlusDone(t *testing.T) {
+	a, _ := seedFleetDB(t)
+	ctx := context.Background()
+	require.NoError(t, a.StartSession(ctx, "live", fleetNow.Add(-1*time.Minute)))
+	require.NoError(t, a.StartSession(ctx, "fin", fleetNow.Add(-10*time.Minute)))
+	require.NoError(t, a.EndSession(ctx, "fin", fleetNow.Add(-2*time.Minute), analytics.SessionStats{}))
+
+	got := fleetBadge(a, fleetNow, fleetStale)
+	assert.Contains(t, got, "run:1")
+	assert.Contains(t, got, "done:1")
+}
+
+// A crashed/stale session is excluded, dropping the live fleet back to 1 -> the
+// badge suppresses (solo).
+func TestFleetBadge_StaleDropsBelowFleet(t *testing.T) {
+	a, _ := seedFleetDB(t)
+	ctx := context.Background()
+	require.NoError(t, a.StartSession(ctx, "live", fleetNow.Add(-1*time.Minute)))
+	require.NoError(t, a.StartSession(ctx, "crashed", fleetNow.Add(-3*time.Hour)))
+
+	assert.Equal(t, "", fleetBadge(a, fleetNow, fleetStale))
+}
+
+// renderFleetSegment opens by path and is fail-open on a bad/missing DB.
+func TestRenderFleetSegment_FailOpenOnBadPath(t *testing.T) {
+	assert.Equal(t, "", renderFleetSegment(filepath.Join(t.TempDir(), "does-not-exist.db"), fleetNow, fleetStale))
+}


### PR DESCRIPTION
## What

Third and final increment of the **Model D fleet board** (#211) — the read/render side. The status line now shows a compact `fleet run:2 done:1` badge reflecting other live Claude Code sessions.

Builds on:
- #212 — pure `internal/fleet` aggregator (`Aggregate` + `Badge`).
- `5b2c617` — `analytics.RecentSessions` read (see note below).

## How

- `renderFleetSegment(dbPath, now, staleness)` — opens the analytics DB **read-only**, renders the badge; **fail-open** (any error → empty segment).
- `fleetBadge(*Analytics, now, staleness)` — the testable core: `RecentSessions` → map `Ended`→done / else running → `fleet.Aggregate` → `Badge`. Appended after the warning segment, mirroring the always-on `renderNotificationSegment` pattern.

## Design decisions

- **Self-suppression (<2 live → empty):** `runStatusLine` doesn't read stdin, so there's no current `session_id` for precise self-exclusion. A constant `run:1` for a solo session would be noise, so the badge only appears once there's a genuine multi-session fleet — solo users see nothing. Precise self-exclusion (via the stdin `session_id`) is a documented follow-up.
- **No new writes:** status and liveness are derived from existing session/event data, so this touches no seam and no hot path. Read-only, fail-open.
- **15-minute staleness window** (const; configurability is a follow-up).

## Tests (strict TDD, red→green)

`cmd_status_line_fleet_test.go`: solo-suppressed, empty, two-running, running+done, stale-drops-below-fleet, bad-path-fail-open — exercising the real `RecentSessions → Aggregate → Badge` chain against a live temp analytics DB.

Gate green: full `cmd/hookwise` `-race -p 2`, 0 zombies.

## Process note

PR 2 (`RecentSessions`, `5b2c617`) was accidentally pushed directly to `main` (branch reflex missed after the #212 merge). It passed full main CI; per maintainer decision it was left in place rather than rewriting history. This PR is correctly branched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "fleet" status badge to the status line displaying live session information
  * Badge shows running and completed session counts across the fleet
  * Sessions considered active within a 15-minute window
  * Self-suppresses when fewer than 2 live sessions exist
  * Fails gracefully on database errors

* **Tests**
  * Added test coverage for fleet badge rendering and error handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->