### PR TITLE
fix(daemon): honor HOOKWISE_STATE_DIR for TUI PID + marker (#116)

### DIFF
--- a/cmd/hookwise/cmd_daemon.go
+++ b/cmd/hookwise/cmd_daemon.go
@@ -275,9 +275,11 @@ func runScheduledSnapshot(dbPath string, retention int) {
 // TUI launcher (Bug #14 — duplicate terminal tabs)
 // ---------------------------------------------------------------------------
 
-// tuiPIDPath returns the path to the TUI PID file.
+// tuiPIDPath returns the path to the TUI PID file. It reads core.GetStateDir()
+// at call time so it honors HOOKWISE_STATE_DIR (#116); the package-level
+// core.DefaultStateDir var is frozen at init and ignores the override.
 func tuiPIDPath() string {
-	return filepath.Join(core.DefaultStateDir, "tui.pid")
+	return filepath.Join(core.GetStateDir(), "tui.pid")
 }
 
 // tuiLaunchCooldown is how long a recorded launch suppresses re-launch. It only
@@ -496,7 +498,9 @@ func launchTUIIfNeeded(launchMethod string) {
 	}()
 
 	l := &tuiLauncher{
-		stateDir:  core.DefaultStateDir,
+		// core.GetStateDir() (not the frozen core.DefaultStateDir) so the launch
+		// marker honors HOOKWISE_STATE_DIR, matching tuiPIDPath (#116).
+		stateDir:  core.GetStateDir(),
 		cooldown:  tuiLaunchCooldown,
 		now:       time.Now,
 		isRunning: isTUIRunning,

--- a/cmd/hookwise/cmd_daemon_statedir_test.go
+++ b/cmd/hookwise/cmd_daemon_statedir_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// #116 Divergence B: the TUI PID path resolved from the init-time-frozen
+// core.DefaultStateDir var, so under HOOKWISE_STATE_DIR the PID landed in
+// ~/.hookwise/tui.pid and the daemon's liveness check could not find it.
+// tuiPIDPath must honor the override by reading core.GetStateDir() at call time.
+func TestTUIPIDPath_HonorsStateDirOverride(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", tmp)
+
+	got := tuiPIDPath()
+
+	assert.Equal(t, filepath.Join(tmp, "tui.pid"), got,
+		"tuiPIDPath must resolve under HOOKWISE_STATE_DIR, not the frozen default")
+}


### PR DESCRIPTION
## Problem (#116, Divergence B)

`tuiPIDPath()` and `launchTUIIfNeeded()` resolved the TUI PID file and the launch-singleton marker from the **package-level `core.DefaultStateDir` var**, which is evaluated **once at init** from `HomeDir()` and never reads `HOOKWISE_STATE_DIR`. Under an overridden state dir:

- the TUI PID landed in `~/.hookwise/tui.pid` → the daemon's liveness check (`tuiPIDFileAlive`) couldn't find it;
- the `tui.launch.marker` (PR #220's O_EXCL singleton guard) landed in `~/.hookwise/` → the guard could mis-fire under an override.

## Fix

Read `core.GetStateDir()` (which reads the env at call time) in both spots:
- `cmd_daemon.go` `tuiPIDPath()`
- `cmd_daemon.go` `launchTUIIfNeeded()` launcher `stateDir`

**Divergence A** from the issue (`analytics.DefaultSnapshotsDir`) was already fixed in a prior change — it already calls `core.GetStateDir()` and has `snapshot_statedir_test.go` covering it. No action needed there.

## Tests (strict TDD, guarded gate green)

- `TestTUIPIDPath_HonorsStateDirOverride` — sets `HOOKWISE_STATE_DIR` via `t.Setenv` and asserts `tuiPIDPath()` resolves under the override (was RED before the fix: resolved to the frozen `~/.hookwise/tui.pid`).
- Full `cmd/hookwise` package green, including the PR #220 TUI-singleton guard tests (marker-path change did not regress the guard).

**Honesty note:** the marker-path line in `launchTUIIfNeeded` is the identical one-line bug class as `tuiPIDPath` but is covered **by inspection**, not a dedicated test — `launchTUIIfNeeded` builds its launcher inline and isn't unit-testable without spawning the real TUI. The tested `tuiPIDPath` fix and this one are the same `DefaultStateDir → GetStateDir` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)