### PR TITLE
feat(tui): daemon watchdog reaps duplicate/runaway TUIs

### DIFF
--- a/cmd/hookwise/cmd_daemon.go
+++ b/cmd/hookwise/cmd_daemon.go
@@ -164,6 +164,13 @@ func newDaemonRunCmd() *cobra.Command {
 			// The scheduler stops when the daemon's stop channel closes.
 			startSnapshotScheduler(config.Analytics, daemon.StopCh())
 
+			// Start the TUI watchdog: a daemon-side backstop that reaps
+			// duplicate / runaway TUIs the singleton launch guard cannot fix
+			// retroactively (older binaries, manual launches, wedged render
+			// loops). Signals processes only (ARCH-3 untouched); stops when the
+			// daemon's stop channel closes.
+			startTUIWatchdog(daemon.StopCh())
+
 			// Block until the daemon stops.
 			// The daemon handles SIGTERM/SIGINT and /shutdown internally.
 			<-daemon.StopCh()

--- a/cmd/hookwise/cmd_daemon_tui_singleton_test.go
+++ b/cmd/hookwise/cmd_daemon_tui_singleton_test.go
@@ -135,6 +135,29 @@ func Test_launchIfNeeded_AlreadyRunning_NoSpawn(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&spawns))
 }
 
+// Test 5b — the post-claim double-check: a TUI that appears AFTER the first
+// isRunning() check but BEFORE we spawn (e.g. another dispatch's TUI finished
+// mounting) must abort the spawn and release the marker. isRunning returns
+// false on the first call (we proceed to claim) and true on the second.
+func Test_launchIfNeeded_TUIAppearsAfterClaim_NoSpawn(t *testing.T) {
+	dir := t.TempDir()
+	var spawns int32
+	l := newTestLauncher(dir, func(string) error {
+		atomic.AddInt32(&spawns, 1)
+		return nil
+	})
+	var checks int32
+	l.isRunning = func() bool {
+		return atomic.AddInt32(&checks, 1) >= 2 // false first, true thereafter
+	}
+
+	spawned, err := l.launchIfNeeded("newWindow")
+	require.NoError(t, err)
+	assert.False(t, spawned)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&spawns), "spawn aborted when a TUI appears after the claim")
+	assert.NoFileExists(t, filepath.Join(dir, "tui.launch.marker"), "marker released on the double-check abort")
+}
+
 // Test 6 — THE Grok-BLOCKER-#1 guard. `pgrep -f hookwise-tui` matches the
 // `open -a Terminal …/hookwise-tui` launcher and stray grep/sh/find that carry
 // the token in argv. Filtering on comm (argv[0] basename) must REJECT those and

