### PR TITLE
feat(analytics): per-dispatch latency tracking (#37)

### DIFF
--- a/cmd/hookwise/cli_test.go
+++ b/cmd/hookwise/cli_test.go
@@ -995,7 +995,7 @@ func TestRecordAnalytics_SessionStart(t *testing.T) {
 	dbPath := filepath.Join(tmpDir, "analytics.db")
 
 	payload := core.HookPayload{SessionID: "test-session-001"}
-	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, core.CostTrackingConfig{})
+	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, core.CostTrackingConfig{}, nil)
 
 	// Verify session was recorded.
 	db, err := analytics.Open(dbPath)
@@ -1021,11 +1021,11 @@ func TestRecordAnalytics_PostToolUse(t *testing.T) {
 
 	// First create a session.
 	payload := core.HookPayload{SessionID: "test-session-002"}
-	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, core.CostTrackingConfig{})
+	recordAnalytics(context.Background(), core.EventSessionStart, payload, dbPath, core.CostTrackingConfig{}, nil)
 
 	// Record a tool use event.
 	payload.ToolName = "Bash"
-	recordAnalytics(context.Background(), core.EventPostToolUse, payload, dbPath, core.CostTrackingConfig{})
+	recordAnalytics(context.Background(), core.EventPostToolUse, payload, dbPath, core.CostTrackingConfig{}, nil)
 
 	db, err := analytics.Open(dbPath)
 	if err != nil {

--- a/cmd/hookwise/cmd_dispatch.go
+++ b/cmd/hookwise/cmd_dispatch.go
@@ -74,6 +74,13 @@ func newDispatchCmd() *cobra.Command {
 				// Run the three-phase dispatch engine
 				dispatchResult := core.Dispatch(ctx, eventType, payload, config)
 
+				// Per-dispatch latency (gh#37): wall-clock around handler
+				// execution only. Measured before budget enforcement and
+				// analytics so those side effects don't inflate it. Recording
+				// it is itself a fail-open side effect — a broken clock or DB
+				// must never change dispatch behavior (ARCH-1).
+				dispatchLatencyMs := time.Since(dispatchStart).Milliseconds()
+
 				// Budget enforcement (PreToolUse only, opt-in via
 				// cost_tracking.enforcement: enforce). A deny here is the hardest
 				// gate, so it overrides whatever dispatch decided. Off by default,
@@ -107,7 +114,7 @@ func newDispatchCmd() *cobra.Command {
 					done := make(chan struct{})
 					go func() {
 						defer close(done)
-						recordAnalytics(ctx, eventType, payload, config.Analytics.DBPath, config.CostTracking)
+						recordAnalytics(ctx, eventType, payload, config.Analytics.DBPath, config.CostTracking, &dispatchLatencyMs)
 					}()
 					select {
 					case <-done:
@@ -215,7 +222,9 @@ const analyticsRecordTimeout = 2 * time.Second
 // recordAnalytics writes session/event data to the SQLite analytics DB. The
 // caller waits for it (bounded) before os.Exit so the write actually persists.
 // Fail-open: any error is logged but never surfaces to the user (ARCH-1).
-func recordAnalytics(ctx context.Context, eventType string, payload core.HookPayload, dataDir string, costCfg core.CostTrackingConfig) {
+// dispatchLatencyMs is the measured handler duration for this dispatch; nil
+// means "not measured" and persists as NULL on the event row.
+func recordAnalytics(ctx context.Context, eventType string, payload core.HookPayload, dataDir string, costCfg core.CostTrackingConfig, dispatchLatencyMs *int64) {
 	defer func() {
 		if r := recover(); r != nil {
 			core.Logger().Error("panic in analytics recording", "recovered", fmt.Sprintf("%v", r))
@@ -244,9 +253,10 @@ func recordAnalytics(ctx context.Context, eventType string, payload core.HookPay
 
 	case core.EventPostToolUse:
 		event := analytics.EventRecord{
-			EventType: eventType,
-			ToolName:  payload.ToolName,
-			Timestamp: now,
+			EventType:         eventType,
+			ToolName:          payload.ToolName,
+			Timestamp:         now,
+			DispatchLatencyMs: dispatchLatencyMs,
 		}
 		if err := a.RecordEvent(ctx, payload.SessionID, event); err != nil {
 			core.Logger().Error("analytics: record event", "error", err)

--- a/cmd/hookwise/cmd_dispatch_cost_test.go
+++ b/cmd/hookwise/cmd_dispatch_cost_test.go
@@ -62,7 +62,7 @@ func TestRecordAnalytics_CostStop(t *testing.T) {
 		SessionID:      sid,
 		TranscriptPath: transcriptPath,
 	}
-	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg, nil)
 
 	// Re-open to assert.
 	db = openTestDB(t, dbPath)
@@ -104,10 +104,10 @@ func TestRecordAnalytics_CostStop_Idempotent(t *testing.T) {
 	}
 
 	// First Stop.
-	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg, nil)
 
 	// Second Stop — same transcript, same session.
-	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg, nil)
 
 	db = openTestDB(t, dbPath)
 	defer db.Close()
@@ -143,7 +143,7 @@ func TestRecordAnalytics_CostStop_TranscriptGrows(t *testing.T) {
 	payload := core.HookPayload{SessionID: sid, TranscriptPath: transcriptPath}
 
 	// Turn 1: single line => $18.
-	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg, nil)
 
 	// The transcript grows by one more identical assistant line (another $18)
 	// before the next turn's Stop, exactly as a live session accumulates usage.
@@ -155,7 +155,7 @@ func TestRecordAnalytics_CostStop_TranscriptGrows(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	// Turn 2: two lines => $36 recomputed; delta +$18 applied.
-	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg, nil)
 
 	db = openTestDB(t, dbPath)
 	defer db.Close()
@@ -209,7 +209,7 @@ func TestRecordAnalytics_CostStop_NegativeDelta(t *testing.T) {
 
 	costCfg := core.CostTrackingConfig{Enabled: true}
 	payload := core.HookPayload{SessionID: sid, TranscriptPath: transcriptPath}
-	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg, nil)
 
 	db = openTestDB(t, dbPath)
 	defer db.Close()
@@ -246,7 +246,7 @@ func TestRecordAnalytics_CostStop_Disabled(t *testing.T) {
 		SessionID:      sid,
 		TranscriptPath: transcriptPath,
 	}
-	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg, nil)
 
 	db = openTestDB(t, dbPath)
 	defer db.Close()
@@ -279,7 +279,7 @@ func TestRecordAnalytics_CostStop_NoTranscript(t *testing.T) {
 
 	// Must not panic.
 	require.NotPanics(t, func() {
-		recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+		recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg, nil)
 	})
 
 	db = openTestDB(t, dbPath)
@@ -325,7 +325,7 @@ func TestRecordAnalytics_CostStop_RatesOverride(t *testing.T) {
 		Rates:   map[string]float64{"sonnet.input": 99.0},
 	}
 	payload := core.HookPayload{SessionID: sid, TranscriptPath: transcriptPath}
-	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg)
+	recordAnalytics(context.Background(), core.EventStop, payload, dbPath, costCfg, nil)
 
 	db = openTestDB(t, dbPath)
 	defer db.Close()

--- a/cmd/hookwise/cmd_dispatch_latency_test.go
+++ b/cmd/hookwise/cmd_dispatch_latency_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/analytics"
+	"github.com/vishnujayvel/hookwise/internal/core"
+)
+
+// queryLatency reads the dispatch_latency_ms of the single event row for the
+// given session.
+func queryLatency(t *testing.T, dbPath, sessionID string) sql.NullInt64 {
+	t.Helper()
+	db := openTestDB(t, dbPath)
+	defer db.Close()
+	var latency sql.NullInt64
+	require.NoError(t, db.QueryRow(context.Background(),
+		"SELECT dispatch_latency_ms FROM events WHERE session_id = ?", sessionID,
+	).Scan(&latency))
+	return latency
+}
+
+// TestRecordAnalytics_WritesDispatchLatency is the gh#37 write-path test: a
+// PostToolUse dispatch with a measured latency must persist a non-NULL
+// dispatch_latency_ms on the event row.
+func TestRecordAnalytics_WritesDispatchLatency(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+	sid := "latency-write-001"
+
+	latencyMs := int64(12)
+	recordAnalytics(context.Background(), core.EventPostToolUse,
+		core.HookPayload{SessionID: sid, ToolName: "Bash"},
+		dbPath, core.CostTrackingConfig{}, &latencyMs)
+
+	got := queryLatency(t, dbPath, sid)
+	require.True(t, got.Valid, "dispatch must write a non-NULL latency")
+	assert.Equal(t, int64(12), got.Int64)
+}
+
+// TestRecordAnalytics_NilLatencyStaysNull verifies the nil contract: callers
+// without a measurement (and a real 0ms dispatch stays distinguishable from
+// them) persist NULL, never a fabricated value.
+func TestRecordAnalytics_NilLatencyStaysNull(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+	sid := "latency-nil-001"
+
+	recordAnalytics(context.Background(), core.EventPostToolUse,
+		core.HookPayload{SessionID: sid, ToolName: "Bash"},
+		dbPath, core.CostTrackingConfig{}, nil)
+
+	got := queryLatency(t, dbPath, sid)
+	assert.False(t, got.Valid, "nil latency must persist as NULL")
+}
+
+// TestRecordAnalytics_ZeroLatencyIsNotNull pins the 0ms-vs-NULL distinction:
+// a sub-millisecond dispatch rounds to 0ms and must still persist as a real
+// measurement, not be dropped as "absent".
+func TestRecordAnalytics_ZeroLatencyIsNotNull(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+	sid := "latency-zero-001"
+
+	latencyMs := int64(0)
+	recordAnalytics(context.Background(), core.EventPostToolUse,
+		core.HookPayload{SessionID: sid, ToolName: "Bash"},
+		dbPath, core.CostTrackingConfig{}, &latencyMs)
+
+	got := queryLatency(t, dbPath, sid)
+	require.True(t, got.Valid, "a real 0ms measurement must not persist as NULL")
+	assert.Equal(t, int64(0), got.Int64)
+}
+
+// seedLatencyEvents writes n PostToolUse events with the given latencies at
+// the given timestamp directly through the analytics layer.
+func seedLatencyEvents(t *testing.T, dbPath string, ts time.Time, latencies ...int64) {
+	t.Helper()
+	db := openTestDB(t, dbPath)
+	defer db.Close()
+	a := analytics.NewAnalytics(db)
+	for i, ms := range latencies {
+		ms := ms
+		require.NoError(t, a.RecordEvent(context.Background(),
+			fmt.Sprintf("latency-seed-%d", i),
+			analytics.EventRecord{
+				EventType:         "PostToolUse",
+				ToolName:          "Bash",
+				Timestamp:         ts,
+				DispatchLatencyMs: &ms,
+			}))
+	}
+}
+
+// TestRunStats_LatencySection verifies stats renders the latency section with
+// percentiles when today's events carry latency data.
+func TestRunStats_LatencySection(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	// stats aggregates by UTC day; seed with UTC now so LIKE matches.
+	seedLatencyEvents(t, dbPath, time.Now().UTC(), 10, 20, 30, 40)
+
+	cmd := newStatsCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"--data-dir", dbPath})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "Dispatch latency (ms):")
+	assert.Contains(t, out, "overall")
+	assert.Contains(t, out, "PostToolUse", "per-event-type breakdown must render")
+	// 10,20,30,40 → avg 25.0, p50=20, p95/p99/max=40 (nearest-rank).
+	assert.Contains(t, out, "avg   25.0")
+	assert.Contains(t, out, "p50   20")
+	assert.Contains(t, out, "max   40")
+	assert.Contains(t, out, "(n=4)")
+}
+
+// TestRunStats_LatencySectionOmittedWhenEmpty is the older-DB honesty test:
+// with no latency data at all (rows predate the column or no dispatches), the
+// section must be absent entirely — never rendered with fabricated zeros.
+func TestRunStats_LatencySectionOmittedWhenEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise"))
+	dbPath := filepath.Join(tmpDir, "analytics.db")
+
+	// Seed one event WITHOUT latency (the migrated-older-DB shape).
+	db := openTestDB(t, dbPath)
+	a := analytics.NewAnalytics(db)
+	require.NoError(t, a.RecordEvent(context.Background(), "no-latency-session",
+		analytics.EventRecord{EventType: "PostToolUse", ToolName: "Bash", Timestamp: time.Now().UTC()}))
+	db.Close()
+
+	cmd := newStatsCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"--data-dir", dbPath})
+	require.NoError(t, cmd.Execute())
+
+	assert.NotContains(t, buf.String(), "Dispatch latency",
+		"latency section must be skipped entirely when no latency data exists")
+}

