### PR TITLE
fix(dispatch): handler-phase guard block emits canonical deny

### DIFF
--- a/internal/contract/contract_test.go
+++ b/internal/contract/contract_test.go
@@ -41,9 +41,11 @@ type ContractFixture struct {
 }
 
 // FixtureConfig is the subset of HooksConfig used in fixtures.
-// Guards are the primary focus; handlers/other fields use defaults.
+// Guards are the primary focus; handler-phase guards are also supported so the
+// contract can pin handler-based block/confirm output shape (ARCH-6).
 type FixtureConfig struct {
-	Guards []core.GuardRuleConfig `json:"guards"`
+	Guards   []core.GuardRuleConfig     `json:"guards"`
+	Handlers []core.CustomHandlerConfig `json:"handlers"`
 }
 
 // =============================================================================
@@ -120,8 +122,8 @@ func buildConfig(fc FixtureConfig) core.HooksConfig {
 	cfg.StatusLine.Enabled = false
 	cfg.CostTracking.Enabled = false
 	cfg.Greeting.Enabled = false
-	// No custom handlers for contract tests (guards-only)
-	cfg.Handlers = nil
+	// Handler-phase guards are exercised by handler fixtures; default is none.
+	cfg.Handlers = fc.Handlers
 	return cfg
 }
 

