### PR TITLE
chore(tui,docs): remove dead transcript_backup config surface

### DIFF
--- a/docs/reference/migration.md
+++ b/docs/reference/migration.md
@@ -111,7 +111,6 @@ hookwise v2.0 accepts both snake_case (YAML convention) and camelCase. The confi
 | `handler_timeout_seconds` | `handlerTimeoutSeconds` |
 | `status_line` | `statusLine` |
 | `cost_tracking` | `costTracking` |
-| `transcript_backup` | `transcriptBackup` |
 
 Write your YAML in snake_case -- it is the convention and hookwise handles the conversion.
 

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -78,11 +78,6 @@ cost_tracking:
   daily_budget: 10.00    # daily spending limit in USD
   enforcement: warn      # "warn" or "enforce"
 
-# Transcript backup: save session transcripts for review
-transcript_backup:
-  enabled: true
-  max_size_mb: 100       # maximum backup directory size in MB
-
 # Status line: comprehensive metrics display
 status_line:
   enabled: true

--- a/tui/hookwise_tui/tabs/dashboard.py
+++ b/tui/hookwise_tui/tabs/dashboard.py
@@ -50,12 +50,6 @@ FEATURES: list[dict[str, Any]] = [
         "description": "Random motivational quote at session start to set the right mindset",
         "config_path": ("greeting", "enabled"),
     },
-    {
-        "key": "transcript_backup",
-        "title": "Transcript Backup",
-        "description": "Auto-save session transcripts for later reference and auditing",
-        "config_path": ("transcript_backup", "enabled"),
-    },
 ]
 
 

--- a/tui/tests/test_app.py
+++ b/tui/tests/test_app.py
@@ -59,6 +59,16 @@ class TestHookwiseTUI:
             # Should have at least the 7 features from dashboard
             assert len(list(cards)) >= 1
 
+    def test_dashboard_omits_removed_transcript_backup(self) -> None:
+        """transcript_backup was deleted from the config schema (Go #200); the
+        dashboard must not advertise a feature that no longer exists, otherwise
+        it shows a card whose config key can never be present."""
+        from hookwise_tui.tabs.dashboard import FEATURES
+        keys = {f["key"] for f in FEATURES}
+        assert "transcript_backup" not in keys, (
+            "dashboard still lists the removed transcript_backup feature"
+        )
+
     async def test_feeds_tab_has_timer(self, app: HookwiseTUI) -> None:
         """Feeds tab shows refresh timer."""
         async with app.run_test() as pilot:


### PR DESCRIPTION
Closes the doc-drift tail flagged by the relaunch audit alongside remediation item **#3punch** (TranscriptBackup removal, #200).

#200 deleted the `TranscriptBackup` block from the Go config schema, but three surfaces still advertised it:

- **TUI dashboard** (`tui/hookwise_tui/tabs/dashboard.py`) listed a "Transcript Backup" feature card whose config key `transcript_backup.enabled` can never be present — **this surface was not in the original Go-focused audit**; found during remediation recon
- `examples/full.yaml` shipped a `transcript_backup:` block as a valid example (now raises an unknown-key validation warning)
- `docs/reference/migration.md` listed it in the TS→Go field-mapping table

All three removed to match the schema.

## Test
`test_dashboard_omits_removed_transcript_backup` (strict TDD red→green): asserts the dashboard `FEATURES` no longer contains the removed key. `mypy --strict` + `ruff` clean; dashboard snapshot unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)