### PR TITLE
fix(tui): race-proof singleton launch guard (mtime cooldown marker)

### DIFF
--- a/cmd/hookwise/cmd_daemon.go
+++ b/cmd/hookwise/cmd_daemon.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -262,10 +264,24 @@ func tuiPIDPath() string {
 	return filepath.Join(core.DefaultStateDir, "tui.pid")
 }
 
-// isTUIRunning checks if a TUI process is already running by reading the PID file,
-// checking if the process exists, and verifying it's actually hookwise-tui
-// (not a stale PID reused by an unrelated process).
+// tuiLaunchCooldown is how long a recorded launch suppresses re-launch. It only
+// has to bridge the open->Terminal->python-exec handoff (~1-3s), because once
+// python has exec'd, listTUIProcs() detects the TUI by comm well before the
+// python TUI writes its PID file on mount. 30s is generous, self-healing slack.
+const tuiLaunchCooldown = 30 * time.Second
+
+// isTUIRunning reports whether a TUI is already up. It first trusts the PID file
+// (written by the python TUI on mount), then falls back to comm-filtered process
+// detection so a TUI that has exec'd but not yet written its PID is still seen.
 func isTUIRunning() bool {
+	if tuiPIDFileAlive() {
+		return true
+	}
+	return len(listTUIProcs()) > 0
+}
+
+// tuiPIDFileAlive checks the PID file points at a live hookwise-tui process.
+func tuiPIDFileAlive() bool {
 	data, err := os.ReadFile(tuiPIDPath())
 	if err != nil {
 		return false
@@ -282,29 +298,176 @@ func isTUIRunning() bool {
 	if err := process.Signal(syscall.Signal(0)); err != nil {
 		return false
 	}
-	// Verify the PID belongs to hookwise-tui, not a stale PID reused by
-	// an unrelated process. Uses `ps` which works on macOS and Linux.
+	// Verify the PID belongs to the TUI, not a stale PID reused by an
+	// unrelated process. Uses `ps` which works on macOS and Linux.
 	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
 	if err != nil {
 		return false
 	}
-	comm := strings.TrimSpace(string(out))
-	return strings.Contains(comm, "hookwise-tui") || strings.Contains(comm, "python") || strings.Contains(comm, "Python")
+	return isTUIComm(strings.TrimSpace(string(out)))
 }
 
-// acquireTUILaunchLock atomically creates a lock file to prevent concurrent
-// TUI launches (TOCTOU race between isTUIRunning check and TUI PID write).
-// Returns a cleanup function and true on success, or nil and false if another
-// dispatch already holds the lock.
-func acquireTUILaunchLock() (unlock func(), ok bool) {
-	lockPath := filepath.Join(core.DefaultStateDir, "tui.launch.lock")
-	_ = os.MkdirAll(filepath.Dir(lockPath), core.DefaultDirMode)
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
-	if err != nil {
-		return nil, false
+// tuiCandidate is one `pgrep -f hookwise-tui` hit with its comm (argv[0]).
+type tuiCandidate struct {
+	pid  int
+	comm string
+}
+
+// isTUIComm reports whether a process command (argv[0] basename, from `ps -o
+// comm=`) belongs to a real TUI process. `pgrep -f hookwise-tui` matches the
+// full command line, so the transient `open -a Terminal …/hookwise-tui`
+// launcher and stray `grep`/`sh`/`find …hookwise-tui` all match — but their
+// comm is open/grep/sh/find, which does NOT contain the token. Filtering on
+// comm (not the full cmdline) rejects those launchers and keeps only the TUI,
+// whose comm is the hookwise-tui wrapper or the python interpreter running it.
+func isTUIComm(comm string) bool {
+	comm = strings.TrimSpace(comm)
+	if comm == "" {
+		return false
 	}
-	f.Close()
-	return func() { os.Remove(lockPath) }, true
+	base := comm
+	if idx := strings.LastIndex(base, "/"); idx >= 0 {
+		base = base[idx+1:]
+	}
+	lower := strings.ToLower(base)
+	return strings.Contains(lower, "hookwise-tui") || strings.Contains(lower, "python")
+}
+
+// filterTUICandidates keeps only the PIDs whose comm is a real TUI process
+// (pure — the testable heart of the comm filter).
+func filterTUICandidates(cands []tuiCandidate) []int {
+	var out []int
+	for _, c := range cands {
+		if isTUIComm(c.comm) {
+			out = append(out, c.pid)
+		}
+	}
+	return out
+}
+
+// listTUIProcs returns the PIDs of live TUI processes via `pgrep -f hookwise-tui`
+// filtered by comm. Shared by the launch guard and the watchdog (PR2).
+func listTUIProcs() []int {
+	out, err := exec.Command("pgrep", "-f", "hookwise-tui").Output()
+	if err != nil {
+		return nil
+	}
+	var cands []tuiCandidate
+	for _, field := range strings.Fields(string(out)) {
+		pid, err := strconv.Atoi(field)
+		if err != nil {
+			continue
+		}
+		commOut, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+		if err != nil {
+			continue
+		}
+		cands = append(cands, tuiCandidate{pid: pid, comm: strings.TrimSpace(string(commOut))})
+	}
+	return filterTUICandidates(cands)
+}
+
+// tuiLauncher carries the dependencies of the singleton launch guard so the
+// decision logic is unit-testable without opening Terminal or touching
+// ~/.hookwise. Production wires real deps in launchTUIIfNeeded.
+type tuiLauncher struct {
+	stateDir  string
+	cooldown  time.Duration
+	now       func() time.Time
+	isRunning func() bool
+	spawn     func(method string) error
+}
+
+func (l *tuiLauncher) markerPath() string {
+	return filepath.Join(l.stateDir, "tui.launch.marker")
+}
+
+func (l *tuiLauncher) removeMarker() {
+	_ = os.Remove(l.markerPath())
+}
+
+// claimMarker atomically claims the launch window. The marker's MTIME is its
+// timestamp (no content is parsed — this avoids the empty-file read race). It
+// returns true iff this caller won the claim and should proceed to spawn:
+//
+//   - absent marker  -> O_EXCL create wins -> true
+//   - fresh marker   -> a launch is in flight -> false (suppress)
+//   - stale marker   -> remove + re-claim via O_EXCL (exactly one winner)
+//   - any I/O error  -> false (FAIL TOWARD SUPPRESS; pile-up is the bug we fix)
+func (l *tuiLauncher) claimMarker() bool {
+	path := l.markerPath()
+	_ = core.EnsureDir(filepath.Dir(path), core.DefaultDirMode)
+	for attempt := 0; attempt < 3; attempt++ {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err == nil {
+			_ = f.Close()
+			return true
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return false // I/O error (ENOTDIR, ENOSPC, EPERM, …) -> suppress
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			// Vanished between Open and Stat (another dispatch removed it) — retry.
+			continue
+		}
+		if l.now().Sub(info.ModTime()) < l.cooldown {
+			return false // fresh -> a launch is in flight -> suppress
+		}
+		// Stale -> drop it and retry the O_EXCL create so exactly one wins.
+		_ = os.Remove(path)
+	}
+	return false
+}
+
+// launchIfNeeded is the testable core of the singleton guard.
+func (l *tuiLauncher) launchIfNeeded(method string) (spawned bool, err error) {
+	if l.isRunning() {
+		return false, nil
+	}
+	if !l.claimMarker() {
+		return false, nil
+	}
+	// Double-check: a TUI may have appeared between the first isRunning check
+	// and winning the claim. If so, release the marker and skip.
+	if l.isRunning() {
+		l.removeMarker()
+		return false, nil
+	}
+	if err := l.spawn(method); err != nil {
+		l.removeMarker() // unclaim so the next dispatch can retry immediately
+		return false, err
+	}
+	return true, nil
+}
+
+// realTUISpawn finds and starts the hookwise-tui process (the only impure,
+// untested part — exec wiring identical to the previous implementation).
+func realTUISpawn(method string) error {
+	tuiCmd, err := exec.LookPath("hookwise-tui")
+	if err != nil {
+		core.Logger().Debug("hookwise-tui not found in PATH, skipping auto-launch")
+		return err
+	}
+
+	var cmd *exec.Cmd
+	switch method {
+	case "newWindow":
+		cmd = exec.Command("open", "-a", "Terminal", tuiCmd) // macOS: new Terminal window
+	default:
+		cmd = exec.Command(tuiCmd) // background process
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
+
+	if err := cmd.Start(); err != nil {
+		core.Logger().Warn("failed to launch TUI", "method", method, "error", err)
+		return err
+	}
+	core.Logger().Info("TUI launched", "method", method, "pid", cmd.Process.Pid)
+	return nil
 }
 
 // launchTUIIfNeeded launches the TUI if it's not already running.
@@ -316,54 +479,16 @@ func launchTUIIfNeeded(launchMethod string) {
 		}
 	}()
 
-	if isTUIRunning() {
-		core.Logger().Debug("TUI already running, skipping launch")
-		return
+	l := &tuiLauncher{
+		stateDir:  core.DefaultStateDir,
+		cooldown:  tuiLaunchCooldown,
+		now:       time.Now,
+		isRunning: isTUIRunning,
+		spawn:     realTUISpawn,
 	}
-
-	// Atomic lock prevents TOCTOU race: two concurrent SessionStart dispatches
-	// could both pass isTUIRunning() before either TUI writes its PID file.
-	unlock, ok := acquireTUILaunchLock()
-	if !ok {
-		core.Logger().Debug("another dispatch is launching TUI, skipping")
-		return
+	if _, err := l.launchIfNeeded(launchMethod); err != nil {
+		core.Logger().Debug("TUI launch suppressed/failed (fail-open)", "error", err)
 	}
-	defer unlock()
-
-	// Re-check after acquiring lock (double-check pattern)
-	if isTUIRunning() {
-		core.Logger().Debug("TUI started between check and lock, skipping")
-		return
-	}
-
-	// Find hookwise-tui executable
-	tuiCmd, err := exec.LookPath("hookwise-tui")
-	if err != nil {
-		core.Logger().Debug("hookwise-tui not found in PATH, skipping auto-launch")
-		return
-	}
-
-	var cmd *exec.Cmd
-	switch launchMethod {
-	case "newWindow":
-		// macOS: open in a new Terminal window
-		cmd = exec.Command("open", "-a", "Terminal", tuiCmd)
-	default:
-		// background: launch directly as a background process
-		cmd = exec.Command(tuiCmd)
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	}
-
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	cmd.Stdin = nil
-
-	if err := cmd.Start(); err != nil {
-		core.Logger().Warn("failed to launch TUI", "method", launchMethod, "error", err)
-		return
-	}
-
-	core.Logger().Info("TUI launched", "method", launchMethod, "pid", cmd.Process.Pid)
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/hookwise/cmd_daemon_tui_singleton_test.go
+++ b/cmd/hookwise/cmd_daemon_tui_singleton_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestLauncher builds a tuiLauncher backed by a real marker file in dir, a
+// real clock, and a spawn closure that the test controls. isRunning defaults to
+// always-false (simulating the boot gap where neither the PID file nor the
+// comm-filtered detection has caught the TUI yet).
+func newTestLauncher(dir string, spawn func(string) error) *tuiLauncher {
+	return &tuiLauncher{
+		stateDir:  dir,
+		cooldown:  tuiLaunchCooldown,
+		now:       time.Now,
+		isRunning: func() bool { return false },
+		spawn:     spawn,
+	}
+}
+
+// Test 1 — the core singleton property: rapid SessionStarts across the boot
+// window (isRunning false throughout) must yield EXACTLY ONE spawn. This is the
+// regression test for the launch-race that piled up Terminal windows.
+func Test_launchIfNeeded_FiveSequential_ExactlyOneSpawn(t *testing.T) {
+	dir := t.TempDir()
+	var spawns int32
+	l := newTestLauncher(dir, func(string) error {
+		atomic.AddInt32(&spawns, 1)
+		return nil
+	})
+
+	for i := 0; i < 5; i++ {
+		_, err := l.launchIfNeeded("newWindow")
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&spawns), "5 rapid launches must spawn exactly once")
+	assert.FileExists(t, filepath.Join(dir, "tui.launch.marker"), "marker should persist to suppress relaunch")
+}
+
+// Test 2 — concurrent dispatches at the same instant must still spawn once
+// (O_EXCL marker claim serializes them).
+func Test_launchIfNeeded_Concurrent_ExactlyOneSpawn(t *testing.T) {
+	dir := t.TempDir()
+	var spawns int32
+	l := newTestLauncher(dir, func(string) error {
+		atomic.AddInt32(&spawns, 1)
+		return nil
+	})
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = l.launchIfNeeded("newWindow")
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&spawns), "%d concurrent launches must spawn exactly once", n)
+}
+
+// Test 3 — once the cooldown has elapsed (marker stale) and the TUI still isn't
+// running, a relaunch is allowed. Elapsed time is simulated by back-dating the
+// marker's mtime (the marker timestamp IS its mtime — no content parsing).
+func Test_launchIfNeeded_CooldownExpiry_AllowsSecond(t *testing.T) {
+	dir := t.TempDir()
+	var spawns int32
+	l := newTestLauncher(dir, func(string) error {
+		atomic.AddInt32(&spawns, 1)
+		return nil
+	})
+
+	_, err := l.launchIfNeeded("newWindow")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), atomic.LoadInt32(&spawns))
+
+	// Age the marker well past the cooldown.
+	marker := filepath.Join(dir, "tui.launch.marker")
+	old := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, os.Chtimes(marker, old, old))
+
+	_, err = l.launchIfNeeded("newWindow")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&spawns), "stale marker must allow a fresh launch")
+}
+
+// Test 4 — a spawn failure must remove the marker so the very next dispatch can
+// retry immediately (no cooldown blackhole on e.g. a transient PATH miss).
+func Test_launchIfNeeded_SpawnFailure_RemovesMarker_AllowsRetry(t *testing.T) {
+	dir := t.TempDir()
+	var attempts int32
+	l := newTestLauncher(dir, func(string) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			return assert.AnError
+		}
+		return nil
+	})
+
+	spawned, err := l.launchIfNeeded("newWindow")
+	require.Error(t, err)
+	assert.False(t, spawned)
+	assert.NoFileExists(t, filepath.Join(dir, "tui.launch.marker"), "failed spawn must unclaim the marker")
+
+	spawned, err = l.launchIfNeeded("newWindow")
+	require.NoError(t, err)
+	assert.True(t, spawned, "retry after a failed spawn must be allowed immediately")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+}
+
+// Test 5 — when the TUI is already running, never spawn.
+func Test_launchIfNeeded_AlreadyRunning_NoSpawn(t *testing.T) {
+	dir := t.TempDir()
+	var spawns int32
+	l := newTestLauncher(dir, func(string) error {
+		atomic.AddInt32(&spawns, 1)
+		return nil
+	})
+	l.isRunning = func() bool { return true }
+
+	spawned, err := l.launchIfNeeded("newWindow")
+	require.NoError(t, err)
+	assert.False(t, spawned)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&spawns))
+}
+
+// Test 6 — THE Grok-BLOCKER-#1 guard. `pgrep -f hookwise-tui` matches the
+// `open -a Terminal …/hookwise-tui` launcher and stray grep/sh/find that carry
+// the token in argv. Filtering on comm (argv[0] basename) must REJECT those and
+// keep only the real TUI (comm hookwise-tui / Python). A false positive here
+// would suppress a legitimate launch.
+func Test_filterTUICandidates_RejectsLaunchersKeepsTUI(t *testing.T) {
+	cands := []tuiCandidate{
+		{pid: 101, comm: "open"},               // the launcher — token is in argv, not comm
+		{pid: 102, comm: "grep"},               // a stray `grep hookwise-tui`
+		{pid: 103, comm: "sh"},                 // `sh -c '… hookwise-tui'`
+		{pid: 104, comm: "find"},               // `find . -name hookwise-tui`
+		{pid: 105, comm: "/usr/bin/cat"},       // `cat …/hookwise-tui`
+		{pid: 201, comm: "hookwise-tui"},       // real TUI wrapper
+		{pid: 202, comm: "Python"},             // real TUI under python interpreter
+		{pid: 203, comm: "/path/.venv/bin/python3.13"},
+	}
+
+	got := filterTUICandidates(cands)
+
+	assert.ElementsMatch(t, []int{201, 202, 203}, got,
+		"only real TUI processes survive the comm filter; launchers/search tools are rejected")
+}
+
+// Test 7 — a marker I/O error (here: the marker's parent is a FILE, so O_EXCL
+// create fails with ENOTDIR, not EEXIST) must FAIL TOWARD SUPPRESS: do not
+// spawn. Pile-up is the bug; under-launch is the safe failure.
+func Test_launchIfNeeded_MarkerIOError_Suppresses(t *testing.T) {
+	base := t.TempDir()
+	notADir := filepath.Join(base, "iam-a-file")
+	require.NoError(t, os.WriteFile(notADir, []byte("x"), 0o644))
+
+	var spawns int32
+	l := newTestLauncher(notADir, func(string) error { // stateDir's parent path is a file
+		atomic.AddInt32(&spawns, 1)
+		return nil
+	})
+
+	spawned, err := l.launchIfNeeded("newWindow")
+	require.NoError(t, err)
+	assert.False(t, spawned)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&spawns), "marker I/O error must suppress, never spawn")
+}
+
+// isTUIComm unit coverage — the decisive allowlist.
+func Test_isTUIComm(t *testing.T) {
+	for _, c := range []struct {
+		comm string
+		want bool
+	}{
+		{"hookwise-tui", true},
+		{"/path/.venv/bin/hookwise-tui", true},
+		{"Python", true},
+		{"python3.13", true},
+		{"open", false},
+		{"grep", false},
+		{"sh", false},
+		{"Terminal", false},
+		{"", false},
+	} {
+		assert.Equalf(t, c.want, isTUIComm(c.comm), "isTUIComm(%q)", c.comm)
+	}
+}