--- a/cmd/hookwise/cmd_daemon_tui_watchdog.go
+++ b/cmd/hookwise/cmd_daemon_tui_watchdog.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// ---------------------------------------------------------------------------
+// TUI watchdog / reaper (PR 2) — converge the system to <=1 healthy TUI.
+//
+// Even a race-proof singleton launch guard (PR 1) cannot retroactively fix
+// duplicates from an older guard-less binary, a manual launch, or a TUI wedged
+// in a CPU-hogging render loop. The watchdog is the daemon-side backstop that
+// reaps duplicate / runaway TUIs. It signals processes only — no DB/cache
+// writes (ARCH-3) — and never propagates failures (ARCH-7).
+// ---------------------------------------------------------------------------
+
+const (
+	// tuiWatchInterval is how often the watchdog sweeps for duplicate/runaway TUIs.
+	tuiWatchInterval = 30 * time.Second
+	// tuiRunawayCPU is the %CPU above which a TUI is treated as a runaway and
+	// killed. High enough that a momentarily-busy TUI (boot/import/render) is not
+	// reaped; only a genuinely pegged render loop.
+	tuiRunawayCPU = 80.0
+	// tuiBootGraceSecs protects a just-started TUI from reaping: boot CPU spikes
+	// are not runaways, and the singleton guard's fresh launch must not be killed
+	// (which would oscillate with the guard).
+	tuiBootGraceSecs = 15.0
+)
+
+// tuiProc is a single live TUI process with the stats the reaper policy needs.
+type tuiProc struct {
+	PID     int
+	CPUPct  float64
+	AgeSecs float64 // process age in seconds (now - start)
+}
+
+// reapTUIs is the pure reaper policy. Given the live TUI processes it returns
+// the PIDs that should be killed:
+//
+//   - procs younger than bootGraceSecs are never touched (boot-spike / fresh-launch
+//     protection);
+//   - among the rest, any proc above runawayCPU is killed;
+//   - among the remaining healthy procs, exactly one — the NEWEST (smallest age,
+//     most likely the window the user is looking at) — is kept; the older
+//     duplicates are killed.
+//
+// If all grace-passed procs are runaway, all are killed (with auto_launch off
+// nothing respawns; with it on the guard relaunches one cleanly).
+func reapTUIs(procs []tuiProc, runawayCPU, bootGraceSecs float64) []int {
+	var kill []int
+	var healthy []tuiProc
+	for _, p := range procs {
+		if p.AgeSecs < bootGraceSecs {
+			continue // boot grace — never touch
+		}
+		if p.CPUPct > runawayCPU {
+			kill = append(kill, p.PID)
+			continue
+		}
+		healthy = append(healthy, p)
+	}
+	if len(healthy) > 1 {
+		newest := 0
+		for i := 1; i < len(healthy); i++ {
+			if healthy[i].AgeSecs < healthy[newest].AgeSecs {
+				newest = i
+			}
+		}
+		for i, p := range healthy {
+			if i != newest {
+				kill = append(kill, p.PID)
+			}
+		}
+	}
+	return kill
+}
+
+// reVerifyTUI re-checks, immediately before signalling, that a PID is still the
+// same TUI process we listed — defeating PID recycle (the PID dies between
+// list() and kill() and is reused by an unrelated process). lookup returns the
+// current (comm, age, ok) for the PID. A recycled PID is rejected because its
+// comm is no longer a TUI, or because a fresh process reusing the PID is far
+// younger than the one we listed.
+func reVerifyTUI(p tuiProc, lookup func(pid int) (comm string, ageSecs float64, ok bool)) bool {
+	comm, age, ok := lookup(p.PID)
+	if !ok {
+		return false // process gone
+	}
+	if !isTUIComm(comm) {
+		return false // recycled into a non-TUI command
+	}
+	// The same process only ages forward between list and kill; a PID reused by
+	// a fresh process is substantially younger. Allow small slack for sampling.
+	if age+2.0 < p.AgeSecs {
+		return false
+	}
+	return true
+}
+
+// tuiReaper carries the watchdog's injectable I/O so sweep() is unit-testable
+// with no real processes. Production wires real list/kill in startTUIWatchdog.
+type tuiReaper struct {
+	list       func() ([]tuiProc, error)
+	kill       func(p tuiProc) error // re-verifies identity, then signals
+	runawayCPU float64
+	bootGrace  float64
+}
+
+// sweep lists TUI processes, computes the reaper policy, and kills the targets.
+// A lister error aborts the sweep with no kills. Individual kill failures (e.g.
+// a re-verify reject) are skipped; only successfully-signalled PIDs are returned.
+func (r *tuiReaper) sweep() (killed []int, err error) {
+	procs, err := r.list()
+	if err != nil {
+		return nil, err
+	}
+	byPID := make(map[int]tuiProc, len(procs))
+	for _, p := range procs {
+		byPID[p.PID] = p
+	}
+	for _, pid := range reapTUIs(procs, r.runawayCPU, r.bootGrace) {
+		if err := r.kill(byPID[pid]); err == nil {
+			killed = append(killed, pid)
+		}
+	}
+	return killed, nil
+}
+
+// parseEtime parses the well-defined `ps -o etime=` format `[[DD-]HH:]MM:SS`
+// into seconds (locale-stable, unlike `lstart`).
+func parseEtime(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	var days float64
+	if i := strings.Index(s, "-"); i >= 0 {
+		d, err := strconv.Atoi(s[:i])
+		if err != nil {
+			return 0, fmt.Errorf("etime days %q: %w", s, err)
+		}
+		days = float64(d)
+		s = s[i+1:]
+	}
+	parts := strings.Split(s, ":")
+	atof := func(x string) (float64, error) { return strconv.ParseFloat(strings.TrimSpace(x), 64) }
+	var h, m, sec float64
+	var err error
+	switch len(parts) {
+	case 2:
+		if m, err = atof(parts[0]); err != nil {
+			return 0, err
+		}
+		if sec, err = atof(parts[1]); err != nil {
+			return 0, err
+		}
+	case 3:
+		if h, err = atof(parts[0]); err != nil {
+			return 0, err
+		}
+		if m, err = atof(parts[1]); err != nil {
+			return 0, err
+		}
+		if sec, err = atof(parts[2]); err != nil {
+			return 0, err
+		}
+	default:
+		return 0, fmt.Errorf("bad etime %q", s)
+	}
+	return days*86400 + h*3600 + m*60 + sec, nil
+}
+
+// psTUILookup returns the current (comm, ageSecs, ok) for a PID, used by the
+// real killer's re-verify. Impure (runs `ps`); not unit-tested.
+func psTUILookup(pid int) (string, float64, bool) {
+	commOut, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+	if err != nil {
+		return "", 0, false
+	}
+	etimeOut, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "etime=").Output()
+	if err != nil {
+		return "", 0, false
+	}
+	age, err := parseEtime(string(etimeOut))
+	if err != nil {
+		return "", 0, false
+	}
+	return strings.TrimSpace(string(commOut)), age, true
+}
+
+// listTUIProcsWithStats is the real lister: the comm-filtered TUI PIDs from PR 1
+// enriched with %cpu + age. Impure; not unit-tested (the policy that consumes it
+// is reapTUIs, which is).
+func listTUIProcsWithStats() ([]tuiProc, error) {
+	pids := listTUIProcs()
+	var procs []tuiProc
+	for _, pid := range pids {
+		out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "%cpu=,etime=").Output()
+		if err != nil {
+			continue
+		}
+		fields := strings.Fields(strings.TrimSpace(string(out)))
+		if len(fields) < 2 {
+			continue
+		}
+		cpu, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil {
+			continue
+		}
+		age, err := parseEtime(fields[1])
+		if err != nil {
+			continue
+		}
+		procs = append(procs, tuiProc{PID: pid, CPUPct: cpu, AgeSecs: age})
+	}
+	return procs, nil
+}
+
+// realKillTUI re-verifies the PID is still the listed TUI, then sends SIGTERM and
+// escalates to SIGKILL if it survives a short grace period.
+func realKillTUI(p tuiProc) error {
+	if !reVerifyTUI(p, psTUILookup) {
+		return errors.New("re-verify failed; skipping kill (PID recycled or gone)")
+	}
+	proc, err := os.FindProcess(p.PID)
+	if err != nil {
+		return err
+	}
+	_ = proc.Signal(syscall.SIGTERM)
+	time.Sleep(500 * time.Millisecond)
+	if reVerifyTUI(p, psTUILookup) {
+		_ = proc.Signal(syscall.SIGKILL)
+	}
+	core.Logger().Info("watchdog reaped TUI", "pid", p.PID, "cpu", p.CPUPct, "ageSecs", p.AgeSecs)
+	return nil
+}
+
+// startTUIWatchdog launches the daemon-side reaper goroutine. It sweeps every
+// tuiWatchInterval and exits when stopCh closes. Mirrors startSnapshotScheduler:
+// the side effect is non-blocking and each tick recovers from panic (ARCH-7).
+func startTUIWatchdog(stopCh <-chan struct{}) {
+	r := &tuiReaper{
+		list:       listTUIProcsWithStats,
+		kill:       realKillTUI,
+		runawayCPU: tuiRunawayCPU,
+		bootGrace:  tuiBootGraceSecs,
+	}
+	go func() {
+		ticker := time.NewTicker(tuiWatchInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-ticker.C:
+				runWatchdogSweep(r)
+			}
+		}
+	}()
+}
+
+// runWatchdogSweep performs one sweep, recovering from any panic so the daemon
+// stays alive (ARCH-7). Failures are logged, never propagated.
+func runWatchdogSweep(r *tuiReaper) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			core.Logger().Error("panic in TUI watchdog", "recovered", fmt.Sprintf("%v", rec))
+		}
+	}()
+	killed, err := r.sweep()
+	if err != nil {
+		core.Logger().Debug("TUI watchdog sweep error (fail-open)", "error", err)
+		return
+	}
+	if len(killed) > 0 {
+		core.Logger().Info("TUI watchdog reaped duplicates/runaways", "pids", killed)
+	}
+}

