### PR TITLE
fix(doctor): disabled cost tracking is not a dead writer

### DIFF
--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -106,13 +106,23 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(w, "INFO  legacy-dolt: %s present (archived; safe to remove)\n", doltDir)
 	}
 
+	// Load config once for the cost-honesty (Check 8) and feed-health (Check 5)
+	// checks below; both consult it and doctor is a one-shot diagnostic.
+	var doctorCfg *core.HooksConfig
+	if loadedCfg, loadErr := core.LoadConfig(cwd); loadErr == nil {
+		doctorCfg = &loadedCfg
+	}
+	costEnabled := doctorCfg != nil && doctorCfg.CostTracking.Enabled
+
 	// Check 8: Cost-tracking honesty. DailySummary aggregates per-session
 	// estimated_cost_usd from the SAME UTC day `hookwise stats` and the
 	// status-line read, so doctor agrees with what the user sees there. If
-	// sessions were recorded today but $0 was computed, the cost writer is
-	// likely dead -- the exact failure that kept stats/status-line silently at
-	// $0. Mirrors the feed zero-liveness principle (cache-fresh != data-present).
-	warnings += checkCostHonesty(w, dbPath)
+	// sessions were recorded today but $0 was computed WHILE cost tracking is
+	// enabled, the cost writer is likely dead -- the exact failure that kept
+	// stats/status-line silently at $0. When cost tracking is disabled (the
+	// default), $0 is expected, not a malfunction. Mirrors the feed
+	// zero-liveness / disabled-subsystem honesty principle.
+	warnings += checkCostHonesty(w, dbPath, costEnabled)
 
 	// Check 4: Daemon liveness via socket dial (replaces PID file check).
 	// Use GetStateDir() to respect HOOKWISE_STATE_DIR env override.
@@ -130,12 +140,8 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(w, "INFO  daemon: not running (start with 'hookwise daemon start')")
 	}
 
-	// Check 5: Feed health.
-	var feedCfg *core.HooksConfig
-	if loadedCfg, loadErr := core.LoadConfig(cwd); loadErr == nil {
-		feedCfg = &loadedCfg
-	}
-	warnings += checkFeedHealth(w, filepath.Join(stateDir, "state"), feedCfg)
+	// Check 5: Feed health (reuses doctorCfg loaded above).
+	warnings += checkFeedHealth(w, filepath.Join(stateDir, "state"), doctorCfg)
 
 	// Check 7: Hook safety — scan Claude Code settings for hook sprawl, missing
 	// binaries, network-dependent hot-path hooks, and duplicate/overlapping
@@ -469,13 +475,15 @@ func feedZeroLivenessReason(feedName string, dataMap map[string]interface{}) str
 }
 
 // checkCostHonesty reports a doctor warning when sessions were recorded today