--- a/internal/core/dispatcher.go
+++ b/internal/core/dispatcher.go
@@ -150,7 +150,11 @@ func executeGuardPhase(ctx context.Context, handlers []ResolvedHandler, payload 
 				if hr.Reason != nil {
 					reason = *hr.Reason
 				}
-				stdout := buildGuardBlockJSON(reason)
+				// Emit the canonical PreToolUse deny shape, identical to the
+				// declarative block guard (line 60) and the confirm->ask path
+				// below. The previous top-level {"decision":"block"} form is
+				// deprecated for PreToolUse and may be ignored by Claude Code.
+				stdout := buildPermissionJSON("deny", reason)
 				return &DispatchResult{Stdout: &stdout, ExitCode: 0}
 
 			case ActionConfirm:
@@ -317,20 +321,6 @@ func buildContextJSON(contextStr string) string {
 	if err != nil {
 		Logger().Error("failed to marshal context JSON", "error", err)
 		return ""
-	}
-	return string(b)
-}
-
-// buildGuardBlockJSON builds JSON output for a handler-based guard block.
-func buildGuardBlockJSON(reason string) string {
-	type blockOutput struct {
-		Decision string `json:"decision"`
-		Reason   string `json:"reason"`
-	}
-	data := blockOutput{Decision: "block", Reason: reason}
-	b, err := json.Marshal(data)
-	if err != nil {
-		return `{"decision":"block","reason":"Blocked by guard rule"}`
 	}
 	return string(b)
 }

--- a/internal/core/dispatcher_test.go
+++ b/internal/core/dispatcher_test.go
@@ -1053,12 +1053,18 @@ func TestIntegration_HandlerBasedGuard_Blocks(t *testing.T) {
 	result := Dispatch(context.Background(), EventPreToolUse, payload, config)
 
 	require.NotNil(t, result.Stdout)
-	// Handler-based guard block produces different JSON format (decision/reason, not hookSpecificOutput)
+	// Handler-phase guard block emits the canonical PreToolUse deny shape — the
+	// same hookSpecificOutput.permissionDecision="deny" as a declarative block
+	// guard (dispatcher.go:60) and the confirm->ask path, not the deprecated
+	// top-level {"decision":"block"} (which Claude Code deprecated for PreToolUse).
 	var output map[string]interface{}
 	err := json.Unmarshal([]byte(*result.Stdout), &output)
 	require.NoError(t, err)
-	assert.Equal(t, "block", output["decision"])
-	assert.Equal(t, "inline guard blocked", output["reason"])
+	hso, ok := output["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok, "expected hookSpecificOutput, got %s", *result.Stdout)
+	assert.Equal(t, "PreToolUse", hso["hookEventName"])
+	assert.Equal(t, "deny", hso["permissionDecision"])
+	assert.Equal(t, "inline guard blocked", hso["permissionDecisionReason"])
 }
 
 func TestIntegration_HandlerBasedGuard_Confirm_AskJSON(t *testing.T) {
@@ -1519,7 +1525,12 @@ echo '{"decision":"block","reason":"script guard blocked"}'
 	var output map[string]interface{}
 	err = json.Unmarshal([]byte(*result.Stdout), &output)
 	require.NoError(t, err)
-	assert.Equal(t, "block", output["decision"])
+	// The script handler's protocol output is {"decision":"block"}, but the
+	// dispatcher emits the canonical PreToolUse deny shape to Claude Code.
+	hso, ok := output["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok, "expected hookSpecificOutput, got %s", *result.Stdout)
+	assert.Equal(t, "deny", hso["permissionDecision"])
+	assert.Equal(t, "script guard blocked", hso["permissionDecisionReason"])
 }
 
 func TestIntegration_FullDispatch_ScriptContextHandler(t *testing.T) {

--- a/testdata/contracts/43_pretooluse_handler_block_deny.json
+++ b/testdata/contracts/43_pretooluse_handler_block_deny.json
@@ -1,0 +1,27 @@
+{
+  "name": "PreToolUse handler-phase guard block emits canonical deny",
+  "event_type": "PreToolUse",
+  "config": {
+    "handlers": [
+      {
+        "name": "inline-guard",
+        "type": "inline",
+        "events": ["PreToolUse"],
+        "phase": "guard",
+        "action": {
+          "decision": "block",
+          "reason": "handler blocked Bash"
+        }
+      }
+    ]
+  },
+  "stdin": {
+    "session_id": "contract-session-h1",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "echo hello"
+    }
+  },
+  "expected_stdout": "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"handler blocked Bash\"}}",
+  "expected_exit_code": 0
+}

--- a/testdata/contracts/44_pretooluse_handler_confirm_ask.json
+++ b/testdata/contracts/44_pretooluse_handler_confirm_ask.json
@@ -1,0 +1,27 @@
+{
+  "name": "PreToolUse handler-phase guard confirm emits ask",
+  "event_type": "PreToolUse",
+  "config": {
+    "handlers": [
+      {
+        "name": "inline-guard",
+        "type": "inline",
+        "events": ["PreToolUse"],
+        "phase": "guard",
+        "action": {
+          "decision": "confirm",
+          "reason": "handler asks about Bash"
+        }
+      }
+    ]
+  },
+  "stdin": {
+    "session_id": "contract-session-h2",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "echo hello"
+    }
+  },
+  "expected_stdout": "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"handler asks about Bash\"}}",
+  "expected_exit_code": 0
+}


### PR DESCRIPTION
Fixes relaunch-audit findings **#6** (handler-phase guard block uses deprecated format) and **#7** (no ARCH-6 contract fixture for handler-phase guard output).

## #6 — canonical deny
A handler-phase guard returning `{"decision":"block"}` made the dispatcher emit the **deprecated** top-level `{"decision":"block"}` stdout. The declarative config-guard block path (`dispatcher.go:60`) and the `confirm`→`ask` path (`:161`) already emit canonical `hookSpecificOutput.permissionDecision`. Claude Code deprecated the top-level `decision` field for PreToolUse, so a handler-phase block could be **silently ignored — a guard failing open**.

Fix: route handler-phase block through `buildPermissionJSON("deny", reason)` (identical to declarative deny); delete the now-dead `buildGuardBlockJSON`. Guard-phase block/confirm are PreToolUse-semantic, matching the existing confirm behavior.

## #7 — ARCH-6 coverage
The contract harness only supported `guards`. Extended `FixtureConfig`/`buildConfig` additively to support handler fixtures (existing guard-only fixtures unchanged), and added two fixtures pinning handler-phase **block (deny)** and **confirm (ask)** byte-identical output.

## Tests (strict TDD red→green)
- `TestIntegration_HandlerBasedGuard_Blocks` + the script-guard block test → assert canonical `permissionDecision="deny"`
- New contract fixtures `43_pretooluse_handler_block_deny.json`, `44_pretooluse_handler_confirm_ask.json`

Guarded gate green: `internal/core` + `internal/contract` (`-race -p 2`). The handler *protocol* (`{"decision":"block"}` a script/inline handler returns) is unchanged — only the dispatcher's emitted stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handler-phase guards in contract test fixtures, including both guard rules and custom handlers.
  * Tool-use guard decisions now use the same standardized permission response format as other decision paths.

* **Bug Fixes**
  * Fixed guard-block responses to return consistent deny/ask decision details and reasons.
  * Updated guard-related test coverage to match the canonical output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->