--- a/cmd/hookwise/cmd_daemon_tui_watchdog_test.go
+++ b/cmd/hookwise/cmd_daemon_tui_watchdog_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test 1 — the core reaper policy: among grace-passed procs, kill runaways and
+// every healthy DUPLICATE, keeping exactly the newest healthy one.
+func Test_reapTUIs_KillsRunawayAndStaleDuplicate_KeepsNewest(t *testing.T) {
+	procs := []tuiProc{
+		{PID: 1, CPUPct: 90, AgeSecs: 100}, // runaway
+		{PID: 2, CPUPct: 5, AgeSecs: 20},   // healthy, newest
+		{PID: 3, CPUPct: 5, AgeSecs: 40},   // healthy, older duplicate
+	}
+	got := reapTUIs(procs, 80.0, 15.0)
+	assert.ElementsMatch(t, []int{1, 3}, got, "kill runaway + older duplicate, keep newest healthy (PID 2)")
+}
+
+// Test 2 — never kill the sole healthy TUI.
+func Test_reapTUIs_SingleHealthy_NoKill(t *testing.T) {
+	procs := []tuiProc{{PID: 7, CPUPct: 5, AgeSecs: 100}}
+	got := reapTUIs(procs, 80.0, 15.0)
+	assert.Empty(t, got)
+}
+
+// Test 3 — boot grace: a process younger than bootGrace is never touched, even
+// at runaway CPU (protects boot spikes AND the singleton guard's fresh launch,
+// killing the guard/reaper oscillation).
+func Test_reapTUIs_BootGraceProtectsYoungProc(t *testing.T) {
+	procs := []tuiProc{
+		{PID: 1, CPUPct: 95, AgeSecs: 5},  // young runaway — grace-protected
+		{PID: 2, CPUPct: 5, AgeSecs: 100}, // sole grace-passed healthy
+	}
+	got := reapTUIs(procs, 80.0, 15.0)
+	assert.Empty(t, got, "young proc protected by boot grace; the one old healthy is the sole keeper")
+}
+
+// Test 4 — all grace-passed procs are runaway → kill them all.
+func Test_reapTUIs_AllRunaway_KillsAll(t *testing.T) {
+	procs := []tuiProc{
+		{PID: 1, CPUPct: 90, AgeSecs: 100},
+		{PID: 2, CPUPct: 95, AgeSecs: 100},
+	}
+	got := reapTUIs(procs, 80.0, 15.0)
+	assert.ElementsMatch(t, []int{1, 2}, got)
+}
+
+// Test 5 — sweep() drives reapTUIs over an injected lister and routes targets to
+// an injected killer, with ZERO real kills. Asserts exactly the expected PIDs.
+func Test_tuiReaper_sweep_KillsExpected_NoRealKills(t *testing.T) {
+	procs := []tuiProc{
+		{PID: 1, CPUPct: 90, AgeSecs: 100},
+		{PID: 2, CPUPct: 5, AgeSecs: 20},
+		{PID: 3, CPUPct: 5, AgeSecs: 40},
+	}
+	var mu sync.Mutex
+	var killedArgs []int
+	r := &tuiReaper{
+		list: func() ([]tuiProc, error) { return procs, nil },
+		kill: func(p tuiProc) error {
+			mu.Lock()
+			killedArgs = append(killedArgs, p.PID)
+			mu.Unlock()
+			return nil
+		},
+		runawayCPU: 80.0,
+		bootGrace:  15.0,
+	}
+
+	killed, err := r.sweep()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int{1, 3}, killed)
+	assert.ElementsMatch(t, []int{1, 3}, killedArgs, "killer invoked for exactly the targets")
+}
+
+// Test 6 — PID-recycle defence. reVerifyTUI must reject a PID that no longer
+// looks like the TUI process we listed (recycled into another command, or now
+// substantially younger = a different process reusing the PID), and must keep a
+// still-alive same process (age grew).
+func Test_reVerifyTUI_RejectsRecycledPID(t *testing.T) {
+	listed := tuiProc{PID: 999, CPUPct: 5, AgeSecs: 100}
+
+	// same process, a few seconds later (age grew) → still valid
+	assert.True(t, reVerifyTUI(listed, func(int) (string, float64, bool) {
+		return "Python", 103, true
+	}), "same TUI, age grew → keep")
+
+	// recycled into a non-TUI command → reject
+	assert.False(t, reVerifyTUI(listed, func(int) (string, float64, bool) {
+		return "bash", 1, true
+	}), "PID recycled into bash → reject")
+
+	// recycled into another python but far younger than at list time → reject
+	assert.False(t, reVerifyTUI(listed, func(int) (string, float64, bool) {
+		return "Python", 0.5, true
+	}), "PID reused by a fresh python → reject (age dropped)")
+
+	// process gone → reject
+	assert.False(t, reVerifyTUI(listed, func(int) (string, float64, bool) {
+		return "", 0, false
+	}), "process gone → reject")
+}
+
+// Test 7 — etime parser across all three documented ps formats.
+func Test_parseEtime(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want float64
+	}{
+		{"00:42", 42},
+		{"01:02:03", 3723},
+		{"2-03:04:05", 183845},
+		{"  10:00  ", 600},
+	} {
+		got, err := parseEtime(c.in)
+		require.NoErrorf(t, err, "parseEtime(%q)", c.in)
+		assert.InDeltaf(t, c.want, got, 0.001, "parseEtime(%q)", c.in)
+	}
+	_, err := parseEtime("garbage")
+	assert.Error(t, err)
+}
+
+// Test 8 — a lister error aborts the sweep without any kills; the daemon
+// survives (fail-open).
+func Test_tuiReaper_sweep_ListError_NoKills(t *testing.T) {
+	var killCalls int
+	r := &tuiReaper{
+		list:       func() ([]tuiProc, error) { return nil, errors.New("pgrep blew up") },
+		kill:       func(tuiProc) error { killCalls++; return nil },
+		runawayCPU: 80.0,
+		bootGrace:  15.0,
+	}
+	killed, err := r.sweep()
+	require.Error(t, err)
+	assert.Empty(t, killed)
+	assert.Zero(t, killCalls, "no kills attempted when the lister fails")
+}