-// but the computed cost is still $0 -- the signature of a dead cost writer
-// (sessions present but the cost value absent). It reads DailySummary for the
-// current UTC day, the same source `hookwise stats` and the status-line use, so
-// doctor stays consistent with what the user sees there. Returns the number of
-// warnings emitted (0 or 1). Absent or unopenable DBs are silent no-ops -- the
-// analytics check (Check 3) already owns reporting those.
-func checkCostHonesty(w io.Writer, dbPath string) int {
+// but the computed cost is still $0 AND cost tracking is enabled -- the
+// signature of a dead cost writer (sessions present but the cost value absent).
+// When cost tracking is disabled (costEnabled=false, the default), a $0 total is
+// expected, not a malfunction, and is reported as a benign INFO instead. It
+// reads DailySummary for the current UTC day, the same source `hookwise stats`
+// and the status-line use, so doctor stays consistent with what the user sees
+// there. Returns the number of warnings emitted (0 or 1). Absent or unopenable
+// DBs are silent no-ops -- the analytics check (Check 3) already owns those.
+func checkCostHonesty(w io.Writer, dbPath string, costEnabled bool) int {
 	if _, err := os.Stat(dbPath); err != nil {
 		return 0
 	}
@@ -496,6 +504,15 @@ func checkCostHonesty(w io.Writer, dbPath string) int {
 		fmt.Fprintln(w, "INFO  cost: no sessions recorded today yet")
 		return 0
 	case summary.EstimatedCostUSD == 0:
+		// A $0 total is only a "dead writer" signal when cost tracking is ON.
+		// With cost tracking disabled (the default), $0 is the expected state,
+		// not a malfunction — report it as benign INFO rather than a misleading
+		// "may be dead" WARN. Same disabled-subsystem honesty principle as the
+		// feed-health checks (a disabled feed isn't "stale", it's off).
+		if !costEnabled {
+			fmt.Fprintf(w, "INFO  cost: tracking disabled (%d session(s) today, $0.00)\n", summary.TotalSessions)
+			return 0
+		}
 		fmt.Fprintf(w, "WARN  cost: %d session(s) today but $0.00 computed "+
 			"(cost tracking may be dead -- see 'hookwise stats')\n", summary.TotalSessions)
 		return 1

--- a/cmd/hookwise/cmd_doctor_cost_test.go
+++ b/cmd/hookwise/cmd_doctor_cost_test.go
@@ -26,13 +26,35 @@ func TestCheckCostHonesty_SessionsButZeroCost(t *testing.T) {
 	db.Close()
 
 	buf := &bytes.Buffer{}
-	warnings := checkCostHonesty(buf, dbPath)
+	// Cost tracking ENABLED: $0-despite-sessions is the dead-writer signal → WARN.
+	warnings := checkCostHonesty(buf, dbPath, true)
 
 	out := buf.String()
-	assert.Equal(t, 1, warnings, "a recorded session with $0 cost must produce exactly one warning")
+	assert.Equal(t, 1, warnings, "a recorded session with $0 cost (tracking enabled) must produce exactly one warning")
 	assert.Contains(t, out, "WARN  cost:")
 	assert.Contains(t, out, "$0.00 computed",
 		"warning must name the zero-cost-despite-sessions condition")
+}
+
+// TestCheckCostHonesty_DisabledTrackingZeroCost is the regression for the
+// false-positive "cost tracking may be dead" warning: with cost tracking
+// DISABLED (the default), a $0 total despite recorded sessions is expected, not
+// a malfunction. doctor must report a benign INFO, not a WARN.
+func TestCheckCostHonesty_DisabledTrackingZeroCost(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.StartSession(context.Background(), "cost-disabled-zero", time.Now().UTC()))
+	db.Close()
+
+	buf := &bytes.Buffer{}
+	warnings := checkCostHonesty(buf, dbPath, false) // tracking disabled
+
+	out := buf.String()
+	assert.Equal(t, 0, warnings, "disabled cost tracking with $0 must not warn")
+	assert.Contains(t, out, "INFO  cost: tracking disabled",
+		"disabled tracking must be reported as benign INFO")
+	assert.NotContains(t, out, "WARN", "disabled tracking must never emit a cost WARN")
 }
 
 // TestCheckCostHonesty_SessionsWithCost verifies the healthy path: sessions
@@ -50,7 +72,7 @@ func TestCheckCostHonesty_SessionsWithCost(t *testing.T) {
 	db.Close()
 
 	buf := &bytes.Buffer{}
-	warnings := checkCostHonesty(buf, dbPath)
+	warnings := checkCostHonesty(buf, dbPath, true)
 
 	out := buf.String()
 	assert.Equal(t, 0, warnings, "a session with non-zero cost must not warn")
@@ -68,7 +90,7 @@ func TestCheckCostHonesty_NoSessions(t *testing.T) {
 	db.Close() // schema created, but no sessions recorded
 
 	buf := &bytes.Buffer{}
-	warnings := checkCostHonesty(buf, dbPath)
+	warnings := checkCostHonesty(buf, dbPath, false)
 
 	out := buf.String()
 	assert.Equal(t, 0, warnings, "no sessions today must not warn")
@@ -84,7 +106,7 @@ func TestCheckCostHonesty_NoDB(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "does-not-exist.db")
 
 	buf := &bytes.Buffer{}
-	warnings := checkCostHonesty(buf, dbPath)
+	warnings := checkCostHonesty(buf, dbPath, false)
 
 	assert.Equal(t, 0, warnings)
 	assert.Empty(t, buf.String(), "absent DB must produce no cost output (analytics check owns that report)")


### PR DESCRIPTION
## What

`hookwise doctor` warned `WARN cost: N session(s) today but $0.00 computed (cost tracking may be dead -- see 'hookwise stats')` whenever sessions existed with $0 cost — **even when cost tracking is disabled** (`CostTracking.Enabled=false`, the default, with empty `Rates`). A $0 total is only a dead-writer signal when cost tracking is **on**; with it off, $0 is the expected state. So the WARN was a false positive — the same disabled-subsystem honesty bug as disabled feeds being reported "stale" (#222).

This surfaced the moment a machine accrued sessions in a day with cost tracking off.

## Fix

- Thread the cost-tracking enabled flag into `checkCostHonesty`. The config is now loaded **once** near the top of `runDoctor` and shared with the feed-health check (was loaded twice).
- When cost tracking is **disabled**, the `$0-despite-sessions` case reports a benign `INFO cost: tracking disabled (N session(s) today, $0.00)` and contributes **zero** warnings.
- When cost tracking is **enabled**, the genuine dead-writer `WARN` is preserved **unchanged** — the real signal is not suppressed.

## Tests (strict TDD)

- `TestCheckCostHonesty_DisabledTrackingZeroCost` — disabled + $0 + sessions → INFO, count 0 (the regression).
- The existing dead-writer test now passes `costEnabled=true` and still asserts the WARN, so the genuine-failure path stays covered.
- `SessionsWithCost` / `NoSessions` / `NoDB` updated for the new signature; behavior unchanged.

Guarded gate green locally: `GOMEMLIMIT=4GiB go test -race -p 2 ./cmd/hookwise/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)