### PR TITLE
fix(doctor): disabled feeds report INFO not stale-data WARN

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -1477,6 +1477,16 @@ func TestDoctorFeedHealthEmptyData(t *testing.T) {
 	cacheDir := filepath.Join(stateDir, "state")
 	os.MkdirAll(cacheDir, 0o700)
 
+	// Enable weather so this test exercises the empty-data WARN, not the
+	// disabled-feed suppression (a disabled feed's empty cache is benign).
+	configYAML := `version: 1
+feeds:
+  weather:
+    enabled: true
+    interval_seconds: 600
+`
+	os.WriteFile(filepath.Join(tmpDir, core.ProjectConfigFile), []byte(configYAML), 0o644)
+
 	// Fresh timestamp, but an empty data object.
 	now := time.Now().UTC().Format(time.RFC3339)
 	writeJSONFile(t, filepath.Join(cacheDir, "weather.json"), map[string]interface{}{

--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -244,6 +244,39 @@ func isKnownFeed(feedName string, cfg *core.HooksConfig) bool {
 	return false
 }
 
+// isFeedEnabled reports whether feedName is enabled in cfg. It mirrors the cases
+// in getFeedInterval's switch (and thus knownBuiltinFeeds); the two are pinned
+// together by TestIsFeedEnabled_MirrorsBuiltins. A disabled feed is not expected
+// to be polled, so checkFeedHealth uses this to downgrade a disabled feed's
+// stale/placeholder/empty cache from a misleading WARN to a benign INFO. Unknown
+// or custom feeds consult cfg.Feeds.Custom; a nil config reports disabled.
+func isFeedEnabled(cfg *core.HooksConfig, feedName string) bool {
+	if cfg == nil {
+		return false
+	}
+	switch feedName {
+	case "project":
+		return cfg.Feeds.Project.Enabled
+	case "calendar":
+		return cfg.Feeds.Calendar.Enabled
+	case "news":
+		return cfg.Feeds.News.Enabled
+	case "insights":
+		return cfg.Feeds.Insights.Enabled
+	case "weather":
+		return cfg.Feeds.Weather.Enabled
+	case "memories":
+		return cfg.Feeds.Memories.Enabled
+	default:
+		for _, cf := range cfg.Feeds.Custom {
+			if cf.Name == feedName {
+				return cf.Enabled
+			}
+		}
+		return false
+	}
+}
+
 // checkFeedHealth reads feed cache files and reports placeholder/stale feeds.
 // Returns the number of warnings emitted.
 func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
@@ -295,8 +328,24 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 			continue
 		}
 
+		// A disabled feed is not expected to be polled, so a leftover cache that
+		// is placeholder/empty/zero-lived/stale is not a malfunction — reporting
+		// it as WARN ("stale data 304h ago") is misleading. Downgrade those
+		// outcomes to a benign INFO "disabled" line. A disabled feed that
+		// nonetheless carries fresh, real data still falls through to the healthy
+		// "OK" path below, so an actively-polled-elsewhere feed is not mislabelled.
+		enabled := isFeedEnabled(cfg, feedName)
+		reportDisabled := func() {
+			fmt.Fprintf(w, "INFO  feed:%s: disabled (cache not refreshed)\n", feedName)
+			feedStatuses[feedName] = "disabled"
+		}
+
 		// Check placeholder.
 		if src, ok := dataMap["source"].(string); ok && src == "placeholder" {
+			if !enabled {
+				reportDisabled()
+				continue
+			}
 			fmt.Fprintf(w, "WARN  feed:%s: placeholder data (no real source configured)\n", feedName)
 			warnings++
 			feedStatuses[feedName] = "placeholder"
@@ -307,6 +356,10 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 		// producer ran but emitted nothing — the segment renders blank. Report
 		// it distinctly rather than as "OK" (issue #99: cache-fresh != data-present).
 		if len(dataMap) == 0 {
+			if !enabled {
+				reportDisabled()
+				continue
+			}
 			fmt.Fprintf(w, "WARN  feed:%s: cache fresh but no data\n", feedName)
 			warnings++
 			feedStatuses[feedName] = "empty"
@@ -318,6 +371,10 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 		// renders blank even though len(dataMap) > 0, so the empty-map guard
 		// above won't catch it. Detect feed-specific zero-liveness conditions.
 		if reason := feedZeroLivenessReason(feedName, dataMap); reason != "" {
+			if !enabled {
+				reportDisabled()
+				continue
+			}
 			fmt.Fprintf(w, "WARN  feed:%s: %s\n", feedName, reason)
 			warnings++
 			feedStatuses[feedName] = "empty"
@@ -340,6 +397,10 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 		if interval > 0 {
 			staleThreshold := time.Duration(2*interval) * time.Second
 			if age > staleThreshold {
+				if !enabled {
+					reportDisabled()
+					continue
+				}
 				fmt.Fprintf(w, "WARN  feed:%s: stale data (last updated %s ago)\n", feedName, age)
 				warnings++
 				feedStatuses[feedName] = "stale"

--- a/cmd/hookwise/cmd_doctor_feedhealth_test.go
+++ b/cmd/hookwise/cmd_doctor_feedhealth_test.go
@@ -33,6 +33,21 @@ func writeFeedFile(t *testing.T, cacheDir, name, source string) {
 	require.NoError(t, err)
 }
 
+// writeFeedFileAged writes a feed cache envelope whose timestamp is ageSeconds in
+// the past, so staleness checks (age > 2*interval) can be exercised. The data is
+// real (non-placeholder, non-empty).
+func writeFeedFileAged(t *testing.T, cacheDir, name string, ageSeconds int) {
+	t.Helper()
+	envelope := map[string]interface{}{
+		"type":      name,
+		"timestamp": time.Now().UTC().Add(-time.Duration(ageSeconds) * time.Second).Format(time.RFC3339),
+		"data":      map[string]interface{}{"key": "value"},
+	}
+	raw, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, name+".json"), raw, 0o644))
+}
+
 // TestCheckFeedHealth_OrphanSkipped verifies that orphan cache files (files with
 // no corresponding built-in or custom feed) are silently skipped and do not
 // produce any output or increment the warning count.
@@ -41,10 +56,14 @@ func TestCheckFeedHealth_OrphanSkipped(t *testing.T) {
 
 	// (a) Orphan: practice.json — no Go producer, not in cfg.Feeds.Custom.
 	writeFeedFile(t, cacheDir, "practice", "placeholder")
-	// (b) Known built-in: news.json — placeholder should still warn.
+	// (b) Known built-in: news.json — placeholder should still warn (when enabled).
 	writeFeedFile(t, cacheDir, "news", "placeholder")
 
 	cfg := core.GetDefaultConfig()
+	// News is disabled by default; enable it so this test exercises the
+	// known-vs-orphan distinction, not the disabled-feed suppression (which has
+	// its own coverage below).
+	cfg.Feeds.News.Enabled = true
 	// Ensure no custom feed named "practice".
 	cfg.Feeds.Custom = nil
 
@@ -61,6 +80,67 @@ func TestCheckFeedHealth_OrphanSkipped(t *testing.T) {
 
 	// Warning count must reflect only the known feed.
 	assert.Equal(t, 1, count, "warning count must be 1 (only the known news feed)")
+}
+
+// TestCheckFeedHealth_DisabledFeedStaleNotWarned is the regression test for the
+// live `feed:news`/`feed:memories stale data` warnings: a feed that is DISABLED
+// in config but left a stale cache file behind must NOT be reported as "stale"
+// (a disabled feed is not expected to be polled). It is reported as a benign
+// INFO "disabled" line and does not increment the warning count.
+func TestCheckFeedHealth_DisabledFeedStaleNotWarned(t *testing.T) {
+	cacheDir := t.TempDir()
+	// news default interval is 1800s → stale threshold 3600s. 8h old = stale.
+	writeFeedFileAged(t, cacheDir, "news", 8*3600)
+
+	cfg := core.GetDefaultConfig()
+	cfg.Feeds.News.Enabled = false // disabled
+
+	var buf bytes.Buffer
+	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	out := buf.String()
+
+	assert.NotContains(t, out, "WARN  feed:news", "disabled feed must not produce a WARN")
+	assert.NotContains(t, out, "stale data", "disabled feed must not be reported as stale")
+	assert.Contains(t, out, "feed:news: disabled", "disabled feed should be reported as a benign INFO disabled line")
+	assert.Equal(t, 0, count, "disabled stale feed must contribute zero warnings")
+}
+
+// TestCheckFeedHealth_EnabledFeedStaleStillWarns verifies the converse: an
+// ENABLED feed with a stale cache (the `feed:calendar` case) is still correctly
+// flagged WARN. The enabled-gate must not suppress genuine staleness.
+func TestCheckFeedHealth_EnabledFeedStaleStillWarns(t *testing.T) {
+	cacheDir := t.TempDir()
+	// calendar default interval 300s → threshold 600s. 8h old = stale.
+	writeFeedFileAged(t, cacheDir, "calendar", 8*3600)
+
+	cfg := core.GetDefaultConfig()
+	cfg.Feeds.Calendar.Enabled = true // enabled
+
+	var buf bytes.Buffer
+	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	out := buf.String()
+
+	assert.Contains(t, out, "WARN  feed:calendar: stale data", "enabled stale feed must still warn")
+	assert.Equal(t, 1, count, "enabled stale feed must contribute one warning")
+}
+
+// TestCheckFeedHealth_DisabledFeedPlaceholderNotWarned verifies a disabled feed
+// whose cache is placeholder data is also suppressed to a benign INFO line
+// (placeholder is expected when a feed never ran because it is off).
+func TestCheckFeedHealth_DisabledFeedPlaceholderNotWarned(t *testing.T) {
+	cacheDir := t.TempDir()
+	writeFeedFile(t, cacheDir, "memories", "placeholder")
+
+	cfg := core.GetDefaultConfig()
+	cfg.Feeds.Memories.Enabled = false
+
+	var buf bytes.Buffer
+	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	out := buf.String()
+
+	assert.NotContains(t, out, "WARN  feed:memories", "disabled placeholder feed must not warn")
+	assert.Contains(t, out, "feed:memories: disabled", "disabled placeholder feed reported as INFO disabled")
+	assert.Equal(t, 0, count, "disabled placeholder feed contributes zero warnings")
 }
 
 // TestCheckFeedHealth_CustomFeedTreatedAsKnown verifies that a feed listed in

--- a/cmd/hookwise/cmd_doctor_feedlist_test.go
+++ b/cmd/hookwise/cmd_doctor_feedlist_test.go
@@ -51,6 +51,32 @@ func TestKnownBuiltinFeeds_MirrorsGetFeedInterval(t *testing.T) {
 	}
 }
 
+// TestIsFeedEnabled_MirrorsBuiltins enforces that isFeedEnabled has a switch case
+// for every builtin (parallel to getFeedInterval). A builtin missing from the
+// switch falls through to the default and is treated as permanently disabled,
+// which would suppress its diagnostics — the opposite failure of the stale-feed
+// bug. Each builtin is enabled here so a missing case (default false) is caught.
+func TestIsFeedEnabled_MirrorsBuiltins(t *testing.T) {
+	cfg := &core.HooksConfig{}
+	cfg.Feeds.Project.Enabled = true
+	cfg.Feeds.News.Enabled = true
+	cfg.Feeds.Calendar.Enabled = true
+	cfg.Feeds.Weather.Enabled = true
+	cfg.Feeds.Memories.Enabled = true
+	cfg.Feeds.Insights.Enabled = true
+
+	for _, feed := range knownBuiltinFeeds {
+		assert.Truef(t, isFeedEnabled(cfg, feed),
+			"isFeedEnabled(%q) must resolve via its own switch case, not fall through to default false", feed)
+	}
+
+	// A declared custom feed reflects its Enabled flag; unknown → false; nil → false.
+	cfg.Feeds.Custom = []core.CustomFeedConfig{{Name: "mycustom", Enabled: true}}
+	assert.True(t, isFeedEnabled(cfg, "mycustom"), "enabled custom feed must report enabled")
+	assert.False(t, isFeedEnabled(cfg, "nonexistent-orphan"), "unknown feed must report disabled")
+	assert.False(t, isFeedEnabled(nil, "project"), "nil config must report disabled (no panic)")
+}
+
 // TestIsKnownFeed pins isKnownFeed across builtins, custom feeds, and unknowns —
 // it had no coverage. Builtins are recognised; a declared custom feed is
 // recognised; an orphan/unknown name is not.


### PR DESCRIPTION
## What

`hookwise doctor` flagged disabled feeds as `stale data` / `placeholder` / `cache fresh but no data`. A feed the user has **disabled** in config is not expected to be polled, so a leftover cache being "stale" is not a malfunction — the WARN was misleading (live example: `WARN feed:news: stale data (304h ago)` and `feed:memories` for feeds nobody enabled).

This is the same cache-fresh-vs-actually-broken honesty family as #98/#99/#150.

## Fix

- Add `isFeedEnabled(cfg, feedName)` — mirrors `getFeedInterval`'s switch (and `knownBuiltinFeeds`), pinned by a new `TestIsFeedEnabled_MirrorsBuiltins` mirror-invariant test.
- Gate the placeholder / empty / zero-liveness / stale WARN branches in `checkFeedHealth` on enabled-state. A disabled feed's bad cache now emits a benign `INFO feed:NAME: disabled (cache not refreshed)` line and contributes **zero** warnings.
- A **disabled-but-fresh** feed still falls through to the healthy `OK` path, so a feed actively polled under a different config (e.g. the daemon's global config) is not mislabelled "disabled".

Net effect on a real machine: `feed:news` and `feed:memories` (disabled, stale leftover caches) drop from WARN → INFO. Genuinely-enabled-but-stale feeds (e.g. `calendar`) **still** WARN correctly.

## Tests (strict TDD, red→green)

- `TestCheckFeedHealth_DisabledFeedStaleNotWarned` — disabled + stale → INFO, count 0 (the news/memories regression).
- `TestCheckFeedHealth_EnabledFeedStaleStillWarns` — converse: enabled + stale → WARN (the calendar case is not suppressed).
- `TestCheckFeedHealth_DisabledFeedPlaceholderNotWarned` — disabled placeholder → INFO, count 0.
- `TestIsFeedEnabled_MirrorsBuiltins` — pins the helper to the builtin list.
- Two existing tests (`OrphanSkipped`, `TestDoctorFeedHealthEmptyData`) incidentally relied on a *disabled* feed warning; updated to enable the feed so they still exercise their intended (known-vs-orphan / empty-data) branch.

Guarded gate green locally: `GOMEMLIMIT=4GiB go test -race -p 2 ./cmd/hookwise/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now treat disabled feeds differently, showing an info message instead of warning about stale, empty, or placeholder cache data.
  * Enabled feeds still report these cache issues as warnings as before.
  * Feed status detection now correctly recognizes built-in and custom feeds from configuration, avoiding false alerts for disabled feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->