### PR TITLE
chore: gitignore Gas City beads DB and story docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,15 @@ dist/
 # openlore — local index/analysis stays out of git; decision records are tracked
 .openlore/*
 !.openlore/decisions/
+
+# Personal usage-audit story (contains reflections on real session usage)
+docs/story/
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.beads/proxieddb/
+
+# Gas City — beads DB stays local-only, never synced to the GitHub code repo
+.beads/


### PR DESCRIPTION
Fences Gas City's rig-local `.beads/` Dolt DB (and the personal `docs/story/` notes) out of the code repo. The hookwise GC rig keeps its work DB on disk only — never git-synced to origin (`sync.remote` removed from the untracked `.beads/config.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository exclusions to prevent local documentation, databases, credentials, and other development-only files from being included in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->