### PR TITLE
fix(test): unbreak nightly daemon integration + chaos tests

### DIFF
--- a/internal/chaos/chaos_test.go
+++ b/internal/chaos/chaos_test.go
@@ -19,6 +19,17 @@ import (
 	"github.com/vishnujayvel/hookwise/internal/feeds"
 )
 
+// shortSocketPath returns a unix socket path under /tmp for a test daemon.
+// macOS /var/folders temp paths (from t.TempDir) can exceed the 104-byte unix
+// socket limit, so sockets get their own short dir. Cleaned up automatically.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "hw-sock-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "d.sock")
+}
+
 // =========================================================================
 // Task 4.1: Dispatch resilience under failure conditions
 // =========================================================================
@@ -242,6 +253,12 @@ func TestChaos_ProducerPanicRecovery(t *testing.T) {
 	daemon := feeds.NewDaemon(core.DaemonConfig{}, core.FeedsConfig{}, registry)
 	daemon.SetPIDFile(pidFile)
 	daemon.SetCacheDir(cacheDir)
+	// Isolate the unix socket. DefaultSocketPath is frozen at init and ignores
+	// HOOKWISE_STATE_DIR, so without this the chaos daemon collides with the
+	// integration package's daemon under parallel `go test ./...` (the nightly
+	// validate tier), binding the same real socket. Uses a short /tmp path to
+	// stay under the macOS 104-byte unix-socket limit.
+	daemon.SetSocketPath(shortSocketPath(t))
 	daemon.SetStaggerOffset(0)
 
 	require.NoError(t, daemon.Start())

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -29,6 +29,17 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// shortSocketPath returns a unix socket path under /tmp for a test daemon.
+// macOS /var/folders temp paths (from t.TempDir) can exceed the 104-byte unix
+// socket limit, so sockets get their own short dir. Cleaned up automatically.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "hw-sock-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "d.sock")
+}
+
 // =========================================================================
 // Helpers
 // =========================================================================
@@ -323,9 +334,21 @@ func TestIntegration_DaemonLifecycleWithCacheBridge(t *testing.T) {
 		},
 	})
 
-	daemon := feeds.NewDaemon(core.DaemonConfig{}, core.FeedsConfig{}, registry)
+	// Weather is a recognised feed and defaults to disabled (FeedEnabled reads
+	// cfg.Weather.Enabled); it must be enabled explicitly or the daemon skips
+	// it and weather.json is never written. "pulse" is not a recognised feed so
+	// it is enabled fail-open by default.
+	daemon := feeds.NewDaemon(core.DaemonConfig{}, core.FeedsConfig{
+		Weather: core.WeatherFeedConfig{Enabled: true},
+	}, registry)
 	daemon.SetPIDFile(pidFile)
 	daemon.SetCacheDir(cacheDir)
+	// Isolate the unix socket. DefaultSocketPath is frozen at package init from
+	// ~/.hookwise, so HOOKWISE_STATE_DIR does not move it; without this the
+	// daemon binds the shared real socket and collides with a live daemon
+	// (local) or a parallel test package (nightly). Uses a short /tmp path to
+	// stay under the macOS 104-byte unix-socket limit.
+	daemon.SetSocketPath(shortSocketPath(t))
 	daemon.SetStaggerOffset(10 * time.Millisecond) // fast for tests
 
 	// Start daemon