--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -123,6 +124,11 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// default), $0 is expected, not a malfunction. Mirrors the feed
 	// zero-liveness / disabled-subsystem honesty principle.
 	warnings += checkCostHonesty(w, dbPath, costEnabled)
+
+	// Check 9: Dispatch latency (gh#37). WARN when the 7-day average exceeds
+	// the threshold; silent when no latency data exists (older DBs / no
+	// dispatches) — disabled-subsystem honesty, same as #222/#223.
+	warnings += checkDispatchLatency(w, dbPath)
 
 	// Check 4: Daemon liveness via socket dial (replaces PID file check).
 	// Use GetStateDir() to respect HOOKWISE_STATE_DIR env override.
@@ -638,4 +644,50 @@ func checkCostHonesty(w io.Writer, dbPath string, costEnabled bool) int {
 			summary.EstimatedCostUSD, summary.TotalSessions)
 		return 0
 	}
+}
+
+// dispatchLatencyWarnMs is the 7-day average dispatch latency above which
+// doctor warns. Dispatch sits on every hook invocation, so a sustained
+// average past this threshold means hooks are visibly slowing tool calls.
+const dispatchLatencyWarnMs = 50.0
+
+// checkDispatchLatency reports a doctor warning when the average dispatch
+// latency over the last 7 days exceeds dispatchLatencyWarnMs. No latency data
+// (DB predates the dispatch_latency_ms column, or no recent dispatches) means
+// no output at all — absence of measurement is not health, and warning on it
+// would be fabrication (disabled-subsystem honesty, #222/#223). Absent or
+// unopenable DBs are silent no-ops — the analytics check (Check 3) owns those.
+func checkDispatchLatency(w io.Writer, dbPath string) int {
+	if _, err := os.Stat(dbPath); err != nil {
+		return 0
+	}
+	db, err := analytics.Open(dbPath)
+	if err != nil {
+		return 0
+	}
+	defer db.Close()
+
+	// Timestamps are stored as UTC RFC3339 strings, so a lexicographic >=
+	// against a same-format cutoff is a correct time comparison.
+	cutoff := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
+	var avg sql.NullFloat64
+	var count int
+	err = db.QueryRow(context.Background(),
+		`SELECT AVG(dispatch_latency_ms), COUNT(*)
+		 FROM events
+		 WHERE dispatch_latency_ms IS NOT NULL AND timestamp >= ?`,
+		cutoff,
+	).Scan(&avg, &count)
+	if err != nil || count == 0 || !avg.Valid {
+		return 0
+	}
+
+	if avg.Float64 > dispatchLatencyWarnMs {
+		fmt.Fprintf(w, "WARN  latency: avg dispatch latency %.1fms over last 7 days exceeds %.0fms (%d dispatch(es)) -- hooks are slowing tool calls\n",
+			avg.Float64, dispatchLatencyWarnMs, count)
+		return 1
+	}
+	fmt.Fprintf(w, "PASS  latency: avg dispatch %.1fms over last 7 days (%d dispatch(es))\n",
+		avg.Float64, count)
+	return 0
 }