### PR DESCRIPTION
## Backstop for the singleton guard (#220)
A launch guard can't retroactively fix TUIs from an older guard-less binary, a manual launch, or a wedged CPU-hogging render loop. This adds a daemon-side watchdog that sweeps every 30s and converges the system to **≤1 healthy TUI**.

## Policy (`reapTUIs`, pure)
- procs younger than a **15s boot grace** are never touched — protects boot CPU spikes **and** the guard's just-launched TUI (kills the guard/reaper oscillation)
- among the rest, **runaways (>80% CPU)** are killed
- among remaining healthy procs, exactly **one — the newest** (the window the user is most likely looking at) — is kept; older duplicates reaped

## PID-recycle safe (Grok design BLOCKER #3)
`realKillTUI` re-verifies (comm still a TUI **and** age hasn't dropped — a recycled PID is younger) immediately before **both** SIGTERM and SIGKILL, so a PID reused between `list()` and `kill()` is never signalled. Age comes from `ps -o etime=` (locale-stable), not `lstart`.

## Testability
Injected lister + killer → `sweep()` unit-tested with **zero real kills**; `reVerifyTUI` and the `etime` parser are pure and tested directly (incl. recycled-PID + all three etime formats). Signals only — **ARCH-3 untouched**; each sweep recovers from panic so the daemon never dies (**ARCH-7**).

## Audit
Grok ran an **implementation audit on the real diffs** (`docs/design/tui-singleton-and-monitor.md` §5.2): ran the suite (now 25 tests, `-race`) + live macOS `ps`/`pgrep` checks; confirmed **all 3 design BLOCKERs closed in code, no new BLOCKER**. One audit SHOULD-FIX folded in here: a test for the singleton's post-claim `isRunning` double-check.

## Scope
`auto_launch` stays **off** in committed config until this backstop is dogfooded — re-enabling it is a separate supervised change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)