### PR TITLE
feat(init): scan existing hooks before writing config (#39)

### DIFF
--- a/cmd/hookwise/cmd_init.go
+++ b/cmd/hookwise/cmd_init.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/vishnujayvel/hookwise/internal/core"
@@ -186,6 +188,86 @@ func runWire(cmd *cobra.Command, wire, unwire, dryRun bool, events []string, noS
 	return nil
 }
 
+// hookAuditReport is the persisted shape of an init-time hook scan. It is
+// written to <state dir>/hook-audit.json so the pre-init state of the user's
+// Claude Code hooks survives as an artifact (e.g. for support and doctor).
+type hookAuditReport struct {
+	GeneratedAt  time.Time        `json:"generated_at"`
+	ScannedPaths []string         `json:"scanned_paths"`
+	Hooks        []hookAuditEntry `json:"hooks"`
+	Findings     []hooks.Finding  `json:"findings"`
+	ParseErrors  []string         `json:"parse_errors,omitempty"`
+}
+
+// hookAuditEntry mirrors hooks.HookEntry with stable snake_case JSON keys.
+type hookAuditEntry struct {
+	Event      string `json:"event"`
+	Matcher    string `json:"matcher"`
+	Type       string `json:"type"`
+	Command    string `json:"command"`
+	SourceFile string `json:"source_file"`
+}
+
+// hookAuditFile is the report file name under the state dir.
+const hookAuditFile = "hook-audit.json"
+
+// scanExistingHooks inventories the user's existing Claude Code hooks BEFORE
+// hookwise writes any config, so users see what is already running (and avoid
+// stacking redundant guard systems). It is strictly read-only with respect to
+// Claude Code settings: it reuses the hermetic hooks.Scan reader and only
+// writes the audit report under hookwise's own state dir. Scan or report
+// failures never abort init — the scan is advisory.
+func scanExistingHooks(out io.Writer) {
+	paths := hooks.DefaultSettingsPaths()
+
+	fmt.Fprintln(out, "Scanning existing Claude Code hooks...")
+	inv, err := hooks.Scan(paths)
+	if err != nil {
+		// Scan currently never returns a non-nil error, but stay defensive.
+		fmt.Fprintf(out, "WARN  hooks: settings scan failed: %v\n", err)
+		return
+	}
+
+	for _, pe := range inv.ParseErrors {
+		fmt.Fprintf(out, "WARN  hook-settings: %s could not be parsed: %v\n", pe.File, pe.Err)
+	}
+
+	findings := hooks.AllFindings(inv, nil)
+	if len(inv.Entries) == 0 {
+		fmt.Fprintln(out, "No existing Claude Code hooks found — clean slate.")
+	} else {
+		for _, f := range findings {
+			renderHookFinding(out, f)
+		}
+	}
+
+	report := hookAuditReport{
+		GeneratedAt:  time.Now().UTC(),
+		ScannedPaths: paths,
+		Hooks:        make([]hookAuditEntry, 0, len(inv.Entries)),
+		Findings:     findings,
+	}
+	for _, e := range inv.Entries {
+		report.Hooks = append(report.Hooks, hookAuditEntry{
+			Event:      e.Event,
+			Matcher:    e.Matcher,
+			Type:       e.Type,
+			Command:    e.Command,
+			SourceFile: e.SourceFile,
+		})
+	}
+	for _, pe := range inv.ParseErrors {
+		report.ParseErrors = append(report.ParseErrors, fmt.Sprintf("%s: %v", pe.File, pe.Err))
+	}
+
+	auditPath := filepath.Join(core.GetStateDir(), hookAuditFile)
+	if err := core.AtomicWriteJSON(auditPath, report); err != nil {
+		fmt.Fprintf(out, "WARN  hook-audit: could not write %s: %v\n", auditPath, err)
+		return
+	}
+	fmt.Fprintf(out, "Hook audit saved to %s\n\n", auditPath)
+}
+
 func runInit(cmd *cobra.Command, args []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -199,6 +281,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "hookwise.yaml already exists at %s -- skipping.\n", configPath)
 		return nil
 	}