--- a/cmd/hookwise/cmd_doctor_latency_test.go
+++ b/cmd/hookwise/cmd_doctor_latency_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCheckDispatchLatency_WarnsOverThreshold seeds a 7-day window whose
+// average dispatch latency exceeds the 50ms threshold and expects exactly one
+// WARN.
+func TestCheckDispatchLatency_WarnsOverThreshold(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	// avg(60,80,100) = 80ms > 50ms.
+	seedLatencyEvents(t, dbPath, time.Now().UTC(), 60, 80, 100)
+
+	buf := &bytes.Buffer{}
+	warnings := checkDispatchLatency(buf, dbPath)
+
+	out := buf.String()
+	assert.Equal(t, 1, warnings, "avg over threshold must produce exactly one warning")
+	assert.Contains(t, out, "WARN  latency:")
+	assert.Contains(t, out, "80.0ms", "warning must state the measured average")
+	assert.Contains(t, out, "exceeds 50ms")
+}
+
+// TestCheckDispatchLatency_PassesUnderThreshold is the discriminating
+// negative: a healthy average must PASS, not warn.
+func TestCheckDispatchLatency_PassesUnderThreshold(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	// avg(10,20,30) = 20ms <= 50ms.
+	seedLatencyEvents(t, dbPath, time.Now().UTC(), 10, 20, 30)
+
+	buf := &bytes.Buffer{}
+	warnings := checkDispatchLatency(buf, dbPath)
+
+	out := buf.String()
+	assert.Equal(t, 0, warnings, "healthy average must not warn")
+	assert.Contains(t, out, "PASS  latency: avg dispatch 20.0ms")
+	assert.NotContains(t, out, "WARN")
+}
+
+// TestCheckDispatchLatency_IgnoresOldEvents verifies the 7-day window: slow
+// dispatches older than 7 days must not trigger the warning (and with nothing
+// recent, the check stays silent).
+func TestCheckDispatchLatency_IgnoresOldEvents(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	// Very slow, but 8 days ago — outside the window.
+	seedLatencyEvents(t, dbPath, time.Now().UTC().AddDate(0, 0, -8), 500, 900)
+
+	buf := &bytes.Buffer{}
+	warnings := checkDispatchLatency(buf, dbPath)
+
+	assert.Equal(t, 0, warnings, "events outside the 7-day window must not warn")
+	assert.Empty(t, buf.String(), "no in-window data must produce no output")
+}
+
+// TestCheckDispatchLatency_NoLatencyDataSilent is the disabled-subsystem
+// honesty test (#222/#223 precedent): a DB whose events all predate the
+// dispatch_latency_ms column (NULL rows only) has no measurements — the check
+// must emit nothing rather than warn or fabricate a PASS.
+func TestCheckDispatchLatency_NoLatencyDataSilent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db := openTestDB(t, dbPath) // schema created, zero events
+	db.Close()
+
+	buf := &bytes.Buffer{}
+	warnings := checkDispatchLatency(buf, dbPath)
+
+	assert.Equal(t, 0, warnings)
+	assert.Empty(t, buf.String(), "absent latency data must produce no output")
+}
+
+// TestCheckDispatchLatency_NoDB verifies graceful no-op when the analytics DB
+// does not exist — the analytics check (Check 3) owns that report.
+func TestCheckDispatchLatency_NoDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "does-not-exist.db")
+
+	buf := &bytes.Buffer{}
+	warnings := checkDispatchLatency(buf, dbPath)
+
+	assert.Equal(t, 0, warnings)
+	assert.Empty(t, buf.String())
+}

