### PR TITLE
feat(audit): standalone hook health scan command (#38)

### DIFF
--- a/cmd/hookwise/cmd_audit.go
+++ b/cmd/hookwise/cmd_audit.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/vishnujayvel/hookwise/internal/hooks"
+)
+
+// auditSchemaVersion identifies the shape of `hookwise audit --json` output.
+// Bump when the structure changes incompatibly.
+const auditSchemaVersion = 1
+
+// errAuditFailed signals FAIL-level findings; main translates it into exit
+// code 1. The message is silenced (findings were already rendered).
+var errAuditFailed = errors.New("audit found FAIL-level issues")
+
+// auditReport is the JSON shape for `hookwise audit --json`. Performance data
+// is deliberately absent: per-dispatch latency tracking does not exist yet,
+// and the JSON contract must never carry fabricated numbers.
+type auditReport struct {
+	SchemaVersion int                `json:"schema_version"`
+	SettingsPaths []string           `json:"settings_paths"`
+	Inventory     auditInventory     `json:"inventory"`
+	Findings      []auditFindingJSON `json:"findings"`
+	Summary       auditSummary       `json:"summary"`
+}
+
+type auditInventory struct {
+	TotalHooks int              `json:"total_hooks"`
+	ByEvent    map[string]int   `json:"by_event"`
+	Hooks      []auditHookEntry `json:"hooks"`
+}
+
+type auditHookEntry struct {
+	Event      string `json:"event"`
+	Matcher    string `json:"matcher"`
+	Type       string `json:"type"`
+	Command    string `json:"command"`
+	SourceFile string `json:"source_file"`
+}
+
+type auditFindingJSON struct {
+	Level   string   `json:"level"`
+	Code    string   `json:"code"`
+	Message string   `json:"message"`
+	Details []string `json:"details,omitempty"`
+}
+
+type auditSummary struct {
+	Result   string `json:"result"` // PASS | WARN | FAIL
+	Warnings int    `json:"warnings"`
+	Failures int    `json:"failures"`
+}
+
+func newAuditCmd() *cobra.Command {
+	var jsonOut bool
+	var projectDir string
+
+	cmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Scan Claude Code hook configuration for health issues",
+		Long: "Scans Claude Code settings files for hook-safety issues: inventory/sprawl,\n" +
+			"missing binaries, network-dependent hooks on hot paths, and duplicate or\n" +
+			"overlapping hooks. Exits 0 on PASS/WARN, 1 on FAIL.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAudit(cmd, jsonOut, projectDir)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit a schema-versioned JSON report instead of text")
+	cmd.Flags().StringVar(&projectDir, "project-dir", "", "Scan <dir>/.claude/settings.json + settings.local.json instead of the user-level settings")
+	return cmd
+}
+
+// auditSettingsPaths resolves which settings files to scan: the project pair
+// when --project-dir is given, otherwise the user-level defaults.
+func auditSettingsPaths(projectDir string) []string {
+	if projectDir != "" {
+		return hooks.ProjectSettingsPaths(projectDir)
+	}
+	return hooks.DefaultSettingsPaths()
+}
+
+// auditFindings runs the scan once and returns the inventory plus the full
+// finding list. Malformed settings files become FAIL findings (never a crash):
+// a broken settings.json means the hook system's real state is unknowable,
+// which for a health audit is a failure — unlike doctor, which folds parse
+// errors into its warning count among many other checks.
+func auditFindings(paths []string) (*hooks.Inventory, []hooks.Finding) {
+	inv, err := hooks.Scan(paths)
+	if err != nil {
+		// Scan currently never returns a non-nil error, but stay fail-safe.
+		return &hooks.Inventory{}, []hooks.Finding{{
+			Level:   hooks.LevelFail,
+			Code:    "hook-settings",
+			Message: fmt.Sprintf("settings scan failed: %v", err),
+		}}
+	}
+
+	var out []hooks.Finding
+	for _, pe := range inv.ParseErrors {
+		out = append(out, hooks.Finding{
+			Level:   hooks.LevelFail,
+			Code:    "hook-settings",
+			Message: fmt.Sprintf("%s could not be parsed", pe.File),
+			Details: []string{
+				pe.Err.Error(),
+				"Hooks in this file are invisible to the scan — fix the JSON and re-run.",
+			},
+		})
+	}
+	return inv, append(out, hooks.AllFindings(inv, nil)...)
+}
+
+// summarize folds findings into the audit verdict. INFO counts as a warning
+// (matching doctor's checkHookSafety accounting); SCAN/PASS are neutral.
+func summarize(findings []hooks.Finding) auditSummary {
+	s := auditSummary{Result: "PASS"}
+	for _, f := range findings {
+		switch f.Level {
+		case hooks.LevelWarn, hooks.LevelInfo:
+			s.Warnings++
+		case hooks.LevelFail:
+			s.Failures++
+		}
+	}
+	switch {
+	case s.Failures > 0:
+		s.Result = "FAIL"
+	case s.Warnings > 0:
+		s.Result = "WARN"
+	}
+	return s
+}
+
+func runAudit(cmd *cobra.Command, jsonOut bool, projectDir string) error {
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	paths := auditSettingsPaths(projectDir)
+	inv, findings := auditFindings(paths)
+	summary := summarize(findings)
+
+	w := cmd.OutOrStdout()
+	if jsonOut {
+		if err := renderAuditJSON(w, paths, inv, findings, summary); err != nil {
+			return err
+		}
+	} else {
+		renderAuditText(w, paths, findings, summary)
+	}
+
+	if summary.Failures > 0 {
+		return errAuditFailed
+	}
+	return nil
+}
+
+// renderAuditText prints the human-readable report in doctor's house style.
+func renderAuditText(w io.Writer, paths []string, findings []hooks.Finding, summary auditSummary) {
+	fmt.Fprintln(w, "hookwise audit — hook health scan")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Settings scanned:")
+	for _, p := range paths {
+		fmt.Fprintf(w, "  %s\n", p)
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "HOOKS")
+	for _, f := range findings {
+		renderHookFinding(w, f)
+	}
+	fmt.Fprintln(w)
+
+	// Per-dispatch latency tracking does not exist yet; say so rather than
+	// fabricate numbers. This section is text-only and omitted from JSON.
+	fmt.Fprintln(w, "PERFORMANCE")
+	fmt.Fprintln(w, "  latency tracking not enabled")
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, strings.Repeat("-", 40))
+	switch summary.Result {
+	case "FAIL":
+		fmt.Fprintf(w, "Result: FAIL (%d warning(s), %d failure(s))\n", summary.Warnings, summary.Failures)
+	case "WARN":
+		fmt.Fprintf(w, "Result: WARN (%d warning(s))\n", summary.Warnings)
+	default:
+		fmt.Fprintln(w, "Result: PASS")
+	}
+}
+
+// renderAuditJSON emits the schema-versioned report, carrying the raw hook
+// entries from the same scan that produced the findings.
+func renderAuditJSON(w io.Writer, paths []string, inv *hooks.Inventory, findings []hooks.Finding, summary auditSummary) error {
+	byEvent := inv.CountByEvent()
+	entries := make([]auditHookEntry, 0, len(inv.Entries))
+	for _, e := range inv.Entries {
+		entries = append(entries, auditHookEntry{
+			Event:      e.Event,
+			Matcher:    e.Matcher,
+			Type:       e.Type,
+			Command:    e.Command,
+			SourceFile: e.SourceFile,
+		})
+	}
+
+	fs := make([]auditFindingJSON, 0, len(findings))
+	for _, f := range findings {
+		fs = append(fs, auditFindingJSON{
+			Level:   f.Level,
+			Code:    f.Code,
+			Message: f.Message,
+			Details: f.Details,
+		})
+	}
+
+	report := auditReport{
+		SchemaVersion: auditSchemaVersion,
+		SettingsPaths: paths,
+		Inventory: auditInventory{
+			TotalHooks: len(inv.Entries),
+			ByEvent:    byEvent,
+			Hooks:      entries,
+		},
+		Findings: fs,
+		Summary:  summary,
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}

--- a/cmd/hookwise/cmd_audit_test.go
+++ b/cmd/hookwise/cmd_audit_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/hooks"
+)
+
+// writeAuditSettings writes a settings.json into dir and returns its path.
+func writeAuditSettings(t *testing.T, dir, content string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	path := filepath.Join(dir, "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// healthySettings has two hooks whose binary ("echo") is always on PATH, so
+// the scan produces no WARN/FAIL findings.
+const healthySettings = `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "", "hooks": [{"type": "command", "command": "echo pre"}]}
+    ],
+    "PostToolUse": [
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo post"}]}
+    ]
+  }
+}`
+
+func TestAuditTextRendersInventoryAndPerformance(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeAuditSettings(t, claudeDir, healthySettings)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	output, err := executeCommand("audit")
+
+	require.NoError(t, err, "PASS must exit 0")
+	assert.Contains(t, output, "SCAN  hooks: 2 hooks across 2 events")
+	assert.Contains(t, output, "PreToolUse:")
+	assert.Contains(t, output, "PostToolUse:")
+	assert.Contains(t, output, "PERFORMANCE")
+	assert.Contains(t, output, "latency tracking not enabled")
+	assert.Contains(t, output, "Result: PASS")
+}
+
+func TestAuditJSONIsSchemaVersionedAndOmitsPerformance(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeAuditSettings(t, claudeDir, healthySettings)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	output, err := executeCommand("audit", "--json")
+	require.NoError(t, err)
+
+	// Assert on a raw map so we catch keys that must NOT exist (performance)
+	// and the presence of schema_version regardless of struct tags.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &raw), "output must be valid JSON")
+	assert.EqualValues(t, 1, raw["schema_version"])
+	assert.NotContains(t, raw, "performance",
+		"latency data does not exist yet — JSON must omit it, never fabricate")
+
+	var report auditReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	assert.Equal(t, 2, report.Inventory.TotalHooks)
+	assert.Equal(t, map[string]int{"PreToolUse": 1, "PostToolUse": 1}, report.Inventory.ByEvent)
+	assert.Equal(t, "PASS", report.Summary.Result)
+	require.NotEmpty(t, report.Findings)
+	assert.Equal(t, hooks.LevelScan, report.Findings[0].Level)
+}
+
+func TestAuditMalformedSettingsFailFindingNoPanic(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeAuditSettings(t, claudeDir, `{"hooks": {`) // truncated JSON
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	output, err := executeCommand("audit", "--json")
+
+	// Malformed settings must be reported as a FAIL finding and exit 1,
+	// never crash (ARCH-1 fail-open: report, don't panic).
+	require.Error(t, err, "FAIL must exit non-zero")
+
+	var report auditReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report), "JSON must still be emitted on FAIL")
+	assert.Equal(t, "FAIL", report.Summary.Result)
+	require.NotEmpty(t, report.Findings)
+	assert.Equal(t, hooks.LevelFail, report.Findings[0].Level)
+	assert.Equal(t, "hook-settings", report.Findings[0].Code)
+	assert.Contains(t, report.Findings[0].Message, "could not be parsed")
+}
+
+func TestAuditExitCodeFailOnMissingBinary(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeAuditSettings(t, claudeDir, `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "", "hooks": [{"type": "command", "command": "hookwise-definitely-not-installed-xyz run"}]}
+    ]
+  }
+}`)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	output, err := executeCommand("audit")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errAuditFailed)
+	assert.Contains(t, output, "hook-binary")
+	assert.Contains(t, output, "Result: FAIL")
+}
+
+func TestAuditWarnStillExitsZero(t *testing.T) {
+	claudeDir := t.TempDir()
+	// A network-dependent runner on a hot-path event yields WARN hook-network.
+	writeAuditSettings(t, claudeDir, `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "", "hooks": [{"type": "command", "command": "curl https://example.com/hook"}]}
+    ]
+  }
+}`)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	output, err := executeCommand("audit")
+
+	require.NoError(t, err, "WARN must exit 0 — only FAIL is exit 1")
+	assert.Contains(t, output, "hook-network")
+	assert.Contains(t, output, "Result: WARN")
+}
+
+func TestAuditProjectDirScansProjectSettingsPair(t *testing.T) {
+	// User-level dir has one hook; the project pair has different ones. With
+	// --project-dir only the project settings must be scanned.
+	userDir := t.TempDir()
+	writeAuditSettings(t, userDir, `{
+  "hooks": {"SessionStart": [{"matcher": "", "hooks": [{"type": "command", "command": "echo user-level"}]}]}
+}`)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", userDir)
+
+	projectDir := t.TempDir()
+	projectClaude := filepath.Join(projectDir, ".claude")
+	writeAuditSettings(t, projectClaude, `{
+  "hooks": {"PreToolUse": [{"matcher": "", "hooks": [{"type": "command", "command": "echo project-shared"}]}]}
+}`)
+	require.NoError(t, os.WriteFile(filepath.Join(projectClaude, "settings.local.json"), []byte(`{
+  "hooks": {"PostToolUse": [{"matcher": "", "hooks": [{"type": "command", "command": "echo project-local"}]}]}
+}`), 0o600))
+
+	output, err := executeCommand("audit", "--project-dir", projectDir, "--json")
+	require.NoError(t, err)
+
+	var report auditReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	assert.Equal(t, hooks.ProjectSettingsPaths(projectDir), report.SettingsPaths)
+	assert.Equal(t, 2, report.Inventory.TotalHooks,
+		"both project settings.json and settings.local.json hooks are scanned")
+	assert.NotContains(t, output, "user-level", "user settings must not leak into a project scan")
+
+	commands := []string{}
+	for _, h := range report.Inventory.Hooks {
+		commands = append(commands, h.Command)
+	}
+	assert.ElementsMatch(t, []string{"echo project-shared", "echo project-local"}, commands)
+}
+
+func TestAuditEmptySettingsIsPass(t *testing.T) {
+	claudeDir := t.TempDir() // no settings files at all
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	output, err := executeCommand("audit")
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "0 hooks across 0 events")
+	assert.Contains(t, output, "Result: PASS")
+}
+
+func TestAuditSummarize(t *testing.T) {
+	tests := []struct {
+		name     string
+		findings []hooks.Finding
+		want     auditSummary
+	}{
+		{
+			name:     "no findings is PASS",
+			findings: nil,
+			want:     auditSummary{Result: "PASS"},
+		},
+		{
+			name:     "scan-only is PASS",
+			findings: []hooks.Finding{{Level: hooks.LevelScan}},
+			want:     auditSummary{Result: "PASS"},
+		},
+		{
+			name:     "info counts as warning",
+			findings: []hooks.Finding{{Level: hooks.LevelInfo}},
+			want:     auditSummary{Result: "WARN", Warnings: 1},
+		},
+		{
+			name:     "warn is WARN",
+			findings: []hooks.Finding{{Level: hooks.LevelScan}, {Level: hooks.LevelWarn}},
+			want:     auditSummary{Result: "WARN", Warnings: 1},
+		},
+		{
+			name: "any fail dominates",
+			findings: []hooks.Finding{
+				{Level: hooks.LevelWarn},
+				{Level: hooks.LevelFail},
+				{Level: hooks.LevelInfo},
+			},
+			want: auditSummary{Result: "FAIL", Warnings: 2, Failures: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, summarize(tt.findings))
+		})
+	}
+}