+
+	// Inventory existing hooks before writing anything (gh#39).
+	scanExistingHooks(cmd.OutOrStdout())
 
 	// Write default config.
 	if err := os.WriteFile(configPath, []byte(defaultYAMLTemplate), 0o644); err != nil {

--- a/cmd/hookwise/cmd_init_scan_test.go
+++ b/cmd/hookwise/cmd_init_scan_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupInitScanEnv isolates an init run: a temp working directory (so
+// hookwise.yaml lands there), a temp state dir, and a temp Claude dir that
+// DefaultSettingsPaths resolves via HOOKWISE_CLAUDE_DIR. Returns the Claude
+// dir and the state dir.
+func setupInitScanEnv(t *testing.T) (claudeDir, stateDir string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stateDir = filepath.Join(tmpDir, ".hookwise")
+	t.Setenv("HOOKWISE_STATE_DIR", stateDir)
+
+	claudeDir = filepath.Join(tmpDir, ".claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	return claudeDir, stateDir
+}
+
+// settingsWithHooks is a realistic settings.json with hooks on two events,
+// including a network-dependent hot-path hook so AllFindings produces a
+// non-SCAN finding to render.
+const settingsWithHooks = `{
+  "model": "opus",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {"type": "command", "command": "guardian check"},
+          {"type": "command", "command": "curl -s https://example.com/audit"}
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "logger post-bash"}
+        ]
+      }
+    ]
+  }
+}
+`
+
+func TestInitScansExistingHooks(t *testing.T) {
+	claudeDir, stateDir := setupInitScanEnv(t)
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	require.NoError(t, os.WriteFile(settingsPath, []byte(settingsWithHooks), 0o600))
+
+	output, err := executeCommand("init")
+	require.NoError(t, err, "init failed: %s", output)
+
+	// Inventory + findings render before the config-created line.
+	assert.Contains(t, output, "Scanning existing Claude Code hooks...")
+	assert.Contains(t, output, "3 hooks across 2 events")
+	assert.Contains(t, output, "PreToolUse:")
+	assert.Contains(t, output, "PostToolUse:")
+	// The curl hook on a hot path must surface a rendered finding.
+	assert.Contains(t, output, "hook-network")
+	assert.NotContains(t, output, "No existing Claude Code hooks found")
+
+	// The scan happens before the template write.
+	scanIdx := indexOf(t, output, "Scanning existing Claude Code hooks...")
+	createdIdx := indexOf(t, output, "Created")
+	assert.Less(t, scanIdx, createdIdx, "scan output must precede config creation")
+
+	// Audit report exists and round-trips.
+	auditPath := filepath.Join(stateDir, "hook-audit.json")
+	data, err := os.ReadFile(auditPath)
+	require.NoError(t, err, "hook-audit.json must be written")
+
+	var report struct {
+		GeneratedAt  string `json:"generated_at"`
+		ScannedPaths []string
+		Hooks        []struct {
+			Event      string `json:"event"`
+			Command    string `json:"command"`
+			SourceFile string `json:"source_file"`
+		} `json:"hooks"`
+		Findings []struct {
+			Level string
+			Code  string
+		} `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal(data, &report))
+	assert.NotEmpty(t, report.GeneratedAt)
+	assert.Len(t, report.Hooks, 3)
+	assert.NotEmpty(t, report.Findings)
+	for _, h := range report.Hooks {
+		assert.Equal(t, settingsPath, h.SourceFile)
+	}
+	// No leftover temp file from the atomic write.
+	tmps, err := filepath.Glob(filepath.Join(stateDir, ".tmp-*"))
+	require.NoError(t, err)
+	assert.Empty(t, tmps)
+}
+
+func TestInitScanEmptyPath(t *testing.T) {
+	_, stateDir := setupInitScanEnv(t)
+	// No settings files exist at all.
+
+	output, err := executeCommand("init")
+	require.NoError(t, err, "init failed: %s", output)
+
+	assert.Contains(t, output, "No existing Claude Code hooks found")
+	assert.NotContains(t, output, "hooks across")
+	assert.Contains(t, output, "Created")
+
+	// The audit is still written, recording the clean scan.
+	data, err := os.ReadFile(filepath.Join(stateDir, "hook-audit.json"))
+	require.NoError(t, err)
+	var report struct {
+		Hooks    []any `json:"hooks"`
+		Findings []any `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal(data, &report))
+	assert.Empty(t, report.Hooks)
+}
+
+func TestInitNeverMutatesSettings(t *testing.T) {
+	claudeDir, _ := setupInitScanEnv(t)
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	localPath := filepath.Join(claudeDir, "settings.local.json")
+	require.NoError(t, os.WriteFile(settingsPath, []byte(settingsWithHooks), 0o600))
+	localBytes := []byte(`{"hooks": {"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "say done"}]}]}}` + "\n")
+	require.NoError(t, os.WriteFile(localPath, localBytes, 0o600))
+
+	before, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	beforeLocal, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+
+	output, err := executeCommand("init")
+	require.NoError(t, err, "init failed: %s", output)
+
+	after, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	afterLocal, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, before, after, "init must leave settings.json byte-identical")
+	assert.Equal(t, beforeLocal, afterLocal, "init must leave settings.local.json byte-identical")
+}
+
+func TestInitScanReportsParseErrors(t *testing.T) {
+	claudeDir, stateDir := setupInitScanEnv(t)
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	malformed := []byte(`{"hooks": not-json`)
+	require.NoError(t, os.WriteFile(settingsPath, malformed, 0o600))
+
+	output, err := executeCommand("init")
+	require.NoError(t, err, "init must not fail on malformed settings: %s", output)
+
+	assert.Contains(t, output, "could not be parsed")
+	assert.Contains(t, output, "Created")
+
+	// Malformed input is recorded in the audit and never rewritten on disk.
+	data, err := os.ReadFile(filepath.Join(stateDir, "hook-audit.json"))
+	require.NoError(t, err)
+	var report struct {
+		ParseErrors []string `json:"parse_errors"`
+	}
+	require.NoError(t, json.Unmarshal(data, &report))
+	assert.Len(t, report.ParseErrors, 1)
+
+	after, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	assert.Equal(t, malformed, after)
+}
+
+func TestInitSkipsScanWhenConfigExists(t *testing.T) {
+	claudeDir, stateDir := setupInitScanEnv(t)
+	require.NoError(t, os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(settingsWithHooks), 0o600))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, "hookwise.yaml"), []byte("version: 1\n"), 0o644))
+
+	output, err := executeCommand("init")
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "already exists")
+	assert.NotContains(t, output, "Scanning existing Claude Code hooks")
+	_, statErr := os.Stat(filepath.Join(stateDir, "hook-audit.json"))
+	assert.True(t, os.IsNotExist(statErr), "no audit should be written when init short-circuits")
+}
+
+// indexOf returns the byte index of substr in s, failing the test if absent.
+func indexOf(t *testing.T, s, substr string) int {
+	t.Helper()
+	idx := strings.Index(s, substr)
+	require.GreaterOrEqual(t, idx, 0, "expected output to contain %q", substr)
+	return idx
+}


### PR DESCRIPTION
Implements #39 — `hookwise init` now inventories existing Claude Code hooks (reusing the #33-36 scan engine) before writing config, prints per-event inventory + remediation findings, and persists `hook-audit.json` to the state dir atomically. Advisory-only: scan/report failures WARN and never block init; settings.json is never mutated (byte-identity asserted in tests).

Built autonomously by a Gas City polecat from a spec bead; independently code-reviewed (APPROVE-WITH-NITS, nits are cosmetic follow-ups) and verified locally: full unit suite green under `GOMEMLIMIT=4GiB go test -race -p 2 ./...`.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