--- a/cmd/hookwise/cmd_stats.go
+++ b/cmd/hookwise/cmd_stats.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -94,5 +95,27 @@ func runStats(cmd *cobra.Command, dataDir string) error {
 		fmt.Fprintln(w, "\nNo tool usage recorded today.")
 	}
 
+	// Dispatch latency (gh#37). Skipped entirely when no latency data exists
+	// for the day — events written before the dispatch_latency_ms column
+	// (older DBs) are NULL and must not be rendered as fabricated 0ms rows.
+	latency, err := a.LatencyStats(ctx, today)
+	if err != nil {
+		return fmt.Errorf("latency stats: %w", err)
+	}
+	if latency.Overall.Count > 0 {
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, "Dispatch latency (ms):")
+		printLatencyBucket(w, "overall", latency.Overall)
+		for _, bucket := range latency.ByEvent {
+			printLatencyBucket(w, bucket.EventType, bucket)
+		}
+	}
+
 	return nil
+}
+
+// printLatencyBucket renders one row of the stats latency section.
+func printLatencyBucket(w io.Writer, label string, b analytics.LatencyBucket) {
+	fmt.Fprintf(w, "  %-16s avg %6.1f  p50 %4d  p95 %4d  p99 %4d  max %4d  (n=%d)\n",
+		label, b.AvgMs, b.P50Ms, b.P95Ms, b.P99Ms, b.MaxMs, b.Count)
 }