### PR DESCRIPTION
## Problem
hookwise piled up Terminal-window TUI processes, pinning the laptop. Root cause: `launchTUIIfNeeded` checks `isTUIRunning()` via a PID file the **Python** TUI only writes seconds later on Textual mount, while the `O_EXCL` launch lock is released (via `defer`) the instant `cmd.Start()` returns. Time-separated `SessionStart` dispatches across the multi-second boot window each see no PID + no lock → each spawn another window. (`O_EXCL` only serialized same-instant concurrency.)

## Fix (PR 1 of 2 — singleton guard)
- **mtime cooldown marker** replaces the instantaneous lock: an `O_EXCL` claim whose timestamp **is its mtime** (no content parsed → no empty-file read race). Fresh marker suppresses relaunch across the boot window (30s); stale marker self-heals; spawn failure unclaims (no cooldown blackhole); marker I/O error **fails toward suppress** (pile-up is the bug; under-launch is safe).
- **comm-filtered detection** (`listTUIProcs`/`isTUIComm`): detects a TUI that has `exec`'d but not yet written its PID. Filtering on `comm` (argv[0]) — **not** the full cmdline — rejects the `open -a Terminal …/hookwise-tui` launcher and stray `grep`/`sh`/`find` that carry the token in argv (which a raw `pgrep -f hookwise-tui` false-matches).
- **`tuiLauncher` seam** (injected clock / `isRunning` / `spawn`) makes the decision logic unit-testable.

## Tests (strict TDD, real marker files)
- 5 rapid sequential + 16 concurrent `launchIfNeeded` → **exactly one spawn**
- cooldown expiry allows relaunch; spawn-failure unclaims + retries; already-running → no spawn; marker I/O error suppresses
- **comm-filter guard**: `open`/`grep`/`sh`/`find`/`cat` candidates rejected, only `hookwise-tui`/`Python` kept

## Design + audit
`docs/design/tui-singleton-and-monitor.md` (local artifact). Grok ran an **adversarial design audit before any code** and ran real terminal experiments; it found 3 BLOCKERs (pgrep false-positive on the `open` launcher; non-atomic marker content parse; reaper PID-recycle) — all resolved in the design and reflected here (#1 and #2 land in this PR; #3 in the watchdog PR).

## Scope / safety
- Public `launchTUIIfNeeded` signature, recover boundary, and fail-open (ARCH-1) unchanged. SessionStart-only — no hot-path change. ARCH-3 untouched.
- `auto_launch` stays **off** in committed config until the PR 2 watchdog ships (the convergence backstop for older-binary / wedged / manual TUIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)