--- a/cmd/hookwise/main.go
+++ b/cmd/hookwise/main.go
@@ -43,6 +43,7 @@ func newRootCmd() *cobra.Command {
 	}
 
 	rootCmd.AddCommand(
+		newAuditCmd(),
 		newDispatchCmd(),
 		newInitCmd(),
 		newDoctorCmd(),

--- a/internal/hooks/paths.go
+++ b/internal/hooks/paths.go
@@ -41,6 +41,14 @@ func DefaultSettingsPaths() []string {
 	return SettingsPaths(claudeDir)
 }
 
+// ProjectSettingsPaths returns the project-level settings files to scan for a
+// given project directory: <dir>/.claude/settings.json and
+// <dir>/.claude/settings.local.json. Like SettingsPaths, both are always
+// listed even if absent — Scan tolerates missing files.
+func ProjectSettingsPaths(projectDir string) []string {
+	return SettingsPaths(filepath.Join(projectDir, ".claude"))
+}
+
 // AllFindings runs every hook-safety analysis over the inventory and returns the
 // findings in a stable order: inventory (SCAN) → sprawl → missing binary →
 // network → duplicates/overlap. lookPath is injected for the binary check

--- a/internal/hooks/paths_test.go
+++ b/internal/hooks/paths_test.go
@@ -60,3 +60,14 @@ func TestDefaultSettingsPaths_HonorsClaudeDirEnv(t *testing.T) {
 	require.NotEmpty(t, paths)
 	assert.Equal(t, filepath.Join(claude, "settings.json"), paths[0])
 }
+
+func TestProjectSettingsPaths(t *testing.T) {
+	project := t.TempDir()
+
+	paths := ProjectSettingsPaths(project)
+
+	assert.Equal(t, []string{
+		filepath.Join(project, ".claude", "settings.json"),
+		filepath.Join(project, ".claude", "settings.local.json"),
+	}, paths, "project scan targets the <dir>/.claude settings pair, settings.json first")
+}


### PR DESCRIPTION
Implements #38 — new `hookwise audit` command: per-event hook inventory, binary/network/sprawl/duplicate findings, risk summary; `--json` (schema_version 1, pipe-clean stdout); `--project-dir` via new `hooks.ProjectSettingsPaths`; exit 0 PASS/WARN, 1 FAIL; malformed settings.json becomes a FAIL finding, never a panic. Thin composition over the existing #33-36 scan engine — zero re-implemented scan logic. PERFORMANCE section honestly reports "latency tracking not enabled" (omitted from JSON) until #37 exists.

Built autonomously by a Gas City polecat from a spec bead; independently code-reviewed (clean APPROVE, incl. binary smoke test proving read-only via file-hash comparison) and verified locally: full unit suite green under `GOMEMLIMIT=4GiB go test -race -p 2 ./...`.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