### PR TITLE
fix(migration): skip Go-origin analytics DB in TS detection (#218)

### DIFF
--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -85,7 +85,13 @@ func DetectTypeScript(opts MigrationOpts) (sqlitePath, costStatePath string) {
 
 	sqliteCandidate := filepath.Join(dir, "analytics.db")
 	if info, err := os.Stat(sqliteCandidate); err == nil && !info.IsDir() {
-		sqlitePath = sqliteCandidate
+		// #218: the Go runtime writes its analytics DB to this same path. Only
+		// treat it as a TypeScript migration source when it is NOT a Go-origin
+		// DB -- otherwise `upgrade` imports the Go DB into itself and hits a
+		// sessions.id UNIQUE conflict on the first run.
+		if !isGoOriginDB(sqliteCandidate) {
+			sqlitePath = sqliteCandidate
+		}
 	}
 
 	costStateCandidate := filepath.Join(dir, "state", "cost-state.json")
@@ -94,6 +100,31 @@ func DetectTypeScript(opts MigrationOpts) (sqlitePath, costStatePath string) {
 	}
 
 	return sqlitePath, costStatePath
+}
+
+// isGoOriginDB reports whether the SQLite database at path was created by the
+// Go analytics runtime rather than a genuine TypeScript-era install (#218).
+//
+// The Go runtime always creates a `schema_meta` table (see internal/analytics)
+// which no TypeScript-era database ever had, so its presence is a reliable
+// Go-origin sentinel. On any open/query error the DB is treated as NOT
+// Go-origin, so a genuine (possibly unusual) TypeScript database is never
+// skipped -- the failure mode we must avoid is dropping a real user's data.
+func isGoOriginDB(path string) bool {
+	db, err := sql.Open("sqlite", path+"?mode=ro")
+	if err != nil {
+		return false
+	}
+	defer db.Close()
+
+	var count int
+	err = db.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='schema_meta'",
+	).Scan(&count)
+	if err != nil {
+		return false
+	}
+	return count > 0
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -223,6 +223,48 @@ func TestDetectTypeScript_OnlySQLite(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Test 3b: DetectTypeScript must NOT treat a Go-origin analytics DB as a TS
+// source (#218). The Go runtime writes its analytics.db to the same path a
+// TypeScript install would, so a presence-only check imports the Go DB into
+// itself → sessions.id UNIQUE conflict on the first `upgrade`.
+// ---------------------------------------------------------------------------
+
+func TestDetectTypeScript_GoOriginSkipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	hwDir := filepath.Join(tmpDir, ".hookwise")
+	require.NoError(t, os.MkdirAll(hwDir, 0o700))
+
+	// Create a genuine Go-format analytics DB at the TS candidate path. Open()
+	// initialises the Go-only schema (including the schema_meta sentinel table).
+	dbPath := filepath.Join(hwDir, "analytics.db")
+	godb, err := analytics.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, godb.Close())
+
+	opts := MigrationOpts{HomeDir: tmpDir}
+	sqlitePath, _ := DetectTypeScript(opts)
+
+	assert.Empty(t, sqlitePath, "a Go-origin analytics.db must not be detected as a TypeScript migration source")
+}
+
+// A genuine TypeScript-era DB (no schema_meta) must still be detected so real
+// TS users migrate cleanly.
+func TestDetectTypeScript_TSOriginDetected(t *testing.T) {
+	tmpDir := t.TempDir()
+	hwDir := filepath.Join(tmpDir, ".hookwise")
+	require.NoError(t, os.MkdirAll(hwDir, 0o700))
+
+	dbPath := filepath.Join(hwDir, "analytics.db")
+	tsdb := createTestSQLite(t, dbPath)
+	require.NoError(t, tsdb.Close())
+
+	opts := MigrationOpts{HomeDir: tmpDir}
+	sqlitePath, _ := DetectTypeScript(opts)
+
+	assert.Equal(t, dbPath, sqlitePath, "a genuine TypeScript-origin analytics.db must still be detected")
+}
+
+// ---------------------------------------------------------------------------
 // Test 4: MigrateSQLite imports sessions
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem (#218)

`DetectTypeScript` stat-checked `~/.hookwise/analytics.db` to decide a TypeScript install existed — but the **Go** runtime writes its analytics DB to that **same path**. On a Go-only / already-migrated install:

1. `DetectTypeScript` returned the Go DB as the "TS sqlite source" (`SQLiteDetected=true`).
2. `Run` opened that same file as the migration **target** and imported its sessions into itself → `sessions.id` TEXT PK UNIQUE conflict on the first `hookwise upgrade`.

The #208 `ts_migration_done` marker prevented the *second* run; the **first** run on a Go-only install still errored.

## Fix

Add `isGoOriginDB(path)`: opens the candidate read-only and checks `sqlite_master` for the Go-only **`schema_meta`** sentinel table (created on every `analytics.Open`; no TypeScript-era DB ever had it). `DetectTypeScript` only treats the candidate as a TS source when it is **not** Go-origin.

The check **fails safe** — any open/query error is treated as *not* Go-origin — so a genuine (even unusual) TS database is never skipped. The failure mode we refuse is dropping a real user's data.

## Tests (strict TDD, guarded gate green)

- `TestDetectTypeScript_GoOriginSkipped` — a real Go-format DB (`analytics.Open`) at the candidate path is **not** detected (was RED before the fix, the exact #218 repro).
- `TestDetectTypeScript_TSOriginDetected` — a genuine TS-schema DB (`createTestSQLite`, no `schema_meta`) **is** still detected.
- Existing `TestDetectTypeScript_BothFound` / `_OnlySQLite` (corrupt `"fake"` file) preserved — a non-openable file fails safe to detected.

Acceptance from the issue met: Go-only `upgrade` is a clean no-op (SQLiteDetected=false → "Nothing to migrate"); genuine TS installs still migrate; both covered by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration detection so existing analytics data is only treated as a migration source when it matches the older TypeScript format.
  * Prevents skipping valid user data when a Go-generated analytics database is already present.

* **Tests**
  * Added coverage for both Go-origin and TypeScript-origin analytics databases to verify the correct migration source is chosen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->