### PR TITLE
feat(daemon): source canonical config from global only (#89)

### DIFF
--- a/cmd/hookwise/cmd_daemon.go
+++ b/cmd/hookwise/cmd_daemon.go
@@ -112,7 +112,25 @@ func newDaemonStopCmd() *cobra.Command {
 	}
 }
 
+// resolveDaemonConfig loads the canonical daemon-process config. The daemon is a
+// singleton — one socket, one cache, one process per state dir — so its entire
+// config (feeds, daemon, analytics snapshots) MUST come from the global config
+// file only, independent of which project directory cold-started it (#89).
+// Honoring a per-project hookwise.yaml here let whichever project won the
+// cold-start race freeze the feed config for every other project/session. Fails
+// open to defaults on error (ARCH-1).
+func resolveDaemonConfig() core.HooksConfig {
+	config, err := core.LoadGlobalConfig()
+	if err != nil {
+		return core.GetDefaultConfig()
+	}
+	return config
+}
+
 func newDaemonRunCmd() *cobra.Command {
+	// configPath is retained only so the daemon still accepts the legacy
+	// --config flag that older spawn paths may pass; it is intentionally NOT used
+	// to source config anymore (#89 — see resolveDaemonConfig).
 	var configPath string
 	var socketPath string
 
@@ -121,16 +139,7 @@ func newDaemonRunCmd() *cobra.Command {
 		Short:  "Run the daemon in the foreground (internal)",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if configPath == "" {
-				cwd, _ := os.Getwd()
-				configPath = filepath.Join(cwd, core.ProjectConfigFile)
-			}
-
-			config, err := core.LoadConfig(filepath.Dir(configPath))
-			if err != nil {
-				// Fail-open: use defaults.
-				config = core.GetDefaultConfig()
-			}
+			config := resolveDaemonConfig()
 
 			registry := feeds.NewRegistry()
 			feeds.RegisterBuiltins(registry)

--- a/cmd/hookwise/cmd_daemon_canonical_test.go
+++ b/cmd/hookwise/cmd_daemon_canonical_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// #89: the feed daemon is a singleton (one socket/cache/state dir), so the
+// config it polls with MUST be canonical — sourced from the global config only,
+// independent of which project directory cold-started it. resolveDaemonConfig is
+// the seam the daemon-run command uses; this proves its effective feed config is
+// identical no matter the cwd, even when conflicting project hookwise.yaml feeds
+// blocks are present.
+func TestResolveDaemonConfig_IdenticalAcrossColdStartCwds(t *testing.T) {
+	globalDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", globalDir)
+	// Global config: weather ON, news OFF.
+	globalConfig := `
+version: 1
+feeds:
+  weather:
+    enabled: true
+  news:
+    enabled: false
+`
+	require.NoError(t, os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte(globalConfig), 0o644))
+
+	// Two project dirs with CONFLICTING feed blocks — under the old per-project
+	// model each would have driven a different daemon feed set.
+	dirA := t.TempDir() // weather OFF, news ON
+	require.NoError(t, os.WriteFile(filepath.Join(dirA, "hookwise.yaml"), []byte(`
+feeds:
+  weather:
+    enabled: false
+  news:
+    enabled: true
+`), 0o644))
+	dirB := t.TempDir() // weather ON, calendar ON
+	require.NoError(t, os.WriteFile(filepath.Join(dirB, "hookwise.yaml"), []byte(`
+feeds:
+  weather:
+    enabled: true
+  calendar:
+    enabled: true
+`), 0o644))
+
+	// Precondition: LoadConfig(dir) DOES diverge by project (the overlay is real),
+	// so the determinism below is meaningful, not vacuous.
+	cfgA, err := core.LoadConfig(dirA)
+	require.NoError(t, err)
+	cfgB, err := core.LoadConfig(dirB)
+	require.NoError(t, err)
+	require.NotEqual(t, cfgA.Feeds.Weather.Enabled, cfgB.Feeds.Weather.Enabled,
+		"precondition: project overlays must diverge for the determinism test to be meaningful")
+
+	// resolveDaemonConfig must be IDENTICAL regardless of cwd.
+	t.Chdir(dirA)
+	daemonA := resolveDaemonConfig()
+	t.Chdir(dirB)
+	daemonB := resolveDaemonConfig()
+
+	assert.Equal(t, daemonA.Feeds, daemonB.Feeds,
+		"daemon feed config must be identical across cold-start cwds (#89)")
+	// And it reflects the GLOBAL config (weather ON, news OFF), not either project.
+	assert.True(t, daemonA.Feeds.Weather.Enabled, "daemon must honor global weather=ON, not project override")
+	assert.False(t, daemonA.Feeds.News.Enabled, "daemon must honor global news=OFF, not project override")
+}
+
+// With no global config file, resolveDaemonConfig fails open to defaults
+// (ARCH-1) rather than crashing or adopting a project config.
+func TestResolveDaemonConfig_NoGlobalFileFailsOpenToDefaults(t *testing.T) {
+	globalDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", globalDir)
+
+	cfg := resolveDaemonConfig()
+	assert.Equal(t, core.GetDefaultConfig().Feeds, cfg.Feeds)
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -321,26 +321,55 @@ func LoadConfig(projectDir string) (HooksConfig, error) {
 	if projectRaw == nil {
 		includeBaseDir = filepath.Dir(globalConfigPath)
 	}
-	merged, err = ResolveIncludes(merged, includeBaseDir)
+	return finalizeConfig(merged, includeBaseDir)
+}
+
+// LoadGlobalConfig loads ONLY the global config (GetStateDir()/config.yaml) with
+// no project overlay. This is the canonical config source for the singleton feed
+// daemon (#89): because one daemon process is shared by every project/session,
+// its config must be deterministic regardless of which directory cold-started
+// it. The pipeline mirrors LoadConfig (includes -> env interpolation -> defaults
+// backfill) minus the project merge.
+func LoadGlobalConfig() (HooksConfig, error) {
+	globalConfigPath := filepath.Join(GetStateDir(), "config.yaml")
+
+	globalRaw, err := readYAMLFile(globalConfigPath)
+	if err != nil {
+		return HooksConfig{}, fmt.Errorf("reading global config: %w", err)
+	}
+	if globalRaw == nil {
+		return GetDefaultConfig(), nil
+	}
+
+	return finalizeConfig(globalRaw, filepath.Dir(globalConfigPath))
+}
+
+// finalizeConfig runs the back half of the config pipeline shared by LoadConfig
+// and LoadGlobalConfig: include resolution, env-var interpolation, then YAML
+// round-trip unmarshalling into HooksConfig (starting from defaults so missing
+// fields get sensible values). includeBaseDir is the directory includes resolve
+// relative to.
+func finalizeConfig(merged map[string]interface{}, includeBaseDir string) (HooksConfig, error) {
+	merged, err := ResolveIncludes(merged, includeBaseDir)
 	if err != nil {
 		return HooksConfig{}, fmt.Errorf("resolving includes: %w", err)
 	}
 
-	// Step 4: Interpolate environment variables
+	// Interpolate environment variables.
 	interpolated := InterpolateEnvVars(merged)
 	merged, ok := interpolated.(map[string]interface{})
 	if !ok {
 		return HooksConfig{}, fmt.Errorf("env var interpolation returned unexpected type %T", interpolated)
 	}
 
-	// Step 5: Marshal back to YAML and unmarshal into struct.
-	// This leverages Go's yaml tags for snake_case -> struct field mapping.
+	// Marshal back to YAML and unmarshal into struct. This leverages Go's yaml
+	// tags for snake_case -> struct field mapping.
 	yamlBytes, err := yaml.Marshal(merged)
 	if err != nil {
 		return HooksConfig{}, fmt.Errorf("re-marshaling config: %w", err)
 	}
 
-	// Start with defaults so missing fields get sensible values
+	// Start with defaults so missing fields get sensible values.
 	config := GetDefaultConfig()
 	if err := yaml.Unmarshal(yamlBytes, &config); err != nil {
 		return HooksConfig{}, fmt.Errorf("unmarshaling config: %w", err)

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -1026,6 +1026,100 @@ analytics:
 	}
 }
 
+// LoadGlobalConfig sources the singleton daemon's config from the global file
+// ONLY (#89). It must never observe a project hookwise.yaml, so its result is
+// deterministic regardless of which directory cold-started the daemon.
+func TestLoadGlobalConfig_ReadsGlobalOnly(t *testing.T) {
+	globalDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", globalDir)
+
+	globalConfig := `
+version: 1
+feeds:
+  weather:
+    enabled: true
+    interval_seconds: 900
+  news:
+    enabled: false
+`
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte(globalConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobalConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.Feeds.Weather.Enabled {
+		t.Error("expected weather enabled from global config")
+	}
+	if cfg.Feeds.Weather.IntervalSeconds != 900 {
+		t.Errorf("expected weather interval 900, got %d", cfg.Feeds.Weather.IntervalSeconds)
+	}
+	if cfg.Feeds.News.Enabled {
+		t.Error("expected news disabled from global config")
+	}
+}
+
+// A project hookwise.yaml in the working directory must NOT influence
+// LoadGlobalConfig — that is the whole point of the global-only source.
+func TestLoadGlobalConfig_IgnoresProjectOverlayInCwd(t *testing.T) {
+	globalDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", globalDir)
+	globalConfig := `
+version: 1
+feeds:
+  weather:
+    enabled: true
+`
+	if err := os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte(globalConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A project config in cwd that would flip weather off under LoadConfig.
+	projectDir := t.TempDir()
+	projectConfig := `
+feeds:
+  weather:
+    enabled: false
+`
+	if err := os.WriteFile(filepath.Join(projectDir, "hookwise.yaml"), []byte(projectConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(projectDir)
+
+	// Sanity: LoadConfig(cwd) DOES see the project override (overlay is real).
+	proj, err := LoadConfig(projectDir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if proj.Feeds.Weather.Enabled {
+		t.Fatal("precondition failed: project overlay should disable weather under LoadConfig")
+	}
+
+	// LoadGlobalConfig must ignore the project overlay entirely.
+	global, err := LoadGlobalConfig()
+	if err != nil {
+		t.Fatalf("LoadGlobalConfig: %v", err)
+	}
+	if !global.Feeds.Weather.Enabled {
+		t.Error("LoadGlobalConfig must ignore the project overlay; weather should stay enabled")
+	}
+}
+
+func TestLoadGlobalConfig_NoFileReturnsDefaults(t *testing.T) {
+	globalDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", globalDir)
+
+	cfg, err := LoadGlobalConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(cfg, GetDefaultConfig()) {
+		t.Error("expected defaults when no global config file exists")
+	}
+}
+
 func TestLoadConfig_GuardsArrayReplaces(t *testing.T) {
 	tmpDir := t.TempDir()
 	globalDir := filepath.Join(tmpDir, "global")


### PR DESCRIPTION
## What & why

The feed daemon is a **singleton** (one socket, one cache, one process per state dir), but it sourced its config from whichever project's `hookwise.yaml` cold-started it — read once at startup, never reloaded. Because `EnsureDaemon` is connect-or-start and discards the caller's config when a daemon already runs, the project that won the cold-start race **froze the feed config for every other project and session** (#89). A session in project A silently drove the feeds for project B.

## Change

- **`core.LoadGlobalConfig()`** — the same resolution pipeline as `LoadConfig` (includes → env interpolation → defaults backfill) but reading **only** the global `config.yaml`, with no project overlay. Shared back-half extracted into `finalizeConfig` so the two loaders don't duplicate it (behavior-preserving for `LoadConfig`).
- **`daemon run`** now resolves its **entire** config — feeds, daemon, **and** analytics snapshots — from `LoadGlobalConfig()` via `resolveDaemonConfig()`. Deterministic regardless of cold-start cwd; fail-open to defaults (ARCH-1). The legacy `--config` flag is accepted-but-ignored for spawn back-compat.

## Tests

- `TestResolveDaemonConfig_IdenticalAcrossColdStartCwds` — proves the daemon's effective feed config is **identical** across two different cold-start cwds carrying conflicting project feed blocks (the #89 determinism guarantee), with a precondition asserting `LoadConfig(dir)` genuinely diverges so the test isn't vacuous.
- `TestResolveDaemonConfig_NoGlobalFileFailsOpenToDefaults` — ARCH-1 fail-open.
- `TestLoadGlobalConfig_*` — global-only load, ignores a project overlay in cwd, defaults when absent.

Guarded gate green locally (`GOMEMLIMIT=4GiB go test -race -p 2`) across `internal/core`, `cmd/hookwise`, `internal/feeds`.

This is slice 1 of 2. Slice 2 wires `hookwise doctor` to report against the daemon's effective runtime config over a new `GET /feeds` socket route (#1), with the project-feeds-ignored back-compat warning.

Design + recorded Grok adversarial design audit drove this (3 BLOCKERs folded in, incl. sourcing analytics from global too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The daemon now uses a single global configuration source, so it behaves consistently regardless of the current project folder.
* **Bug Fixes**
  * Fixed cases where project-specific settings could unexpectedly change daemon behavior.
  * If no global config is present, the daemon now falls back to safe default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->