--- a/cmd/hookwise/cmd_stats_test.go
+++ b/cmd/hookwise/cmd_stats_test.go
@@ -68,7 +68,7 @@ func TestRunStats_ReadsConfigDBPath(t *testing.T) {
 	recordAnalytics(context.Background(), core.EventStop, core.HookPayload{
 		SessionID:      sid,
 		TranscriptPath: transcriptPath,
-	}, customDB, core.CostTrackingConfig{Enabled: true})
+	}, customDB, core.CostTrackingConfig{Enabled: true}, nil)
 
 	// Run `stats` from the project dir with NO --data-dir flag.
 	t.Chdir(projectDir)

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"time"
 )
 
@@ -29,6 +30,10 @@ type EventRecord struct {
 	LinesAdded        int
 	LinesRemoved      int
 	AIConfidenceScore float64
+	// DispatchLatencyMs is the wall-clock duration of the dispatch handler
+	// run that produced this event. nil means "not measured" (writers
+	// predating gh#37) and persists as NULL — distinct from a real 0ms.
+	DispatchLatencyMs *int64
 }
 
 // AuthorshipEntry describes a single authorship ledger row.
@@ -58,6 +63,28 @@ type ToolBreakdownEntry struct {
 	ToolName   string
 	Count      int
 	Percentage float64
+}
+
+// LatencyBucket holds dispatch-latency aggregates for one grouping (overall
+// or a single event type). Percentiles use the nearest-rank method on the
+// recorded millisecond values.
+type LatencyBucket struct {
+	EventType string // "" for the overall bucket
+	Count     int
+	AvgMs     float64
+	P50Ms     int64
+	P95Ms     int64
+	P99Ms     int64
+	MaxMs     int64
+}
+
+// LatencyStatsResult holds the overall dispatch-latency aggregates plus a
+// per-event-type breakdown, ordered by count descending. Overall.Count == 0
+// means no latency data exists for the date (rows predating the
+// dispatch_latency_ms column stay NULL and are excluded).
+type LatencyStatsResult struct {
+	Overall LatencyBucket
+	ByEvent []LatencyBucket
 }
 
 // ---------------------------------------------------------------------------