@@ -364,7 +387,9 @@ func TestIntegration_DaemonLifecycleWithCacheBridge(t *testing.T) {
 	pulseEntry, ok := flattened["pulse"].(map[string]interface{})
 	require.True(t, ok)
 	assert.NotEmpty(t, pulseEntry["updated_at"], "should have updated_at")
-	assert.Equal(t, bridge.DefaultTTLSeconds, pulseEntry["ttl_seconds"], "should have ttl_seconds")
+	// ttl_seconds is a JSON number (float64) after the cache round-trip; the
+	// daemon injects feedCacheTTLSeconds(60s interval) = 180, floored to 300.
+	assert.Equal(t, float64(bridge.DefaultTTLSeconds), pulseEntry["ttl_seconds"], "should have ttl_seconds")
 	assert.Equal(t, float64(3), pulseEntry["session_count"], "data field should be at top level")
 	assert.Equal(t, float64(1), pulseEntry["active_sessions"], "data field should be at top level")
 	assert.NotContains(t, pulseEntry, "type", "envelope field should not be present")
@@ -693,6 +718,9 @@ func TestIntegration_DaemonWritesCacheNotAnalyticsDB(t *testing.T) {
 	daemon := feeds.NewDaemon(core.DaemonConfig{}, core.FeedsConfig{}, registry)
 	daemon.SetPIDFile(pidFile)
 	daemon.SetCacheDir(cacheDir)
+	// Isolate the unix socket (see the lifecycle test above): DefaultSocketPath
+	// is frozen at init and ignores HOOKWISE_STATE_DIR.
+	daemon.SetSocketPath(shortSocketPath(t))
 	daemon.SetStaggerOffset(0)
 
 	require.NoError(t, daemon.Start())


### PR DESCRIPTION
## What

Fixes the **Nightly Validate** workflow, which has been failing every day for
weeks (back to at least June 23). Per-PR `CI` only runs Tier 0/1 (`dagger call
test`), which excludes the integration/chaos tier, so these failures never
gated a PR and went unnoticed.

The nightly's `dagger call validate` (chaos + mutation + snapshots) was red
because **two integration tests + one chaos test** fail. Mutation and snapshots
pass. All fixes are **test-only** (behind `//go:build integration`); no
production code is touched.

## Root causes (three, stacked in the lifecycle test)

1. **Socket not isolated.** `DefaultSocketPath` is frozen at package init from
   `~/.hookwise`, so the tests' `t.Setenv("HOOKWISE_STATE_DIR", …)` never moves
   it. Since #67 made socket-bind the single-instance authority (SOCKET-1), the
   three daemon tests all bound the shared real `~/.hookwise/daemon.sock` and
   collided — with each other under parallel `go test ./...`, or with a live
   local daemon. Fix: `SetSocketPath` into a short `/tmp` dir (matching every
   `feeds`/`bridge` daemon test), short enough for the macOS 104-byte
   unix-socket limit.
2. **Weather defaults to disabled.** `FeedEnabled("weather")` reads
   `cfg.Weather.Enabled`; the lifecycle test passed an empty `FeedsConfig{}`,
   so the daemon skipped the weather producer and `weather.json` was never
   written. Fix: enable weather in the test config (as a real user must).
3. **`ttl_seconds` type mismatch.** After the JSON cache round-trip it's a
   `float64`; the assertion compared against untyped-int `DefaultTTLSeconds`.
   Value is correct (60s → 180 → floored 300); fix: cast to `float64`, matching
   the sibling assertion.

## Test evidence

Full integration + chaos suites green:

```
GOMEMLIMIT=4GiB go test -race -p 2 -tags integration ./internal/integration/... ./internal/chaos/...
ok  github.com/vishnujayvel/hookwise/internal/integration
ok  github.com/vishnujayvel/hookwise/internal/chaos
```

Verified **with a real daemon holding the default socket** and **run together**
(the exact parallel-daemon collision the nightly hits).

## Note (not addressed here)

In production the daemon socket path doesn't honor `HOOKWISE_STATE_DIR` at
runtime the way the TUI PID does after #227 — `DefaultSocketPath` is frozen at
init. That's a separate daemon-coordination question, not needed to green the
nightly, and left for a supervised follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test and daemon socket handling to avoid UNIX socket path length issues on macOS and reduce socket collisions during parallel runs.
  * Fixed cache/lifecycle behavior so weather data is generated correctly and cache values are validated more reliably.
* **Tests**
  * Updated integration and chaos test coverage to use isolated per-test socket paths and more accurate TTL assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->