### PR TITLE
polish(init,audit): snake_case audit findings + review-nit tests

### DIFF
--- a/cmd/hookwise/cmd_audit_test.go
+++ b/cmd/hookwise/cmd_audit_test.go
@@ -94,6 +94,23 @@ func TestAuditMalformedSettingsFailFindingNoPanic(t *testing.T) {
 	assert.Contains(t, report.Findings[0].Message, "could not be parsed")
 }
 
+func TestAuditMalformedSettingsTextRender(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeAuditSettings(t, claudeDir, `{"hooks": {`) // truncated JSON
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	output, err := executeCommand("audit")
+
+	// Same FAIL contract as the JSON path, rendered as text.
+	require.Error(t, err, "FAIL must exit non-zero")
+	assert.ErrorIs(t, err, errAuditFailed)
+	assert.Contains(t, output, "FAIL")
+	assert.Contains(t, output, "hook-settings")
+	assert.Contains(t, output, "could not be parsed")
+	assert.Contains(t, output, "fix the JSON and re-run")
+	assert.Contains(t, output, "Result: FAIL")
+}
+
 func TestAuditExitCodeFailOnMissingBinary(t *testing.T) {
 	claudeDir := t.TempDir()
 	writeAuditSettings(t, claudeDir, `{

--- a/cmd/hookwise/cmd_init.go
+++ b/cmd/hookwise/cmd_init.go
@@ -192,11 +192,11 @@ func runWire(cmd *cobra.Command, wire, unwire, dryRun bool, events []string, noS
 // written to <state dir>/hook-audit.json so the pre-init state of the user's
 // Claude Code hooks survives as an artifact (e.g. for support and doctor).
 type hookAuditReport struct {
-	GeneratedAt  time.Time        `json:"generated_at"`
-	ScannedPaths []string         `json:"scanned_paths"`
-	Hooks        []hookAuditEntry `json:"hooks"`
-	Findings     []hooks.Finding  `json:"findings"`
-	ParseErrors  []string         `json:"parse_errors,omitempty"`
+	GeneratedAt  time.Time          `json:"generated_at"`
+	ScannedPaths []string           `json:"scanned_paths"`
+	Hooks        []hookAuditEntry   `json:"hooks"`
+	Findings     []hookAuditFinding `json:"findings"`
+	ParseErrors  []string           `json:"parse_errors,omitempty"`
 }
 
 // hookAuditEntry mirrors hooks.HookEntry with stable snake_case JSON keys.
@@ -206,6 +206,15 @@ type hookAuditEntry struct {
 	Type       string `json:"type"`
 	Command    string `json:"command"`
 	SourceFile string `json:"source_file"`
+}
+
+// hookAuditFinding mirrors hooks.Finding with stable snake_case JSON keys, so
+// the on-disk schema stays uniform and decoupled from internal/hooks.
+type hookAuditFinding struct {
+	Level   string   `json:"level"`
+	Code    string   `json:"code"`
+	Message string   `json:"message"`
+	Details []string `json:"details,omitempty"`
 }
 
 // hookAuditFile is the report file name under the state dir.
@@ -245,7 +254,15 @@ func scanExistingHooks(out io.Writer) {
 		GeneratedAt:  time.Now().UTC(),
 		ScannedPaths: paths,
 		Hooks:        make([]hookAuditEntry, 0, len(inv.Entries)),
-		Findings:     findings,
+		Findings:     make([]hookAuditFinding, 0, len(findings)),
+	}
+	for _, f := range findings {
+		report.Findings = append(report.Findings, hookAuditFinding{
+			Level:   f.Level,
+			Code:    f.Code,
+			Message: f.Message,
+			Details: f.Details,
+		})
 	}
 	for _, e := range inv.Entries {
 		report.Hooks = append(report.Hooks, hookAuditEntry{
@@ -265,7 +282,7 @@ func scanExistingHooks(out io.Writer) {
 		fmt.Fprintf(out, "WARN  hook-audit: could not write %s: %v\n", auditPath, err)
 		return
 	}
-	fmt.Fprintf(out, "Hook audit saved to %s\n\n", auditPath)
+	fmt.Fprintf(out, "Hook audit saved to %s\n", auditPath)
 }
 
 func runInit(cmd *cobra.Command, args []string) error {

--- a/cmd/hookwise/cmd_init_scan_test.go
+++ b/cmd/hookwise/cmd_init_scan_test.go
@@ -96,15 +96,21 @@ func TestInitScansExistingHooks(t *testing.T) {
 			Command    string `json:"command"`
 			SourceFile string `json:"source_file"`
 		} `json:"hooks"`
-		Findings []struct {
-			Level string
-			Code  string
-		} `json:"findings"`
+		Findings []map[string]any `json:"findings"`
 	}
 	require.NoError(t, json.Unmarshal(data, &report))
 	assert.NotEmpty(t, report.GeneratedAt)
 	assert.Len(t, report.Hooks, 3)
-	assert.NotEmpty(t, report.Findings)
+	require.NotEmpty(t, report.Findings)
+	// Findings must serialize with the same snake_case keys as the rest of
+	// the report, not internal/hooks PascalCase field names.
+	for _, f := range report.Findings {
+		assert.Contains(t, f, "level")
+		assert.Contains(t, f, "code")
+		assert.Contains(t, f, "message")
+		assert.NotContains(t, f, "Level")
+		assert.NotContains(t, f, "Details")
+	}
 	for _, h := range report.Hooks {
 		assert.Equal(t, settingsPath, h.SourceFile)
 	}
@@ -185,6 +191,42 @@ func TestInitScanReportsParseErrors(t *testing.T) {
 	after, err := os.ReadFile(settingsPath)
 	require.NoError(t, err)
 	assert.Equal(t, malformed, after)
+}
+
+func TestInitScanReportsLocalSettingsParseErrors(t *testing.T) {
+	claudeDir, stateDir := setupInitScanEnv(t)
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	localPath := filepath.Join(claudeDir, "settings.local.json")
+	require.NoError(t, os.WriteFile(settingsPath, []byte(settingsWithHooks), 0o600))
+	malformedLocal := []byte(`{"hooks": [broken`)
+	require.NoError(t, os.WriteFile(localPath, malformedLocal, 0o600))
+
+	output, err := executeCommand("init")
+	require.NoError(t, err, "init must not fail on malformed settings.local.json: %s", output)
+
+	// The parse error names the local file; the valid settings.json still scans.
+	assert.Contains(t, output, "settings.local.json could not be parsed")
+	assert.Contains(t, output, "3 hooks across 2 events")
+	assert.Contains(t, output, "Created")
+
+	data, err := os.ReadFile(filepath.Join(stateDir, "hook-audit.json"))
+	require.NoError(t, err)
+	var report struct {
+		ParseErrors []string `json:"parse_errors"`
+	}
+	require.NoError(t, json.Unmarshal(data, &report))
+	require.Len(t, report.ParseErrors, 1)
+	assert.Contains(t, report.ParseErrors[0], "settings.local.json")
+
+	// Neither settings file is rewritten, byte for byte.
+	after, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(settingsWithHooks), after,
+		"init must leave settings.json byte-identical")
+	afterLocal, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+	assert.Equal(t, malformedLocal, afterLocal,
+		"init must leave malformed settings.local.json byte-identical")
 }
 
 func TestInitSkipsScanWhenConfigExists(t *testing.T) {


### PR DESCRIPTION
Follow-ups from the independent code reviews of #230/#231: `hook-audit.json` findings now serialize uniformly snake_case via a local mirror struct (schema decoupled from `internal/hooks`); adds malformed `settings.local.json` byte-identity case and a text-render malformed-settings assertion; drops a stray blank line in init output.

Built autonomously by a Gas City polecat from the reviewers' nit list; verified locally: guarded unit gate green (`GOMEMLIMIT=4GiB go test -race -p 2`), diff surface confirmed limited to cmd_init/cmd_audit + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook audit reporting for malformed settings files.
  * Audit output now clearly shows failure status, parse errors, finding codes, and remediation guidance.
  * Initialization continues scanning valid settings when a local settings file is malformed.
  * Settings files are preserved without modification when parse errors occur.
  * Saved audit reports now use consistent, stable field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->