@@ -138,8 +165,8 @@ func (a *Analytics) EndSession(ctx context.Context, sessionID string, endedAt ti
 // RecordEvent inserts a row into the events table.
 func (a *Analytics) RecordEvent(ctx context.Context, sessionID string, event EventRecord) error {
 	_, err := a.db.Exec(ctx,
-		`INSERT INTO events (session_id, event_type, tool_name, timestamp, file_path, lines_added, lines_removed, ai_confidence_score)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO events (session_id, event_type, tool_name, timestamp, file_path, lines_added, lines_removed, ai_confidence_score, dispatch_latency_ms)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		sessionID,
 		event.EventType,
 		event.ToolName,
@@ -148,6 +175,7 @@ func (a *Analytics) RecordEvent(ctx context.Context, sessionID string, event Eve
 		event.LinesAdded,
 		event.LinesRemoved,
 		event.AIConfidenceScore,
+		event.DispatchLatencyMs, // nil → NULL
 	)
 	if err != nil {
 		return fmt.Errorf("analytics: record event: %w", err)
@@ -289,4 +317,80 @@ func (a *Analytics) ToolBreakdown(ctx context.Context, date string) ([]ToolBreak
 	}
 
 	return entries, nil
+}
+
+// LatencyStats returns dispatch-latency aggregates for a given date
+// (YYYY-MM-DD): overall avg/p50/p95/p99/max plus a per-event-type breakdown.
+// Only rows with a non-NULL dispatch_latency_ms count — events recorded before
+// the column existed are excluded, never fabricated as 0ms.
+func (a *Analytics) LatencyStats(ctx context.Context, date string) (*LatencyStatsResult, error) {
+	rows, err := a.db.Query(ctx,
+		`SELECT event_type, dispatch_latency_ms
+		 FROM events
+		 WHERE dispatch_latency_ms IS NOT NULL AND timestamp LIKE ?
+		 ORDER BY dispatch_latency_ms ASC`,
+		date+"%",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("analytics: latency stats: %w", err)
+	}
+	defer rows.Close()
+
+	// Rows arrive pre-sorted by latency, so each per-type slice (and the
+	// overall slice) stays sorted — percentiles read straight off them.
+	var all []int64
+	byType := map[string][]int64{}
+	for rows.Next() {
+		var eventType string
+		var ms int64
+		if err := rows.Scan(&eventType, &ms); err != nil {
+			return nil, fmt.Errorf("analytics: latency stats scan: %w", err)
+		}
+		all = append(all, ms)
+		byType[eventType] = append(byType[eventType], ms)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("analytics: latency stats rows: %w", err)
+	}
+
+	result := &LatencyStatsResult{Overall: latencyBucket("", all)}
+	for eventType, values := range byType {
+		result.ByEvent = append(result.ByEvent, latencyBucket(eventType, values))
+	}
+	sort.Slice(result.ByEvent, func(i, j int) bool {
+		if result.ByEvent[i].Count != result.ByEvent[j].Count {
+			return result.ByEvent[i].Count > result.ByEvent[j].Count
+		}
+		return result.ByEvent[i].EventType < result.ByEvent[j].EventType
+	})
+	return result, nil
+}
+
+// latencyBucket aggregates a sorted-ascending slice of latency values.
+func latencyBucket(eventType string, sorted []int64) LatencyBucket {
+	b := LatencyBucket{EventType: eventType, Count: len(sorted)}
+	if len(sorted) == 0 {
+		return b
+	}
+	var sum int64
+	for _, v := range sorted {
+		sum += v
+	}
+	b.AvgMs = float64(sum) / float64(len(sorted))
+	b.P50Ms = percentileNearestRank(sorted, 0.50)
+	b.P95Ms = percentileNearestRank(sorted, 0.95)
+	b.P99Ms = percentileNearestRank(sorted, 0.99)
+	b.MaxMs = sorted[len(sorted)-1]
+	return b
+}
+
+// percentileNearestRank returns the q-th percentile (0 < q <= 1) of a
+// sorted-ascending slice using the nearest-rank method: the value at
+// ceil(q*N), 1-indexed.
+func percentileNearestRank(sorted []int64, q float64) int64 {
+	idx := int(math.Ceil(q*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	return sorted[idx]
 }

--- a/internal/analytics/latency_test.go
+++ b/internal/analytics/latency_test.go
@@ -1,0 +1,251 @@
+package analytics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// legacyEventsDDL is the pre-gh#37 events table shape, without the
+// dispatch_latency_ms column, used to simulate a DB created by an older
+// hookwise binary.
+const legacyEventsDDL = `CREATE TABLE events (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	session_id TEXT NOT NULL,
+	event_type TEXT NOT NULL,
+	tool_name TEXT,
+	timestamp TEXT NOT NULL,
+	file_path TEXT,
+	lines_added INTEGER DEFAULT 0,
+	lines_removed INTEGER DEFAULT 0,
+	ai_confidence_score REAL
+)`
+
+// eventsColumns returns the column names of the events table.
+func eventsColumns(t *testing.T, dbPath string) []string {
+	t.Helper()
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer raw.Close()
+
+	rows, err := raw.Query("PRAGMA table_info(events)")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var cols []string
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		require.NoError(t, rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk))
+		cols = append(cols, name)
+	}
+	require.NoError(t, rows.Err())
+	return cols
+}
+
+// TestMigration_DispatchLatencyColumn_OldDB verifies the gh#37 migration:
+// opening a DB whose events table predates dispatch_latency_ms adds the
+// column, and pre-existing rows read back as NULL (never fabricated as 0).
+func TestMigration_DispatchLatencyColumn_OldDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+
+	// Build an "old binary" DB: legacy events table + one pre-migration row.
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = raw.Exec(legacyEventsDDL)
+	require.NoError(t, err)
+	_, err = raw.Exec(
+		`INSERT INTO events (session_id, event_type, tool_name, timestamp) VALUES (?, ?, ?, ?)`,
+		"old-session", "PostToolUse", "Bash", "2026-01-01T00:00:00Z")
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+	assert.NotContains(t, eventsColumns(t, dbPath), "dispatch_latency_ms",
+		"precondition: legacy DB must not have the column yet")
+
+	// Opening through the analytics layer must run the migration.
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	assert.Contains(t, eventsColumns(t, dbPath), "dispatch_latency_ms",
+		"Open must add dispatch_latency_ms to a pre-existing events table")
+
+	// Pre-migration rows stay NULL.
+	db, err = Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	var latency sql.NullInt64
+	require.NoError(t, db.QueryRow(context.Background(),
+		"SELECT dispatch_latency_ms FROM events WHERE session_id = ?", "old-session",
+	).Scan(&latency))
+	assert.False(t, latency.Valid, "pre-migration rows must read back as NULL, not 0")
+}
+
+// TestMigration_DispatchLatencyColumn_Idempotent verifies re-opening an
+// already-migrated DB is a no-op (the tolerate-duplicate-column guard), for
+// both migrated-old and created-fresh DBs.
+func TestMigration_DispatchLatencyColumn_Idempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+
+	for i := 0; i < 3; i++ {
+		db, err := Open(dbPath)
+		require.NoError(t, err, "open #%d must not fail on an already-present column", i+1)
+		require.NoError(t, db.Close())
+	}
+	cols := eventsColumns(t, dbPath)
+	count := 0
+	for _, c := range cols {
+		if c == "dispatch_latency_ms" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "column must exist exactly once after repeated opens")
+}
+
+// seedLatencyEvent inserts one PostToolUse event with the given latency at
+// the given timestamp.
+func seedLatencyEvent(t *testing.T, a *Analytics, ts time.Time, latencyMs int64) {
+	t.Helper()
+	require.NoError(t, a.RecordEvent(context.Background(), "latency-session", EventRecord{
+		EventType:         "PostToolUse",
+		ToolName:          "Bash",
+		Timestamp:         ts,
+		DispatchLatencyMs: &latencyMs,
+	}))
+}
+
+// TestLatencyStats_Percentiles seeds a known distribution and verifies
+// avg/p50/p95/p99/max via the nearest-rank method.
+func TestLatencyStats_Percentiles(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	a := NewAnalytics(db)
+
+	// 100 values: 1..100ms. Nearest-rank: p50=50, p95=95, p99=99, max=100.
+	now := time.Now().UTC()
+	for ms := int64(1); ms <= 100; ms++ {
+		seedLatencyEvent(t, a, now, ms)
+	}
+
+	result, err := a.LatencyStats(context.Background(), now.Format("2006-01-02"))
+	require.NoError(t, err)
+
+	overall := result.Overall
+	assert.Equal(t, 100, overall.Count)
+	assert.InDelta(t, 50.5, overall.AvgMs, 0.001)
+	assert.Equal(t, int64(50), overall.P50Ms)
+	assert.Equal(t, int64(95), overall.P95Ms)
+	assert.Equal(t, int64(99), overall.P99Ms)
+	assert.Equal(t, int64(100), overall.MaxMs)
+
+	require.Len(t, result.ByEvent, 1)
+	assert.Equal(t, "PostToolUse", result.ByEvent[0].EventType)
+	assert.Equal(t, overall.P95Ms, result.ByEvent[0].P95Ms,
+		"single event type must mirror the overall percentiles")
+}
+
+// TestLatencyStats_PerEventTypeOrdering verifies the per-type breakdown is
+// grouped correctly and ordered by count descending.
+func TestLatencyStats_PerEventTypeOrdering(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	a := NewAnalytics(db)
+
+	now := time.Now().UTC()
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		ms := int64(10 * (i + 1))
+		require.NoError(t, a.RecordEvent(ctx, "s", EventRecord{
+			EventType: "PostToolUse", Timestamp: now, DispatchLatencyMs: &ms}))
+	}
+	ms := int64(200)
+	require.NoError(t, a.RecordEvent(ctx, "s", EventRecord{
+		EventType: "PreToolUse", Timestamp: now, DispatchLatencyMs: &ms}))
+
+	result, err := a.LatencyStats(ctx, now.Format("2006-01-02"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, result.Overall.Count)
+	require.Len(t, result.ByEvent, 2)
+	assert.Equal(t, "PostToolUse", result.ByEvent[0].EventType, "higher count first")
+	assert.Equal(t, 3, result.ByEvent[0].Count)
+	assert.Equal(t, "PreToolUse", result.ByEvent[1].EventType)
+	assert.Equal(t, int64(200), result.ByEvent[1].MaxMs)
+}
+
+// TestLatencyStats_NullRowsExcluded verifies that events without a measured
+// latency (NULL rows, e.g. written by an older binary after migration) are
+// excluded from the aggregates rather than counted as 0ms.
+func TestLatencyStats_NullRowsExcluded(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	a := NewAnalytics(db)
+
+	now := time.Now().UTC()
+	ctx := context.Background()
+	// One NULL-latency event and one measured event.
+	require.NoError(t, a.RecordEvent(ctx, "s", EventRecord{
+		EventType: "PostToolUse", Timestamp: now})) // DispatchLatencyMs nil
+	ms := int64(40)
+	require.NoError(t, a.RecordEvent(ctx, "s", EventRecord{
+		EventType: "PostToolUse", Timestamp: now, DispatchLatencyMs: &ms}))
+
+	result, err := a.LatencyStats(ctx, now.Format("2006-01-02"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Overall.Count, "NULL rows must not count")
+	assert.InDelta(t, 40.0, result.Overall.AvgMs, 0.001,
+		"a NULL row averaged in as 0 would drag this to 20")
+}
+
+// TestLatencyStats_Empty verifies the no-data contract used by stats to skip
+// the section: Overall.Count == 0 and no per-type buckets.
+func TestLatencyStats_Empty(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "analytics.db")
+	db, err := Open(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	result, err := NewAnalytics(db).LatencyStats(context.Background(),
+		time.Now().UTC().Format("2006-01-02"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.Overall.Count)
+	assert.Empty(t, result.ByEvent)
+}
+
+// TestPercentileNearestRank pins the nearest-rank edge cases the bucket math
+// relies on (single element, small N where ranks collapse).
+func TestPercentileNearestRank(t *testing.T) {
+	cases := []struct {
+		name   string
+		sorted []int64
+		q      float64
+		want   int64
+	}{
+		{"single element p50", []int64{7}, 0.50, 7},
+		{"single element p99", []int64{7}, 0.99, 7},
+		{"two elements p50 is first", []int64{1, 9}, 0.50, 1},
+		{"two elements p95 is second", []int64{1, 9}, 0.95, 9},
+		{"ten elements p99 is last", []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 0.99, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, percentileNearestRank(tc.sorted, tc.q),
+				fmt.Sprintf("q=%v over %v", tc.q, tc.sorted))
+		})
+	}
+}

--- a/internal/analytics/sqlite.go
+++ b/internal/analytics/sqlite.go
@@ -194,6 +194,15 @@ func (d *DB) initSchema(ctx context.Context) error {
 		return fmt.Errorf("migrate ttl_seconds: %w", err)
 	}
 
+	// Migration: add dispatch_latency_ms to events (gh#37). Nullable, no
+	// default: rows written before this column existed stay NULL so readers
+	// can distinguish "not measured" from a real 0ms dispatch.
+	if _, err := d.db.ExecContext(ctx,
+		"ALTER TABLE events ADD COLUMN dispatch_latency_ms INTEGER"); err != nil &&
+		!strings.Contains(err.Error(), "duplicate column") {
+		return fmt.Errorf("migrate dispatch_latency_ms: %w", err)
+	}
+
 	return nil
 }
 
@@ -223,7 +232,8 @@ var schemaDDL = []string{
 		file_path TEXT,
 		lines_added INTEGER DEFAULT 0,
 		lines_removed INTEGER DEFAULT 0,
-		ai_confidence_score REAL
+		ai_confidence_score REAL,
+		dispatch_latency_ms INTEGER
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp)`,


### PR DESCRIPTION
Implements #37 — wall-clock latency recorded per hook dispatch so gradual slowdowns (the incident class that motivated this) become visible.

- Migration-safe `dispatch_latency_ms` column on `events` (ALTER w/ duplicate-column tolerance; old rows stay NULL, never 0 — asserted both directions)
- Hot-path cost: one `time.Since` — the analytics write remains the existing bounded async side effect (ARCH-7); dispatch stdout untouched (ARCH-6 contract fixtures unmodified)
- `hookwise stats`: avg/p50/p95/p99/max + per-event-type breakdown (nearest-rank, small-N safe); section omitted entirely when no data
- `hookwise doctor`: WARN when 7-day avg exceeds 50ms; silence when no data (disabled-subsystem honesty)

Built autonomously by a Gas City polecat; independently code-reviewed (clean APPROVE — migration idempotency, NULL semantics, percentile edges all verified) and gates green locally: full unit suite + integration under `GOMEMLIMIT=4GiB go test -race -p 2`.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dispatch latency tracking to analytics events.
  - Added latency statistics to the `stats` command, including averages, percentiles, maximums, and per-event breakdowns.
  - Added dispatch latency health checks to the `doctor` command, with warnings when recent averages exceed 50 ms.
  - Existing analytics databases are upgraded automatically while preserving unavailable latency data as unknown.

- **Bug Fixes**
  - Distinguishes measured zero-millisecond latency from missing measurements.
  - Omits latency statistics when no measurements are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->