### PR TITLE
feat(doctor): report feed health vs daemon effective config (#1)

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -1433,15 +1433,18 @@ func TestDoctorFeedHealthStale(t *testing.T) {
 	cacheDir := filepath.Join(stateDir, "state")
 	os.MkdirAll(cacheDir, 0o700)
 
-	// Config with weather interval = 60 seconds.
-	configYAML := `version: 1
+	// Feed config lives in the GLOBAL config now — the singleton daemon sources
+	// feeds canonically from there (#89), and doctor reports against that. Weather
+	// interval = 60s.
+	globalYAML := `version: 1
 feeds:
   weather:
     enabled: true
     interval_seconds: 60
 `
-	configPath := filepath.Join(tmpDir, core.ProjectConfigFile)
-	os.WriteFile(configPath, []byte(configYAML), 0o644)
+	os.WriteFile(filepath.Join(stateDir, "config.yaml"), []byte(globalYAML), 0o644)
+	// Minimal project config so Check 1 passes without a project feeds: block.
+	os.WriteFile(filepath.Join(tmpDir, core.ProjectConfigFile), []byte("version: 1\n"), 0o644)
 
 	// Write a stale weather feed (timestamp 5 minutes ago, interval is 60s, threshold is 120s).
 	staleTime := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
@@ -1477,15 +1480,18 @@ func TestDoctorFeedHealthEmptyData(t *testing.T) {
 	cacheDir := filepath.Join(stateDir, "state")
 	os.MkdirAll(cacheDir, 0o700)
 
-	// Enable weather so this test exercises the empty-data WARN, not the
-	// disabled-feed suppression (a disabled feed's empty cache is benign).
-	configYAML := `version: 1
+	// Enable weather in the GLOBAL config (the daemon's canonical feed source,
+	// #89) so this test exercises the empty-data WARN, not the disabled-feed
+	// suppression (a disabled feed's empty cache is benign).
+	globalYAML := `version: 1
 feeds:
   weather:
     enabled: true
     interval_seconds: 600
 `
-	os.WriteFile(filepath.Join(tmpDir, core.ProjectConfigFile), []byte(configYAML), 0o644)
+	os.WriteFile(filepath.Join(stateDir, "config.yaml"), []byte(globalYAML), 0o644)
+	// Minimal project config so Check 1 passes without a project feeds: block.
+	os.WriteFile(filepath.Join(tmpDir, core.ProjectConfigFile), []byte("version: 1\n"), 0o644)
 
 	// Fresh timestamp, but an empty data object.
 	now := time.Now().UTC().Format(time.RFC3339)

--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -128,7 +129,8 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// Use GetStateDir() to respect HOOKWISE_STATE_DIR env override.
 	socketPath := filepath.Join(core.GetStateDir(), "daemon.sock")
 	client := feeds.NewDaemonClient(socketPath)
-	if client.IsRunning() {
+	daemonUp := client.IsRunning()
+	if daemonUp {
 		health, healthErr := client.Health()
 		if healthErr == nil {
 			fmt.Fprintf(w, "PASS  daemon: running (pid: %v, uptime: %v)\n",
@@ -140,8 +142,31 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(w, "INFO  daemon: not running (start with 'hookwise daemon start')")
 	}
 
-	// Check 5: Feed health (reuses doctorCfg loaded above).
-	warnings += checkFeedHealth(w, filepath.Join(stateDir, "state"), doctorCfg)
+	// Resolve the feed config doctor reports against: the daemon's runtime view
+	// is authoritative (#1), falling back to the on-disk global config when the
+	// daemon is down or unreachable.
+	effectiveFeeds, feedSource := resolveEffectiveFeeds(client, daemonUp)
+	switch feedSource {
+	case "global-after-error":
+		fmt.Fprintln(w, "INFO  feed-config: daemon feed query failed; reporting against on-disk global config")
+	case "global":
+		fmt.Fprintln(w, "INFO  feed-config: daemon not running; reporting against on-disk global config")
+	}
+
+	// Drift: the daemon reads config once at startup. If it is up but its runtime
+	// feed config no longer matches the on-disk global config, the user edited the
+	// config without restarting — warn so the change isn't silently un-applied.
+	if feedSource == "daemon" {
+		warnings += checkFeedConfigDrift(w, effectiveFeeds)
+	}
+
+	// Back-compat: a project-level feeds: block is ignored by the singleton daemon
+	// (#89); tell the user to migrate it to the global config.
+	warnings += checkProjectFeedsIgnored(w, cwd)
+
+	// Check 5: Feed health against the daemon's effective feed config. doctorCfg
+	// (the project config) is still used for the status-line segment cross-check.
+	warnings += checkFeedHealth(w, filepath.Join(stateDir, "state"), effectiveFeeds, doctorCfg)
 
 	// Check 7: Hook safety — scan Claude Code settings for hook sprawl, missing
 	// binaries, network-dependent hot-path hooks, and duplicate/overlapping
@@ -228,64 +253,155 @@ func renderHookFinding(w io.Writer, f hooks.Finding) {
 }
 
 // knownBuiltinFeeds is the canonical list of feed names that have a Go producer.
-// Mirrors the cases in getFeedInterval's switch statement.
+// It seeds the builtin half of feedsFromConfig's enumeration.
 var knownBuiltinFeeds = []string{"project", "news", "calendar", "weather", "memories", "insights"}
 
-// isKnownFeed returns true if feedName corresponds to a built-in producer or to
-// a custom feed declared in cfg. Unknown orphan files (written by old versions or
-// by the Python TUI) return false and should be silently skipped.
-func isKnownFeed(feedName string, cfg *core.HooksConfig) bool {
-	for _, b := range knownBuiltinFeeds {
-		if feedName == b {
-			return true
-		}
-	}
-	if cfg != nil {
-		for _, c := range cfg.Feeds.Custom {
-			if feedName == c.Name {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// isFeedEnabled reports whether feedName is enabled in cfg. It mirrors the cases
-// in getFeedInterval's switch (and thus knownBuiltinFeeds); the two are pinned
-// together by TestIsFeedEnabled_MirrorsBuiltins. A disabled feed is not expected
-// to be polled, so checkFeedHealth uses this to downgrade a disabled feed's
-// stale/placeholder/empty cache from a misleading WARN to a benign INFO. Unknown
-// or custom feeds consult cfg.Feeds.Custom; a nil config reports disabled.
-func isFeedEnabled(cfg *core.HooksConfig, feedName string) bool {
+// feedsFromConfig builds the doctor-side effective feed map from a config. It is
+// the fallback used when the daemon is down: it mirrors what the daemon's
+// EffectiveFeeds would report for the same config because it resolves
+// enabled/interval through the SAME shared feeds.FeedEnabled /
+// feeds.EffectiveIntervalSeconds helpers the daemon uses — so doctor can never
+// report a feed enabled/stale differently from what the daemon actually polls
+// (#1). A nil config yields an empty map (all caches treated as orphans).
+func feedsFromConfig(cfg *core.HooksConfig) map[string]feeds.FeedStatus {
+	out := map[string]feeds.FeedStatus{}
 	if cfg == nil {
-		return false
+		return out
 	}
-	switch feedName {
-	case "project":
-		return cfg.Feeds.Project.Enabled
-	case "calendar":
-		return cfg.Feeds.Calendar.Enabled
-	case "news":
-		return cfg.Feeds.News.Enabled
-	case "insights":
-		return cfg.Feeds.Insights.Enabled
-	case "weather":
-		return cfg.Feeds.Weather.Enabled
-	case "memories":
-		return cfg.Feeds.Memories.Enabled
-	default:
-		for _, cf := range cfg.Feeds.Custom {
-			if cf.Name == feedName {
-				return cf.Enabled
-			}
+	names := append([]string{}, knownBuiltinFeeds...)
+	for _, c := range cfg.Feeds.Custom {
+		names = append(names, c.Name)
+	}
+	for _, name := range names {
+		out[name] = feeds.FeedStatus{
+			Name:            name,
+			Enabled:         feeds.FeedEnabled(cfg.Feeds, name),
+			IntervalSeconds: feeds.EffectiveIntervalSeconds(cfg.Feeds, name),
 		}
-		return false
 	}
+	return out
 }
 
-// checkFeedHealth reads feed cache files and reports placeholder/stale feeds.
-// Returns the number of warnings emitted.
-func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
+// resolveEffectiveFeeds returns the feed config doctor should report against,
+// plus a source tag. The daemon's runtime view (GET /feeds) is authoritative
+// (#1); when the daemon is down or the query fails, fall back to the on-disk
+// global config — what the daemon WOULD poll on next start — labeling it so the
+// user knows it is best-effort. Always fail-open (ARCH-1): never returns an
+// error, only an empty map in the worst case.
+//
+// source is one of: "daemon" (authoritative), "global" (daemon down),
+// "global-after-error" (daemon was up but the /feeds query failed).
+func resolveEffectiveFeeds(client *feeds.DaemonClient, daemonUp bool) (m map[string]feeds.FeedStatus, source string) {
+	if daemonUp {
+		if list, err := client.EffectiveFeeds(); err == nil {
+			out := make(map[string]feeds.FeedStatus, len(list))
+			for _, fs := range list {
+				out[fs.Name] = fs
+			}
+			return out, "daemon"
+		}
+		// Daemon was up but the query failed — fall through to on-disk, labeled.
+		gcfg, err := core.LoadGlobalConfig()
+		if err != nil {
+			return map[string]feeds.FeedStatus{}, "global-after-error"
+		}
+		return feedsFromConfig(&gcfg), "global-after-error"
+	}
+	gcfg, err := core.LoadGlobalConfig()
+	if err != nil {
+		return map[string]feeds.FeedStatus{}, "global"
+	}
+	return feedsFromConfig(&gcfg), "global"
+}
+
+// checkFeedConfigDrift warns when the daemon is polling a feed config that no
+// longer matches the on-disk global config — i.e. the user edited the global
+// config but did not restart the daemon (the daemon reads config once at
+// startup). Without this, a post-edit global config LOOKS applied while the
+// daemon keeps polling the old set. Only meaningful when daemonFeeds came from
+// the daemon socket. Returns 1 if it warned.
+//
+// The comparison is symmetric over the UNION of feed names: a feed present on
+// only one side (a custom feed added to or removed from the on-disk config
+// without a restart) is drift too, not just an enabled/interval change on a feed
+// both sides know about.
+func checkFeedConfigDrift(w io.Writer, daemonFeeds map[string]feeds.FeedStatus) int {
+	gcfg, err := core.LoadGlobalConfig()
+	if err != nil {
+		return 0 // fail-open: can't compare, don't warn
+	}
+	onDisk := feedsFromConfig(&gcfg)
+
+	drifted := map[string]bool{}
+	for name, d := range daemonFeeds {
+		o, ok := onDisk[name]
+		if !ok || d.Enabled != o.Enabled || d.IntervalSeconds != o.IntervalSeconds {
+			drifted[name] = true
+		}
+	}
+	for name := range onDisk {
+		if _, ok := daemonFeeds[name]; !ok {
+			drifted[name] = true
+		}
+	}
+	if len(drifted) == 0 {
+		return 0
+	}
+
+	names := make([]string, 0, len(drifted))
+	for name := range drifted {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	fmt.Fprintf(w, "WARN  feed-config: daemon is polling a stale feed config (differs for: %s) — restart the daemon (hookwise daemon stop) to apply changes to %s\n",
+		strings.Join(names, ", "), filepath.Join(core.GetStateDir(), "config.yaml"))
+	return 1
+}
+
+// checkProjectFeedsIgnored warns when the project hookwise.yaml in cwd carries a
+// feeds: block. Since the daemon is a singleton that sources feed config from
+// the global config only (#89), a project-level feeds: block is silently
+// ignored for polling — so the user must be told to move those keys to the
+// global config, or their per-project feed settings vanish. Returns 1 if warned.
+func checkProjectFeedsIgnored(w io.Writer, cwd string) int {
+	keys := projectFeedKeys(cwd)
+	if len(keys) == 0 {
+		return 0
+	}
+	fmt.Fprintf(w, "WARN  config: feed settings in this project's %s are ignored — the daemon uses %s (move these feed keys there: %s)\n",
+		core.ProjectConfigFile, filepath.Join(core.GetStateDir(), "config.yaml"), strings.Join(keys, ", "))
+	return 1
+}
+
+// projectFeedKeys returns the sorted top-level keys under the feeds: block of
+// cwd/hookwise.yaml, or nil if there is no project config or no feeds: block.
+func projectFeedKeys(cwd string) []string {
+	data, err := os.ReadFile(filepath.Join(cwd, core.ProjectConfigFile))
+	if err != nil {
+		return nil
+	}
+	var raw map[string]interface{}
+	if yaml.Unmarshal(data, &raw) != nil {
+		return nil
+	}
+	feedsRaw, ok := raw["feeds"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	keys := make([]string, 0, len(feedsRaw))
+	for k := range feedsRaw {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// checkFeedHealth reads feed cache files and reports placeholder/stale feeds
+// against `effective` — the feed config the daemon is actually polling with
+// (#1), resolved by the caller from the daemon socket (or the on-disk global
+// config as a fallback). `cfg` is the PROJECT config, used only for the
+// status-line segment cross-reference. Returns the number of warnings emitted.
+func checkFeedHealth(w io.Writer, cacheDir string, effective map[string]feeds.FeedStatus, cfg *core.HooksConfig) int {
 	warnings := 0
 
 	feedFiles, err := filepath.Glob(filepath.Join(cacheDir, "*.json"))
@@ -302,9 +418,11 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 			continue
 		}
 		feedName := strings.TrimSuffix(base, ".json")
-		// Skip orphan cache files that have no Go producer and are not in the
-		// config's custom feeds. Only known feeds produce actionable diagnostics.
-		if !isKnownFeed(feedName, cfg) {
+		// Skip orphan cache files that the daemon is not polling (no producer in
+		// its effective config). Only feeds the daemon actually runs produce
+		// actionable diagnostics.
+		fs, known := effective[feedName]
+		if !known {
 			continue
 		}
 
@@ -340,7 +458,7 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 		// outcomes to a benign INFO "disabled" line. A disabled feed that
 		// nonetheless carries fresh, real data still falls through to the healthy
 		// "OK" path below, so an actively-polled-elsewhere feed is not mislabelled.
-		enabled := isFeedEnabled(cfg, feedName)
+		enabled := fs.Enabled
 		reportDisabled := func() {
 			fmt.Fprintf(w, "INFO  feed:%s: disabled (cache not refreshed)\n", feedName)
 			feedStatuses[feedName] = "disabled"
@@ -398,8 +516,8 @@ func checkFeedHealth(w io.Writer, cacheDir string, cfg *core.HooksConfig) int {
 
 		age := time.Since(ts).Truncate(time.Second)
 
-		// Check staleness.
-		interval := getFeedInterval(cfg, feedName)
+		// Check staleness against the daemon's effective poll interval.
+		interval := fs.IntervalSeconds
 		if interval > 0 {
 			staleThreshold := time.Duration(2*interval) * time.Second
 			if age > staleThreshold {
@@ -519,35 +637,6 @@ func checkCostHonesty(w io.Writer, dbPath string, costEnabled bool) int {
 	default:
 		fmt.Fprintf(w, "PASS  cost: $%.2f across %d session(s) today\n",
 			summary.EstimatedCostUSD, summary.TotalSessions)
-		return 0
-	}
-}
-
-// getFeedInterval returns the configured interval_seconds for a feed name.
-func getFeedInterval(cfg *core.HooksConfig, feedName string) int {
-	if cfg == nil {
-		return 0
-	}
-	switch feedName {
-	case "project":
-		return cfg.Feeds.Project.IntervalSeconds
-	case "calendar":
-		return cfg.Feeds.Calendar.IntervalSeconds
-	case "news":
-		return cfg.Feeds.News.IntervalSeconds
-	case "insights":
-		return cfg.Feeds.Insights.IntervalSeconds
-	case "weather":
-		return cfg.Feeds.Weather.IntervalSeconds
-	case "memories":
-		return cfg.Feeds.Memories.IntervalSeconds
-	default:
-		// Check custom feeds.
-		for _, cf := range cfg.Feeds.Custom {
-			if cf.Name == feedName {
-				return cf.IntervalSeconds
-			}
-		}
 		return 0
 	}
 }

--- a/cmd/hookwise/cmd_doctor_effective_test.go
+++ b/cmd/hookwise/cmd_doctor_effective_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vishnujayvel/hookwise/internal/core"
+	"github.com/vishnujayvel/hookwise/internal/feeds"
+)
+
+// A project hookwise.yaml with a feeds: block is ignored by the singleton daemon
+// (#89); doctor must WARN and list the keys so the user migrates them to global.
+func TestCheckProjectFeedsIgnored_WarnsAndListsKeys(t *testing.T) {
+	cwd := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, core.ProjectConfigFile), []byte(`
+feeds:
+  calendar:
+    enabled: true
+  weather:
+    latitude: 1.0
+`), 0o644))
+
+	var buf bytes.Buffer
+	count := checkProjectFeedsIgnored(&buf, cwd)
+	out := buf.String()
+
+	assert.Equal(t, 1, count)
+	assert.Contains(t, out, "WARN  config:")
+	assert.Contains(t, out, "are ignored")
+	// Lists the feed keys (sorted), including a key that is only a sub-setting.
+	assert.Contains(t, out, "calendar")
+	assert.Contains(t, out, "weather")
+}
+
+// No project config, or a project config with no feeds: block, must not warn.
+func TestCheckProjectFeedsIgnored_NoFeedsBlockSilent(t *testing.T) {
+	cwd := t.TempDir()
+	// (a) no project config at all.
+	var buf bytes.Buffer
+	assert.Equal(t, 0, checkProjectFeedsIgnored(&buf, cwd))
+
+	// (b) project config without a feeds block.
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, core.ProjectConfigFile), []byte(`
+guards:
+  - match: "Read"
+    action: warn
+`), 0o644))
+	buf.Reset()
+	assert.Equal(t, 0, checkProjectFeedsIgnored(&buf, cwd))
+	assert.Empty(t, buf.String())
+}
+
+// When the daemon's runtime feed config differs from the on-disk global config,
+// doctor warns to restart the daemon (config is read once at startup).
+func TestCheckFeedConfigDrift(t *testing.T) {
+	globalDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", globalDir)
+	require.NoError(t, os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte(`
+version: 1
+feeds:
+  weather:
+    enabled: true
+    interval_seconds: 900
+`), 0o644))
+
+	gcfg, err := core.LoadGlobalConfig()
+	require.NoError(t, err)
+	onDisk := feedsFromConfig(&gcfg)
+
+	// (a) Daemon polling the same config → no drift.
+	var buf bytes.Buffer
+	assert.Equal(t, 0, checkFeedConfigDrift(&buf, onDisk))
+	assert.Empty(t, buf.String())
+
+	// (b) Daemon polling a diverged config (weather disabled) → drift WARN.
+	drifted := map[string]feeds.FeedStatus{}
+	for k, v := range onDisk {
+		drifted[k] = v
+	}
+	w := drifted["weather"]
+	w.Enabled = false
+	drifted["weather"] = w
+
+	buf.Reset()
+	assert.Equal(t, 1, checkFeedConfigDrift(&buf, drifted))
+	assert.Contains(t, buf.String(), "WARN  feed-config:")
+	assert.Contains(t, buf.String(), "restart the daemon")
+	assert.Contains(t, buf.String(), "weather", "drift WARN should name the drifted feed")
+
+	// (c) Daemon polls a custom feed that was removed from the on-disk config
+	// (asymmetric membership) → still drift, even though no shared feed differs.
+	membership := map[string]feeds.FeedStatus{}
+	for k, v := range onDisk {
+		membership[k] = v
+	}
+	membership["stocks"] = feeds.FeedStatus{Name: "stocks", Enabled: true, IntervalSeconds: 120}
+
+	buf.Reset()
+	assert.Equal(t, 1, checkFeedConfigDrift(&buf, membership))
+	assert.Contains(t, buf.String(), "stocks", "drift WARN must catch a daemon-only custom feed")
+}
+
+// With the daemon down, resolveEffectiveFeeds falls back to the on-disk global
+// config and reports source "global".
+func TestResolveEffectiveFeeds_DaemonDownFallsBackToGlobal(t *testing.T) {
+	globalDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", globalDir)
+	require.NoError(t, os.WriteFile(filepath.Join(globalDir, "config.yaml"), []byte(`
+version: 1
+feeds:
+  weather:
+    enabled: true
+    interval_seconds: 900
+`), 0o644))
+
+	// A client pointed at a socket that does not exist (daemon down).
+	client := feeds.NewDaemonClient(filepath.Join(globalDir, "nonexistent.sock"))
+	m, source := resolveEffectiveFeeds(client, false)
+
+	assert.Equal(t, "global", source)
+	require.Contains(t, m, "weather")
+	assert.True(t, m["weather"].Enabled)
+	assert.Equal(t, 900, m["weather"].IntervalSeconds)
+}

--- a/cmd/hookwise/cmd_doctor_feedhealth_test.go
+++ b/cmd/hookwise/cmd_doctor_feedhealth_test.go
@@ -68,7 +68,7 @@ func TestCheckFeedHealth_OrphanSkipped(t *testing.T) {
 	cfg.Feeds.Custom = nil
 
 	var buf bytes.Buffer
-	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	count := checkFeedHealth(&buf, cacheDir, feedsFromConfig(&cfg), &cfg)
 	out := buf.String()
 
 	// Known feed must still warn.
@@ -96,7 +96,7 @@ func TestCheckFeedHealth_DisabledFeedStaleNotWarned(t *testing.T) {
 	cfg.Feeds.News.Enabled = false // disabled
 
 	var buf bytes.Buffer
-	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	count := checkFeedHealth(&buf, cacheDir, feedsFromConfig(&cfg), &cfg)
 	out := buf.String()
 
 	assert.NotContains(t, out, "WARN  feed:news", "disabled feed must not produce a WARN")
@@ -117,7 +117,7 @@ func TestCheckFeedHealth_EnabledFeedStaleStillWarns(t *testing.T) {
 	cfg.Feeds.Calendar.Enabled = true // enabled
 
 	var buf bytes.Buffer
-	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	count := checkFeedHealth(&buf, cacheDir, feedsFromConfig(&cfg), &cfg)
 	out := buf.String()
 
 	assert.Contains(t, out, "WARN  feed:calendar: stale data", "enabled stale feed must still warn")
@@ -135,7 +135,7 @@ func TestCheckFeedHealth_DisabledFeedPlaceholderNotWarned(t *testing.T) {
 	cfg.Feeds.Memories.Enabled = false
 
 	var buf bytes.Buffer
-	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	count := checkFeedHealth(&buf, cacheDir, feedsFromConfig(&cfg), &cfg)
 	out := buf.String()
 
 	assert.NotContains(t, out, "WARN  feed:memories", "disabled placeholder feed must not warn")
@@ -158,7 +158,7 @@ func TestCheckFeedHealth_CustomFeedTreatedAsKnown(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	count := checkFeedHealth(&buf, cacheDir, feedsFromConfig(&cfg), &cfg)
 	out := buf.String()
 
 	assert.Contains(t, out, "feed:pulse", "custom feed (pulse) must appear in output")
@@ -210,7 +210,7 @@ func TestCheckFeedHealth_InsightsZeroSessionsWarns(t *testing.T) {
 	cfg.Feeds.Insights.Enabled = true
 
 	var buf bytes.Buffer
-	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	count := checkFeedHealth(&buf, cacheDir, feedsFromConfig(&cfg), &cfg)
 	out := buf.String()
 
 	assert.Contains(t, out, "WARN  feed:insights: cache fresh but no sessions recorded",
@@ -230,7 +230,7 @@ func TestCheckFeedHealth_InsightsWithSessionsOK(t *testing.T) {
 	cfg.Feeds.Insights.Enabled = true
 
 	var buf bytes.Buffer
-	count := checkFeedHealth(&buf, cacheDir, &cfg)
+	count := checkFeedHealth(&buf, cacheDir, feedsFromConfig(&cfg), &cfg)
 	out := buf.String()
 
 	assert.Contains(t, out, "feed:insights: OK",

--- a/cmd/hookwise/cmd_doctor_feedlist_test.go
+++ b/cmd/hookwise/cmd_doctor_feedlist_test.go
@@ -4,93 +4,76 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/vishnujayvel/hookwise/internal/core"
+	"github.com/vishnujayvel/hookwise/internal/feeds"
 )
 
-// TestKnownBuiltinFeeds_MirrorsGetFeedInterval enforces the invariant documented
-// on knownBuiltinFeeds ("Mirrors the cases in getFeedInterval's switch
-// statement"). The two lists are hand-maintained in separate places; if they
-// drift, doctor misbehaves — a builtin recognised by isKnownFeed but absent from
-// getFeedInterval's switch resolves to interval 0, and a name in the switch but
-// missing from knownBuiltinFeeds makes isKnownFeed treat a real feed's orphan
-// cache file as unknown (silently skipped). Nothing else guarded this; this pins
-// it. Each builtin is given a DISTINCT interval so a missing switch case (which
-// would fall through to the default 0) is caught per-feed.
-func TestKnownBuiltinFeeds_MirrorsGetFeedInterval(t *testing.T) {
-	cfg := &core.HooksConfig{}
-	cfg.Feeds.Project.IntervalSeconds = 11
-	cfg.Feeds.News.IntervalSeconds = 22
-	cfg.Feeds.Calendar.IntervalSeconds = 33
-	cfg.Feeds.Weather.IntervalSeconds = 44
-	cfg.Feeds.Memories.IntervalSeconds = 55
-	cfg.Feeds.Insights.IntervalSeconds = 66
-
-	// The test's own expectation map must cover exactly the builtin list — if a
-	// builtin is added to knownBuiltinFeeds without updating this map, the
-	// completeness check below fails, forcing the author to also give it an
-	// interval field (and thus a getFeedInterval case).
-	wantInterval := map[string]int{
-		"project":  11,
-		"news":     22,
-		"calendar": 33,
-		"weather":  44,
-		"memories": 55,
-		"insights": 66,
-	}
-
-	require.Len(t, wantInterval, len(knownBuiltinFeeds),
-		"wantInterval map must cover exactly knownBuiltinFeeds")
-
-	for _, feed := range knownBuiltinFeeds {
-		want, ok := wantInterval[feed]
-		require.Truef(t, ok, "knownBuiltinFeeds entry %q has no expected interval — a builtin was added without a getFeedInterval mapping", feed)
-		assert.Equalf(t, want, getFeedInterval(cfg, feed),
-			"getFeedInterval(%q) must resolve via its own switch case, not fall through to the default 0", feed)
-	}
-}
-
-// TestIsFeedEnabled_MirrorsBuiltins enforces that isFeedEnabled has a switch case
-// for every builtin (parallel to getFeedInterval). A builtin missing from the
-// switch falls through to the default and is treated as permanently disabled,
-// which would suppress its diagnostics — the opposite failure of the stale-feed
-// bug. Each builtin is enabled here so a missing case (default false) is caught.
-func TestIsFeedEnabled_MirrorsBuiltins(t *testing.T) {
-	cfg := &core.HooksConfig{}
-	cfg.Feeds.Project.Enabled = true
-	cfg.Feeds.News.Enabled = true
-	cfg.Feeds.Calendar.Enabled = true
+// TestFeedsFromConfig_AgreesWithDaemonEffectiveFeeds is the #1 guarantee: doctor's
+// per-feed verdict (enabled + interval) must match what the daemon actually
+// polls. Doctor's fallback builder (feedsFromConfig) and the daemon's
+// EffectiveFeeds both resolve through the SAME shared feeds.FeedEnabled /
+// feeds.EffectiveIntervalSeconds helpers, so they cannot diverge by
+// construction; this pins that invariant (and that knownBuiltinFeeds matches the
+// daemon's registered builtins).
+func TestFeedsFromConfig_AgreesWithDaemonEffectiveFeeds(t *testing.T) {
+	cfg := core.GetDefaultConfig()
 	cfg.Feeds.Weather.Enabled = true
-	cfg.Feeds.Memories.Enabled = true
-	cfg.Feeds.Insights.Enabled = true
-
-	for _, feed := range knownBuiltinFeeds {
-		assert.Truef(t, isFeedEnabled(cfg, feed),
-			"isFeedEnabled(%q) must resolve via its own switch case, not fall through to default false", feed)
+	cfg.Feeds.Weather.IntervalSeconds = 900
+	cfg.Feeds.Calendar.Enabled = true
+	cfg.Feeds.Calendar.IntervalSeconds = 300
+	cfg.Feeds.News.Enabled = false
+	cfg.Feeds.Custom = []core.CustomFeedConfig{
+		{Name: "pulse", Command: "echo {}", IntervalSeconds: 120, Enabled: true},
 	}
 
-	// A declared custom feed reflects its Enabled flag; unknown → false; nil → false.
-	cfg.Feeds.Custom = []core.CustomFeedConfig{{Name: "mycustom", Enabled: true}}
-	assert.True(t, isFeedEnabled(cfg, "mycustom"), "enabled custom feed must report enabled")
-	assert.False(t, isFeedEnabled(cfg, "nonexistent-orphan"), "unknown feed must report disabled")
-	assert.False(t, isFeedEnabled(nil, "project"), "nil config must report disabled (no panic)")
+	// The daemon's authoritative view of the same config.
+	registry := feeds.NewRegistry()
+	feeds.RegisterBuiltins(registry)
+	registry.Register(feeds.NewCustomProducer("pulse", "echo {}", 0))
+	d := feeds.NewDaemon(core.DaemonConfig{}, cfg.Feeds, registry)
+	daemonView := map[string]feeds.FeedStatus{}
+	for _, f := range d.EffectiveFeeds() {
+		daemonView[f.Name] = f
+	}
+
+	// Doctor's fallback view of the same config.
+	doctorView := feedsFromConfig(&cfg)
+
+	for _, name := range append(append([]string{}, knownBuiltinFeeds...), "pulse") {
+		assert.Equalf(t, daemonView[name].Enabled, doctorView[name].Enabled,
+			"enabled mismatch for %q — doctor diverges from daemon", name)
+		assert.Equalf(t, daemonView[name].IntervalSeconds, doctorView[name].IntervalSeconds,
+			"interval mismatch for %q — doctor diverges from daemon", name)
+	}
 }
 
-// TestIsKnownFeed pins isKnownFeed across builtins, custom feeds, and unknowns —
-// it had no coverage. Builtins are recognised; a declared custom feed is
-// recognised; an orphan/unknown name is not.
-func TestIsKnownFeed(t *testing.T) {
-	cfg := &core.HooksConfig{}
-	cfg.Feeds.Custom = []core.CustomFeedConfig{{Name: "mycustom"}}
+// TestFeedsFromConfig_BuiltinsAndCustoms pins that feedsFromConfig enumerates
+// every builtin plus declared customs, and resolves enabled/interval (unset
+// interval → the shared default, not 0).
+func TestFeedsFromConfig_BuiltinsAndCustoms(t *testing.T) {
+	cfg := core.GetDefaultConfig()
+	cfg.Feeds.Weather.Enabled = true
+	cfg.Feeds.Weather.IntervalSeconds = 900
+	cfg.Feeds.Memories.IntervalSeconds = 0 // unset → should resolve to the default
+	cfg.Feeds.Custom = []core.CustomFeedConfig{{Name: "pulse", Enabled: true, IntervalSeconds: 120}}
 
-	for _, feed := range knownBuiltinFeeds {
-		assert.Truef(t, isKnownFeed(feed, cfg), "builtin %q must be known", feed)
+	got := feedsFromConfig(&cfg)
+
+	for _, name := range knownBuiltinFeeds {
+		_, ok := got[name]
+		assert.Truef(t, ok, "builtin %q must be present", name)
 	}
-	assert.True(t, isKnownFeed("mycustom", cfg), "declared custom feed must be known")
-	assert.False(t, isKnownFeed("nonexistent-orphan", cfg), "unknown orphan must not be known")
+	assert.True(t, got["weather"].Enabled)
+	assert.Equal(t, 900, got["weather"].IntervalSeconds)
+	assert.True(t, got["pulse"].Enabled)
+	assert.Equal(t, 120, got["pulse"].IntervalSeconds)
+	// A feed with no explicit interval resolves to the shared default, not 0.
+	assert.Equal(t, feeds.DefaultIntervalSeconds, got["memories"].IntervalSeconds)
+}
 
-	// nil config: builtins still known, customs cannot be (no panic).
-	assert.True(t, isKnownFeed("project", nil), "builtin must be known with nil config")
-	assert.False(t, isKnownFeed("mycustom", nil), "custom cannot be resolved with nil config")
+// A nil config yields an empty map — doctor then treats every cache file as an
+// orphan and skips it (fail-open, no panic).
+func TestFeedsFromConfig_NilConfigEmpty(t *testing.T) {
+	assert.Empty(t, feedsFromConfig(nil))
 }

--- a/cmd/hookwise/cmd_init.go
+++ b/cmd/hookwise/cmd_init.go
@@ -28,13 +28,19 @@ tui:
   auto_launch: false
   launch_method: "newWindow"
 
-# feeds:
-#   weather:
-#     enabled: true
-#     interval_seconds: 900
-#     latitude: 37.7749
-#     longitude: -122.4194
-#     temperature_unit: "fahrenheit" # or "celsius"
+# Feeds are polled by a single shared daemon, so they are configured GLOBALLY in
+# ~/.hookwise/config.yaml — NOT here. A feeds: block in this project file is
+# ignored for polling ('hookwise doctor' will warn). Put feeds in the global
+# config instead, e.g.:
+#
+#   # ~/.hookwise/config.yaml
+#   feeds:
+#     weather:
+#       enabled: true
+#       interval_seconds: 900
+#       latitude: 37.7749
+#       longitude: -122.4194
+#       temperature_unit: "fahrenheit" # or "celsius"
 `
 
 func newInitCmd() *cobra.Command {

--- a/docs/guide/feeds-guide.md
+++ b/docs/guide/feeds-guide.md
@@ -2,6 +2,8 @@
 
 The feed platform is a background data aggregation system introduced in hookwise v1.1, with the insights producer added in v1.2. It collects data from multiple sources, caches it with TTL-aware freshness, and surfaces it through the status line and TUI.
 
+> **Note:** Feeds are polled by a single shared background daemon, so feed settings are configured globally in `~/.hookwise/config.yaml`, not in a project's `hookwise.yaml`. A `feeds:` block in a project config is ignored, and `hookwise doctor` will warn about it.
+
 ## Architecture
 
 ```

--- a/hookwise.yaml
+++ b/hookwise.yaml
@@ -12,11 +12,9 @@ guards:
     when: 'tool_input.command contains "force push"'
     reason: "Force push requires confirmation"
 
-feeds:
-  calendar:
-    enabled: true
-    interval_seconds: 300
-    lookahead_minutes: 120
+# Feeds are polled by a single shared daemon and are configured GLOBALLY in
+# ~/.hookwise/config.yaml, not here — a feeds: block in a project file is ignored
+# for polling (hookwise doctor will warn). See docs/guide/feeds-guide.md.
 
 status_line:
   enabled: true

--- a/internal/feeds/client.go
+++ b/internal/feeds/client.go
@@ -213,3 +213,30 @@ func (c *DaemonClient) Health() (map[string]interface{}, error) {
 
 	return result, nil
 }
+
+// EffectiveFeeds sends GET /feeds to the daemon and returns its effective
+// per-feed config — what the daemon is actually polling with (#1). Callers
+// should treat any error as "daemon view unavailable" and fall back to the
+// on-disk global config.
+func (c *DaemonClient) EffectiveFeeds() ([]FeedStatus, error) {
+	resp, err := c.httpClient.Get("http://unix/feeds")
+	if err != nil {
+		return nil, fmt.Errorf("feeds: feeds request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// A non-200 (e.g. an older daemon without the /feeds route) is "view
+	// unavailable" — let the caller fall back rather than decode an error body.
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("feeds: feeds request: status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Feeds []FeedStatus `json:"feeds"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("feeds: decode feeds response: %w", err)
+	}
+
+	return result.Feeds, nil
+}

--- a/internal/feeds/daemon.go
+++ b/internal/feeds/daemon.go
@@ -130,6 +130,9 @@ func (d *Daemon) Start() error {
 	d.server = NewSocketServer(d.socketPath, func() {
 		d.triggerShutdown()
 	}, d.startedAt)
+	// Expose the daemon's effective feed config over GET /feeds so doctor reports
+	// against what is actually polling (#1).
+	d.server.SetFeedsProvider(d.EffectiveFeeds)
 
 	if err := d.server.Start(); err != nil {
 		return fmt.Errorf("feeds: daemon already running: %w", err)

--- a/internal/feeds/feed_status.go
+++ b/internal/feeds/feed_status.go
@@ -1,0 +1,108 @@
+package feeds
+
+import (
+	"time"
+
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// DefaultIntervalSeconds is the poll cadence applied to an enabled feed that
+// does not specify its own interval. It is the single source for this default,
+// shared by the daemon's poll loop and doctor's feed-health report so the two
+// can never disagree on cadence (#1).
+const DefaultIntervalSeconds = 60
+
+// FeedEnabled reports whether the named feed is enabled in cfg. Truly-unknown
+// feeds are enabled by default (fail-open), matching the daemon's poll-gate.
+// This is the single source of feed-enabled truth shared by the daemon and
+// doctor, so doctor never reports a feed enabled/disabled differently from what
+// the daemon actually polls (#1).
+func FeedEnabled(cfg core.FeedsConfig, name string) bool {
+	switch name {
+	case "project":
+		return cfg.Project.Enabled
+	case "calendar":
+		return cfg.Calendar.Enabled
+	case "news":
+		return cfg.News.Enabled
+	case "weather":
+		return cfg.Weather.Enabled
+	case "memories":
+		return cfg.Memories.Enabled
+	case "insights":
+		return cfg.Insights.Enabled
+	default:
+		for _, c := range cfg.Custom {
+			if c.Name == name {
+				return c.Enabled
+			}
+		}
+		// Truly unknown feeds are enabled by default (fail-open).
+		return true
+	}
+}
+
+// EffectiveIntervalSeconds returns the poll interval (seconds) for the named
+// feed, applying DefaultIntervalSeconds when the config leaves it unset. Shared
+// by the daemon and doctor (see FeedEnabled).
+func EffectiveIntervalSeconds(cfg core.FeedsConfig, name string) int {
+	var seconds int
+	switch name {
+	case "project":
+		seconds = cfg.Project.IntervalSeconds
+	case "calendar":
+		seconds = cfg.Calendar.IntervalSeconds
+	case "news":
+		seconds = cfg.News.IntervalSeconds
+	case "weather":
+		seconds = cfg.Weather.IntervalSeconds
+	case "memories":
+		seconds = cfg.Memories.IntervalSeconds
+	case "insights":
+		seconds = cfg.Insights.IntervalSeconds
+	default:
+		for _, c := range cfg.Custom {
+			if c.Name == name {
+				seconds = c.IntervalSeconds
+				break
+			}
+		}
+	}
+	if seconds > 0 {
+		return seconds
+	}
+	return DefaultIntervalSeconds
+}
+
+// FeedStatus is the effective per-feed configuration the daemon is actively
+// polling with. It is exposed over GET /feeds and consumed by `hookwise doctor`
+// (#1): because it is derived from the daemon's in-memory config + registry, it
+// reflects what is REALLY running rather than a re-derivation from on-disk
+// config that could have diverged.
+type FeedStatus struct {
+	Name            string `json:"name"`
+	Enabled         bool   `json:"enabled"`
+	IntervalSeconds int    `json:"interval_seconds"`
+}
+
+// EffectiveFeeds returns the effective per-feed config the daemon is polling
+// with: every registered producer (builtins + customs) with its enabled flag
+// and resolved interval. This is the authoritative answer to "what is the
+// daemon actually doing", which doctor reports against (#1) instead of
+// re-deriving a possibly-divergent view from on-disk config.
+//
+// d.feeds and the registry are immutable after NewDaemon/Start (the poll loop
+// only reads them), so no lock is needed; a fresh slice is returned each call.
+func (d *Daemon) EffectiveFeeds() []FeedStatus {
+	producers := d.registry.All()
+	out := make([]FeedStatus, 0, len(producers))
+	for _, p := range producers {
+		name := p.Name()
+		out = append(out, FeedStatus{
+			Name:            name,
+			Enabled:         d.isEnabled(name),
+			IntervalSeconds: int(d.intervalFor(name) / time.Second),
+		})
+	}
+	return out
+}

--- a/internal/feeds/feed_status_test.go
+++ b/internal/feeds/feed_status_test.go
@@ -1,0 +1,126 @@
+package feeds
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// EffectiveFeeds is the daemon's authoritative view of what it is actually
+// polling: every registered producer (builtins + customs) with its enabled flag
+// and effective interval resolved from the daemon's own config. doctor consumes
+// this over GET /feeds so it reports against the daemon's real state (#1).
+func TestDaemonEffectiveFeeds_ReflectsConfigAndRegistry(t *testing.T) {
+	registry := NewRegistry()
+	RegisterBuiltins(registry)
+
+	feedsCfg := core.FeedsConfig{
+		Weather:  core.WeatherFeedConfig{Enabled: true, IntervalSeconds: 900},
+		Calendar: core.CalendarFeedConfig{Enabled: false},
+		// project/news/memories/insights left zero-valued (disabled, no interval)
+	}
+	d := NewDaemon(core.DaemonConfig{}, feedsCfg, registry)
+
+	byName := map[string]FeedStatus{}
+	for _, f := range d.EffectiveFeeds() {
+		byName[f.Name] = f
+	}
+
+	// Every registered builtin is reported.
+	for _, n := range []string{"project", "calendar", "news", "weather", "memories", "insights"} {
+		_, ok := byName[n]
+		assert.True(t, ok, "builtin %q should be reported by EffectiveFeeds", n)
+	}
+
+	// Enabled + explicit interval round-trip.
+	assert.True(t, byName["weather"].Enabled)
+	assert.Equal(t, 900, byName["weather"].IntervalSeconds)
+
+	// Disabled feed reported as disabled.
+	assert.False(t, byName["calendar"].Enabled)
+
+	// An enabled feed with no explicit interval reports the daemon's effective
+	// default, not 0 — so doctor judges staleness against the real poll cadence.
+	assert.Equal(t, int(defaultInterval.Seconds()), byName["project"].IntervalSeconds)
+}
+
+// Custom feeds (#124) must be reported too, or doctor re-derives a divergent set.
+func TestDaemonEffectiveFeeds_IncludesCustomFeeds(t *testing.T) {
+	registry := NewRegistry()
+	RegisterBuiltins(registry)
+	registry.Register(NewCustomProducer("stocks", "echo {}", 0))
+
+	custom := []core.CustomFeedConfig{
+		{Name: "stocks", Command: "echo {}", IntervalSeconds: 120, Enabled: true},
+	}
+	d := NewDaemon(core.DaemonConfig{}, core.FeedsConfig{Custom: custom}, registry)
+
+	byName := map[string]FeedStatus{}
+	for _, f := range d.EffectiveFeeds() {
+		byName[f.Name] = f
+	}
+	got, ok := byName["stocks"]
+	require.True(t, ok, "custom feed should be reported")
+	assert.True(t, got.Enabled)
+	assert.Equal(t, 120, got.IntervalSeconds)
+}
+
+// FeedEnabled / EffectiveIntervalSeconds are the single source of truth shared
+// by the daemon's poll-gate and doctor's report (#1).
+func TestFeedEnabledAndInterval_SharedSemantics(t *testing.T) {
+	cfg := core.FeedsConfig{
+		Weather:  core.WeatherFeedConfig{Enabled: true, IntervalSeconds: 900},
+		Calendar: core.CalendarFeedConfig{Enabled: false},
+		Custom:   []core.CustomFeedConfig{{Name: "stocks", Enabled: true, IntervalSeconds: 120}},
+	}
+
+	assert.True(t, FeedEnabled(cfg, "weather"))
+	assert.False(t, FeedEnabled(cfg, "calendar"))
+	assert.True(t, FeedEnabled(cfg, "stocks"))
+	// Truly-unknown feeds fail open to enabled (matches the daemon poll-gate).
+	assert.True(t, FeedEnabled(cfg, "does-not-exist"))
+
+	assert.Equal(t, 900, EffectiveIntervalSeconds(cfg, "weather"))
+	assert.Equal(t, 120, EffectiveIntervalSeconds(cfg, "stocks"))
+	// Unset interval resolves to the shared default, not 0.
+	assert.Equal(t, DefaultIntervalSeconds, EffectiveIntervalSeconds(cfg, "calendar"))
+	assert.Equal(t, DefaultIntervalSeconds, EffectiveIntervalSeconds(cfg, "news"))
+}
+
+// The client's EffectiveFeeds() must round-trip the daemon's GET /feeds payload
+// byte-faithfully — this is the wire contract doctor relies on (#1).
+func TestDaemonClientEffectiveFeeds_RoundTripsOverSocket(t *testing.T) {
+	socketPath := filepath.Join(socketTempDir(t), "d.sock")
+	want := []FeedStatus{
+		{Name: "weather", Enabled: true, IntervalSeconds: 900},
+		{Name: "calendar", Enabled: false, IntervalSeconds: 300},
+	}
+
+	srv := NewSocketServer(socketPath, func() {}, time.Now())
+	srv.SetFeedsProvider(func() []FeedStatus { return want })
+	require.NoError(t, srv.Start())
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	client := NewDaemonClient(socketPath)
+	got, err := client.EffectiveFeeds()
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// With no provider wired, GET /feeds returns an empty list, not an error — so a
+// daemon built without the provider never breaks doctor.
+func TestSocketFeeds_NoProviderReturnsEmpty(t *testing.T) {
+	socketPath := filepath.Join(socketTempDir(t), "d.sock")
+	srv := NewSocketServer(socketPath, func() {}, time.Now())
+	require.NoError(t, srv.Start())
+	defer func() { _ = srv.Shutdown(context.Background()) }()
+
+	got, err := NewDaemonClient(socketPath).EffectiveFeeds()
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/internal/feeds/polling.go
+++ b/internal/feeds/polling.go
@@ -37,7 +37,7 @@ type ConfigAware interface {
 
 // defaultInterval is the fallback polling interval when a producer has no
 // explicit configuration.
-const defaultInterval = 60 * time.Second
+const defaultInterval = DefaultIntervalSeconds * time.Second
 
 // defaultStaggerOffset is the delay between starting successive feed goroutines,
 // preventing a thundering-herd of simultaneous fetches.
@@ -158,64 +158,16 @@ func (d *Daemon) runAllFeeds() {
 }
 
 // intervalFor returns the configured polling interval for the named feed,
-// falling back to defaultInterval if not configured.
+// falling back to defaultInterval if not configured. Delegates to the shared
+// EffectiveIntervalSeconds so the daemon and doctor resolve intervals
+// identically (#1).
 func (d *Daemon) intervalFor(name string) time.Duration {
-	var seconds int
-
-	switch name {
-	case "project":
-		seconds = d.feeds.Project.IntervalSeconds
-	case "calendar":
-		seconds = d.feeds.Calendar.IntervalSeconds
-	case "news":
-		seconds = d.feeds.News.IntervalSeconds
-	case "weather":
-		seconds = d.feeds.Weather.IntervalSeconds
-	case "memories":
-		seconds = d.feeds.Memories.IntervalSeconds
-	case "insights":
-		seconds = d.feeds.Insights.IntervalSeconds
-	default:
-		// Custom feeds (#124) carry their interval in config.Feeds.Custom.
-		for _, c := range d.feeds.Custom {
-			if c.Name == name {
-				seconds = c.IntervalSeconds
-				break
-			}
-		}
-	}
-
-	if seconds > 0 {
-		return time.Duration(seconds) * time.Second
-	}
-	return defaultInterval
+	return time.Duration(EffectiveIntervalSeconds(d.feeds, name)) * time.Second
 }
 
-// isEnabled returns true if the named feed is enabled in the config.
-// Feeds that have no explicit Enabled field default to true (fail-open:
-// unrecognised feeds are also considered enabled).
+// isEnabled returns true if the named feed is enabled in the config. Delegates
+// to the shared FeedEnabled so the daemon and doctor agree on enabled-state
+// (#1); unrecognised feeds default to enabled (fail-open).
 func (d *Daemon) isEnabled(name string) bool {
-	switch name {
-	case "project":
-		return d.feeds.Project.Enabled
-	case "calendar":
-		return d.feeds.Calendar.Enabled
-	case "news":
-		return d.feeds.News.Enabled
-	case "weather":
-		return d.feeds.Weather.Enabled
-	case "memories":
-		return d.feeds.Memories.Enabled
-	case "insights":
-		return d.feeds.Insights.Enabled
-	default:
-		// Custom feeds (#124) carry their enabled flag in config.Feeds.Custom.
-		for _, c := range d.feeds.Custom {
-			if c.Name == name {
-				return c.Enabled
-			}
-		}
-		// Truly unknown feeds are enabled by default (fail-open).
-		return true
-	}
+	return FeedEnabled(d.feeds, name)
 }

--- a/internal/feeds/socket.go
+++ b/internal/feeds/socket.go
@@ -19,10 +19,18 @@ type SocketServer struct {
 	socketPath   string
 	listener     net.Listener
 	server       *http.Server
-	shutdownFn   func() // triggers daemon shutdown
+	shutdownFn   func()              // triggers daemon shutdown
+	feedsFn      func() []FeedStatus // returns the daemon's effective feed config
 	shutdownOnce sync.Once
 	startedAt    time.Time
 	mu           sync.Mutex
+}
+
+// SetFeedsProvider wires the function that GET /feeds calls to report the
+// daemon's effective feed config (#1). Must be called before Start. If unset,
+// GET /feeds returns an empty list.
+func (s *SocketServer) SetFeedsProvider(fn func() []FeedStatus) {
+	s.feedsFn = fn
 }
 
 // NewSocketServer creates a new SocketServer.
@@ -81,6 +89,7 @@ func (s *SocketServer) Start() error {
 	// Register routes.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", s.handleHealth)
+	mux.HandleFunc("/feeds", s.handleFeeds)
 	mux.HandleFunc("/shutdown", s.handleShutdown)
 
 	s.server = &http.Server{
@@ -145,6 +154,27 @@ func (s *SocketServer) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
+}
+
+// handleFeeds responds to GET /feeds with the daemon's effective feed config
+// (#1): the per-feed enabled flag + interval the daemon is actually polling
+// with. doctor queries this so it reports against the daemon's real state
+// rather than re-deriving from possibly-divergent on-disk config.
+func (s *SocketServer) handleFeeds(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	statuses := []FeedStatus{}
+	if s.feedsFn != nil {
+		if got := s.feedsFn(); got != nil {
+			statuses = got
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"feeds": statuses})
 }
 
 // handleShutdown responds to POST /shutdown and triggers the shutdown function


### PR DESCRIPTION
## What & why

`hookwise doctor` re-derived feed config from `LoadConfig(cwd)` plus its own parallel `isFeedEnabled`/`getFeedInterval` switches. When the singleton daemon was cold-started from a *different* project (#89), doctor could report a feed enabled/stale that the daemon was **not** actually polling — the `feed:calendar stale` confusion.

This is slice 2 of 2 (slice 1 = #224, daemon canonical config).

## Change

- **`GET /feeds` socket route** — read-only, returns the daemon's effective per-feed config (`{name, enabled, interval_seconds}`) for **builtins + customs**, derived from the in-memory registry. `/health` shape untouched.
- **`DaemonClient.EffectiveFeeds()`** — client method; doctor reports against this runtime view, falling back to the on-disk global config (labeled) when the daemon is down/unreachable (ARCH-1 fail-open).
- **Single source of truth** — extract the enabled/interval logic into shared pure functions `feeds.FeedEnabled` / `feeds.EffectiveIntervalSeconds` that **both** the daemon poll-gate and doctor's fallback builder call, so they cannot diverge by construction. This removes the hand-maintained doctor↔daemon duplication that was #1's root cause (~50 lines deleted from the daemon).
- **Drift WARN** — when the daemon is polling a feed config that no longer matches on-disk global (config is read once at startup → restart to apply).
- **Back-compat WARN** — a project `hookwise.yaml` `feeds:` block is ignored by the singleton daemon (#89); doctor lists the keys to migrate to global. Migrated this repo's own redundant block; updated the init template + feeds guide.

## Tests

- `TestFeedsFromConfig_AgreesWithDaemonEffectiveFeeds` — **the #1 agreement guarantee**: doctor's per-feed verdict (enabled + interval) matches the daemon's `EffectiveFeeds` for the same config.
- `TestDaemonClientEffectiveFeeds_RoundTripsOverSocket` — the `GET /feeds` wire contract.
- `TestCheckProjectFeedsIgnored_*`, `TestCheckFeedConfigDrift`, `TestResolveEffectiveFeeds_DaemonDownFallsBackToGlobal` — the new warnings + fallback.
- `TestDaemonEffectiveFeeds_*`, `TestFeedEnabledAndInterval_SharedSemantics`, plus the existing daemon/feed-health suites (refactor is behavior-preserving).

Full guarded gate green locally (`GOMEMLIMIT=4GiB go test -race -p 2 ./...`).

Design + a recorded Grok adversarial design audit (3 BLOCKERs folded in: WARN-not-INFO back-compat, drift WARN, custom-feeds in `/feeds`) drove this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)