### PR TITLE
fix(tui): render nothing for unconfigured weather, not sunny

### DIFF
--- a/tui/hookwise_tui/widgets/weather_data.py
+++ b/tui/hookwise_tui/widgets/weather_data.py
@@ -116,6 +116,19 @@ def read_weather_from_cache(
     description = weather_entry.get("description", "")
     city = weather_entry.get("city", "")
 
+    # An unconfigured-location placeholder (the producer's "Set location" envelope
+    # when no coordinates are set, #210) carries a description/emoji but no numeric
+    # weather signal. Without this guard, code defaults to 0 -> WMO 0 -> "clear",
+    # so the widget renders a spurious sunny animation for a location that was
+    # never configured. Treat "no numeric signal and no condition" as nothing to
+    # show. `is not None` distinguishes an absent field from a legitimate 0.
+    has_weather_signal = any(
+        weather_entry.get(key) is not None
+        for key in ("weatherCode", "code", "temperature", "temp_c", "temp_f")
+    ) or bool(weather_entry.get("condition"))
+    if not has_weather_signal:
+        return None
+
     # Derive condition from description or WMO code
     condition = weather_entry.get("condition", "")
     if not condition and description:

--- a/tui/tests/test_weather.py
+++ b/tui/tests/test_weather.py
@@ -122,6 +122,28 @@ class TestReadWeatherFromCache:
         result = read_weather_from_cache(cache)
         assert result is None
 
+    def test_returns_none_for_unconfigured_location_envelope(self) -> None:
+        """The Go producer emits a "Set location" placeholder (no coordinates set,
+        #210) with a description/emoji but NO numeric weather fields. Without a
+        guard, code defaults to 0 -> WMO 0 -> "clear", so the widget would render a
+        spurious sunny animation for a location that was never configured. The
+        unconfigured envelope must yield None (render nothing)."""
+        cache = {
+            "weather": {
+                "description": "Set location",
+                "emoji": "\U0001f4cd",
+            }
+        }
+        assert read_weather_from_cache(cache) is None
+
+    def test_preserves_legitimate_zero_temperature(self) -> None:
+        """A real 0-degree reading is weather data, not an empty envelope — the
+        unconfigured guard must distinguish absent fields from a valid 0."""
+        cache = {"weather": {"condition": "clear", "code": 0, "temp_c": 0, "temp_f": 32}}
+        result = read_weather_from_cache(cache)
+        assert result is not None
+        assert result.temp_c == 0.0
+
     def test_returns_none_when_weather_not_dict(self) -> None:
         cache = {"weather": "rain"}
         result = read_weather_from_cache(cache)


### PR DESCRIPTION
Fixes relaunch-audit finding **#10** — the consumer side of the #210 weather honesty fix.

#210 made the Go producer emit a `"Set location"` placeholder envelope (description + 📍, **no numeric fields**) when no coordinates are set. But `weather_data.py` defaulted `weatherCode` to `0`, and `WEATHER_CODE_MAP[0] == "clear"` → the dashboard rendered a **spurious sunny widget** (temp 0°) for a location that was never configured.

## Fix
`read_weather_from_cache` now returns `None` when the envelope carries no numeric weather signal (`weatherCode`/`code`/`temperature`/`temp_c`/`temp_f` all absent) and no `condition`. `is not None` distinguishes an absent field from a legitimate `0°`.

## Tests (strict TDD red→green)
- `test_returns_none_for_unconfigured_location_envelope` — the placeholder yields `None`
- `test_preserves_legitimate_zero_temperature` — a real 0° reading still renders (regression guard)

`mypy --strict` + `ruff` clean; all 49 weather tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weather display handling so placeholder “set location” entries no longer show a fake weather state.
  * Preserved valid zero-value weather readings, ensuring temperatures like 0° continue to display correctly.

* **Tests**
  * Added coverage for unconfigured weather data and zero-degree readings to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->