### PR TITLE
feat(audit): interactive exact-duplicate hook removal (audit --fix)

### DIFF
--- a/cmd/hookwise/cmd_audit.go
+++ b/cmd/hookwise/cmd_audit.go
@@ -60,20 +60,35 @@ type auditSummary struct {
 func newAuditCmd() *cobra.Command {
 	var jsonOut bool
 	var projectDir string
+	var fix bool
+	var dryRun bool
 
 	cmd := &cobra.Command{
 		Use:   "audit",
 		Short: "Scan Claude Code hook configuration for health issues",
 		Long: "Scans Claude Code settings files for hook-safety issues: inventory/sprawl,\n" +
 			"missing binaries, network-dependent hooks on hot paths, and duplicate or\n" +
-			"overlapping hooks. Exits 0 on PASS/WARN, 1 on FAIL.",
+			"overlapping hooks. Exits 0 on PASS/WARN, 1 on FAIL.\n\n" +
+			"With --fix, interactively removes EXACT duplicate hook entries within a\n" +
+			"single settings file (timestamped backup + atomic write + post-write\n" +
+			"validation). Near-duplicates and cross-file repeats are never removed —\n" +
+			"they are reported as recommendations. --dry-run prints the removal plan\n" +
+			"without changing anything.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if (fix || dryRun) && jsonOut {
+				return errors.New("--json cannot be combined with --fix/--dry-run")
+			}
+			if fix || dryRun {
+				return runAuditFix(cmd, auditSettingsPaths(projectDir), dryRun)
+			}
 			return runAudit(cmd, jsonOut, projectDir)
 		},
 	}
 
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit a schema-versioned JSON report instead of text")
 	cmd.Flags().StringVar(&projectDir, "project-dir", "", "Scan <dir>/.claude/settings.json + settings.local.json instead of the user-level settings")
+	cmd.Flags().BoolVar(&fix, "fix", false, "Interactively remove exact duplicate hook entries (per-change y/N)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the duplicate-removal plan without modifying any file")
 	return cmd
 }
 

--- a/cmd/hookwise/cmd_audit_fix.go
+++ b/cmd/hookwise/cmd_audit_fix.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/vishnujayvel/hookwise/internal/hooks"
+)
+
+// auditStdinIsInteractive reports whether stdin is a terminal. It is a
+// package var so tests can force either branch: applying removals is only
+// permitted with a human answering the per-change prompts (design F —
+// non-interactive stdin must refuse to apply).
+var auditStdinIsInteractive = func() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// runAuditFix implements `audit --fix` / `audit --dry-run`: plan exact
+// intra-file duplicate removals, print recommendations for everything else,
+// then (fix only, interactive only) prompt y/N per removal and apply the
+// accepted ones per file. A declined removal is never added to acceptedIDs,
+// so it is unreachable by ApplyRemovals by construction.
+func runAuditFix(cmd *cobra.Command, paths []string, dryRun bool) error {
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	w := cmd.OutOrStdout()
+
+	plan, err := hooks.PlanDuplicateRemovals(paths)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w, "hookwise audit --fix — exact duplicate hook removal")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Settings scanned:")
+	for _, p := range paths {
+		fmt.Fprintf(w, "  %s\n", p)
+	}
+	fmt.Fprintln(w)
+
+	for _, pe := range plan.SkippedFiles {
+		fmt.Fprintf(w, "SKIP  %s: %v (nothing will be removed from this file)\n", pe.File, pe.Err)
+	}
+	for _, rec := range plan.Recommendations {
+		fmt.Fprintf(w, "NOTE  [%s] %s\n", rec.Kind, rec.Message)
+	}
+	if len(plan.SkippedFiles) > 0 || len(plan.Recommendations) > 0 {
+		fmt.Fprintln(w)
+	}
+
+	if len(plan.Removals) == 0 {
+		fmt.Fprintln(w, "Nothing to fix: no exact duplicate hook entries found.")
+		return nil
+	}
+
+	fmt.Fprintf(w, "%d exact duplicate hook entr%s eligible for removal:\n",
+		len(plan.Removals), pluralYIes(len(plan.Removals)))
+	for i, r := range plan.Removals {
+		fmt.Fprintf(w, "  [%d] %s\n      event=%s matcher=%q command=%q\n",
+			i+1, r.File, r.Event, r.Matcher, r.Command)
+	}
+	fmt.Fprintln(w)
+
+	if dryRun {
+		fmt.Fprintln(w, "Dry run: no changes made.")
+		return nil
+	}
+
+	if !auditStdinIsInteractive() {
+		fmt.Fprintln(w, "Refusing to apply: stdin is not an interactive terminal.")
+		fmt.Fprintln(w, "Removals mutate your Claude Code settings and require per-change confirmation.")
+		fmt.Fprintln(w, "Run `hookwise audit --fix` in an interactive terminal to proceed.")
+		return nil
+	}
+
+	// Per-change confirmation, default No. Only explicitly accepted IDs are
+	// ever handed to ApplyRemovals.
+	reader := bufio.NewReader(cmd.InOrStdin())
+	acceptedByFile := map[string][]string{}
+	accepted := 0
+	for i, r := range plan.Removals {
+		fmt.Fprintf(w, "Remove [%d/%d] event=%s matcher=%q command=%q from %s? [y/N] ",
+			i+1, len(plan.Removals), r.Event, r.Matcher, r.Command, r.File)
+		line, readErr := reader.ReadString('\n')
+		answer := strings.ToLower(strings.TrimSpace(line))
+		if answer == "y" || answer == "yes" {
+			acceptedByFile[r.File] = append(acceptedByFile[r.File], r.ID)
+			accepted++
+		}
+		fmt.Fprintln(w)
+		if readErr != nil {
+			if readErr == io.EOF {
+				break // remaining prompts default to No
+			}
+			return readErr
+		}
+	}
+
+	if accepted == 0 {
+		fmt.Fprintln(w, "No removals accepted: no changes made.")
+		return nil
+	}
+
+	// Apply per file, deterministically in scan-path order.
+	var failed bool
+	for _, p := range paths {
+		ids := acceptedByFile[p]
+		if len(ids) == 0 {
+			continue
+		}
+		removed, backup, applyErr := hooks.ApplyRemovals(p, ids, plan.Guards[p])
+		if applyErr != nil {
+			failed = true
+			fmt.Fprintf(w, "FAIL  %s: %v\n", p, applyErr)
+			if backup != "" {
+				fmt.Fprintf(w, "      backup: %s\n", backup)
+			}
+			continue
+		}
+		fmt.Fprintf(w, "OK    %s: removed %d duplicate hook entr%s (backup: %s)\n",
+			p, removed, pluralYIes(removed), backup)
+	}
+	if failed {
+		return fmt.Errorf("audit --fix: one or more files could not be fixed")
+	}
+	return nil
+}
+
+// pluralYIes returns "y" for 1 and "ies" otherwise, for "entry/entries".
+func pluralYIes(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}

--- a/cmd/hookwise/cmd_audit_fix_test.go
+++ b/cmd/hookwise/cmd_audit_fix_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// executeCommandWithIn is executeCommand plus a scripted stdin, for the
+// interactive --fix prompts.
+func executeCommandWithIn(in io.Reader, args ...string) (string, error) {
+	rootCmd := newRootCmd()
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetIn(in)
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// forceInteractive stubs the terminal check for the duration of one test.
+func forceInteractive(t *testing.T, interactive bool) {
+	t.Helper()
+	orig := auditStdinIsInteractive
+	auditStdinIsInteractive = func() bool { return interactive }
+	t.Cleanup(func() { auditStdinIsInteractive = orig })
+}
+
+// duplicateSettings holds one exact duplicate pair on PreToolUse. Single-line
+// array so the expected post-fix content is an exact literal.
+const duplicateSettings = `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo a"}, {"type": "command", "command": "echo a"}]}
+    ]
+  }
+}`
+
+const duplicateSettingsFixed = `{
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo a"}]}
+    ]
+  }
+}`
+
+func TestAuditFixDryRunMutatesNothing(t *testing.T) {
+	claudeDir := t.TempDir()
+	path := writeAuditSettings(t, claudeDir, duplicateSettings)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	output, err := executeCommand("audit", "--fix", "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, output, "eligible for removal")
+	assert.Contains(t, output, "Dry run: no changes made.")
+
+	after, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, duplicateSettings, string(after), "--dry-run must be byte-identical no-op")
+
+	backups, globErr := filepath.Glob(path + ".bak-*")
+	require.NoError(t, globErr)
+	assert.Empty(t, backups, "--dry-run must not write backups")
+}
+
+func TestAuditFixNonInteractiveStdinRefusesToApply(t *testing.T) {
+	claudeDir := t.TempDir()
+	path := writeAuditSettings(t, claudeDir, duplicateSettings)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+	forceInteractive(t, false)
+
+	output, err := executeCommand("audit", "--fix")
+	require.NoError(t, err, "non-interactive refusal must exit 0")
+	assert.Contains(t, output, "Refusing to apply")
+	assert.Contains(t, output, "interactive terminal")
+
+	after, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, duplicateSettings, string(after))
+}
+
+func TestAuditFixInteractiveAcceptRemovesDuplicate(t *testing.T) {
+	claudeDir := t.TempDir()
+	path := writeAuditSettings(t, claudeDir, duplicateSettings)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+	forceInteractive(t, true)
+
+	output, err := executeCommandWithIn(strings.NewReader("y\n"), "audit", "--fix")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Remove [1/1]")
+	assert.Contains(t, output, "OK")
+	assert.Contains(t, output, "removed 1 duplicate")
+
+	after, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, duplicateSettingsFixed, string(after))
+
+	backups, globErr := filepath.Glob(path + ".bak-*")
+	require.NoError(t, globErr)
+	require.Len(t, backups, 1, "apply must leave a timestamped backup")
+	bak, readBakErr := os.ReadFile(backups[0])
+	require.NoError(t, readBakErr)
+	assert.Equal(t, duplicateSettings, string(bak))
+}
+
+func TestAuditFixDeclineByDefaultLeavesFileUntouched(t *testing.T) {
+	claudeDir := t.TempDir()
+	path := writeAuditSettings(t, claudeDir, duplicateSettings)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+	forceInteractive(t, true)
+
+	// Bare Enter (empty answer) must default to No; EOF after it ends input.
+	output, err := executeCommandWithIn(strings.NewReader("\n"), "audit", "--fix")
+	require.NoError(t, err)
+	assert.Contains(t, output, "No removals accepted")
+
+	after, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, duplicateSettings, string(after))
+
+	backups, globErr := filepath.Glob(path + ".bak-*")
+	require.NoError(t, globErr)
+	assert.Empty(t, backups, "a fully-declined run must not write backups")
+}
+
+func TestAuditFixSecondRunReportsNothingToFix(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeAuditSettings(t, claudeDir, duplicateSettings)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+	forceInteractive(t, true)
+
+	_, err := executeCommandWithIn(strings.NewReader("y\n"), "audit", "--fix")
+	require.NoError(t, err)
+
+	output, err := executeCommandWithIn(strings.NewReader(""), "audit", "--fix")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Nothing to fix")
+}
+
+func TestAuditFixNothingToFixOnHealthySettings(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeAuditSettings(t, claudeDir, healthySettings)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	output, err := executeCommand("audit", "--fix", "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Nothing to fix")
+}
+
+func TestAuditFixRejectsJSONCombination(t *testing.T) {
+	claudeDir := t.TempDir()
+	writeAuditSettings(t, claudeDir, healthySettings)
+	t.Setenv("HOOKWISE_CLAUDE_DIR", claudeDir)
+
+	_, err := executeCommand("audit", "--fix", "--json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--json cannot be combined")
+}

--- a/internal/hooks/fix.go
+++ b/internal/hooks/fix.go
@@ -1,0 +1,668 @@
+package hooks
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// This file implements `hookwise audit --fix`: two-phase removal of EXACT
+// duplicate hook entries (issue #40, amended design v1.1).
+//
+// Phase 1 — PlanDuplicateRemovals: pure, read-only. Groups hook entries by
+// canonical full-object deep-equality (every field, including timeout/type),
+// keyed WITHIN a single settings file only. The first occurrence in document
+// order is always kept; later occurrences become removal candidates.
+// Anything weaker than full-object intra-file equality — (matcher,command)
+// matches with differing other fields, or the same hook appearing across
+// files (layering) — is surfaced as a recommendation, never a removal.
+//
+// Phase 2 — ApplyRemovals: mutates ONLY the caller-accepted candidate IDs,
+// guarded by a plan-time (mtime,size,sha256) fingerprint (TOCTOU: a live
+// Claude Code session may write settings.json at any moment). The mutation
+// is a byte-range splice of the original file, so every byte the user did
+// not agree to remove — unknown JSON keys included — survives verbatim.
+// Safety chain: timestamped backup before any write, atomic temp+rename
+// write, then a re-scan gate (parseable, exact removed count, no hook event
+// category vanished); any gate failure restores the backup automatically.
+
+// ---------------------------------------------------------------------------
+// Plan types
+// ---------------------------------------------------------------------------
+
+// FileGuard fingerprints a settings file at plan time so ApplyRemovals can
+// detect (and refuse) concurrent modification.
+type FileGuard struct {
+	ModTime time.Time
+	Size    int64
+	SHA256  string
+}
+
+// RemovalCandidate is one exact-duplicate hook entry that may be removed.
+// ID is deterministic for a given file content, so a plan ID resolves to the
+// same entry at apply time once the FileGuard has verified the bytes are
+// unchanged.
+type RemovalCandidate struct {
+	ID      string // "<event>#g<group>#h<hook>#<sha8 of canonical object>"
+	File    string // settings file path
+	Event   string // e.g. "PreToolUse"
+	Matcher string // matcher of the enclosing group
+	Command string // command string, for display
+}
+
+// Recommendation is a finding the fixer refuses to act on automatically.
+type Recommendation struct {
+	Kind    string // "near-duplicate" | "cross-file"
+	Message string
+}
+
+// FixPlan is the output of PlanDuplicateRemovals.
+type FixPlan struct {
+	Removals        []RemovalCandidate
+	Recommendations []Recommendation
+	Guards          map[string]FileGuard // keyed by settings file path
+	SkippedFiles    []ParseError         // unparseable files: never planned against
+}
+
+// ---------------------------------------------------------------------------
+// File layout walk (byte-exact)
+// ---------------------------------------------------------------------------
+
+// elemRange is the byte range [Start,End) of one array element in the
+// original file.
+type elemRange struct {
+	Start int
+	End   int
+}
+
+// hookSite is one hook object's location within a settings file.
+type hookSite struct {
+	Event     string
+	Matcher   string
+	GroupIdx  int
+	HookIdx   int
+	ArrayID   int // Start offset of the enclosing "hooks" array's first element region; unique per array
+	Range     elemRange
+	Canonical string // canonical JSON of the full hook object
+	Command   string
+}
+
+// fileLayout is the byte-exact map of every hook entry in one settings file.
+type fileLayout struct {
+	sites  []hookSite          // document order
+	arrays map[int][]elemRange // ArrayID → all element ranges of that hooks array
+}
+
+// canonicalJSON re-marshals a raw JSON value with sorted object keys and no
+// insignificant whitespace, giving a deep-equality key for full objects.
+func canonicalJSON(raw []byte) (string, error) {
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.Marshal(v) // maps marshal with sorted keys
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// decodeRawWithOffsets decodes the next JSON value from dec into a
+// RawMessage and returns its exact byte range within data (base-relative).
+// The decoder guarantees RawMessage holds the verbatim input bytes of the
+// value; the invariant is re-checked against data to make any offset-math
+// bug loud instead of silently splicing the wrong bytes.
+func decodeRawWithOffsets(dec *json.Decoder, data []byte, base int) (json.RawMessage, elemRange, error) {
+	var raw json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		return nil, elemRange{}, err
+	}
+	end := base + int(dec.InputOffset())
+	start := end - len(raw)
+	if start < 0 || end > len(data) || !bytes.Equal(data[start:end], raw) {
+		return nil, elemRange{}, fmt.Errorf("hooks: internal offset mismatch while walking settings JSON")
+	}
+	return raw, elemRange{Start: start, End: end}, nil
+}
+
+// expectDelim consumes one token and verifies it is the given delimiter.
+func expectDelim(dec *json.Decoder, want json.Delim) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != want {
+		return fmt.Errorf("hooks: expected %q in settings JSON, got %v", want, tok)
+	}
+	return nil
+}
+
+// walkSettings maps every hook entry in a settings file to its exact byte
+// range. Non-conforming shapes (hooks value not an object, event value not an
+// array, group not an object) are tolerated and yield no sites — the fixer
+// simply has nothing it can safely remove there.
+func walkSettings(data []byte) (*fileLayout, error) {
+	layout := &fileLayout{arrays: map[int][]elemRange{}}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	if err := expectDelim(dec, '{'); err != nil {
+		return nil, err
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, _ := keyTok.(string)
+		raw, r, err := decodeRawWithOffsets(dec, data, 0)
+		if err != nil {
+			return nil, err
+		}
+		if key != "hooks" {
+			continue
+		}
+		if err := walkHooksObject(raw, r.Start, data, layout); err != nil {
+			return nil, err
+		}
+	}
+	return layout, nil
+}
+
+// walkHooksObject walks the value of the top-level "hooks" key.
+func walkHooksObject(hooksRaw []byte, base int, data []byte, layout *fileLayout) error {
+	trimmed := bytes.TrimSpace(hooksRaw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil // "hooks" is not an object — nothing to plan
+	}
+	dec := json.NewDecoder(bytes.NewReader(hooksRaw))
+	if err := expectDelim(dec, '{'); err != nil {
+		return err
+	}
+	for dec.More() {
+		evTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		event, _ := evTok.(string)
+		raw, r, err := decodeRawWithOffsets(dec, data, base)
+		if err != nil {
+			return err
+		}
+		if err := walkEventGroups(raw, r.Start, event, data, layout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// walkEventGroups walks one event's matcher-group array.
+func walkEventGroups(groupsRaw []byte, base int, event string, data []byte, layout *fileLayout) error {
+	trimmed := bytes.TrimSpace(groupsRaw)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil // event value is not an array — nothing to plan
+	}
+	dec := json.NewDecoder(bytes.NewReader(groupsRaw))
+	if err := expectDelim(dec, '['); err != nil {
+		return err
+	}
+	for gi := 0; dec.More(); gi++ {
+		raw, r, err := decodeRawWithOffsets(dec, data, base)
+		if err != nil {
+			return err
+		}
+		if err := walkGroup(raw, r.Start, event, gi, data, layout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// walkGroup walks one matcher group's "hooks" array, recording a hookSite
+// for each hook object.
+func walkGroup(groupRaw []byte, base int, event string, gi int, data []byte, layout *fileLayout) error {
+	trimmed := bytes.TrimSpace(groupRaw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil // group is not an object — nothing to plan
+	}
+
+	// Field order inside the group is arbitrary, so read the matcher via a
+	// plain unmarshal before walking for offsets.
+	var meta struct {
+		Matcher string `json:"matcher"`
+	}
+	_ = json.Unmarshal(groupRaw, &meta) // tolerated: non-string matcher → ""
+
+	dec := json.NewDecoder(bytes.NewReader(groupRaw))
+	if err := expectDelim(dec, '{'); err != nil {
+		return err
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key, _ := keyTok.(string)
+		raw, r, err := decodeRawWithOffsets(dec, data, base)
+		if err != nil {
+			return err
+		}
+		if key != "hooks" {
+			continue
+		}
+		inner := bytes.TrimSpace(raw)
+		if len(inner) == 0 || inner[0] != '[' {
+			continue // group "hooks" is not an array — nothing to plan
+		}
+		hdec := json.NewDecoder(bytes.NewReader(raw))
+		if err := expectDelim(hdec, '['); err != nil {
+			return err
+		}
+		arrayID := r.Start
+		for hi := 0; hdec.More(); hi++ {
+			hraw, hr, err := decodeRawWithOffsets(hdec, data, r.Start)
+			if err != nil {
+				return err
+			}
+			canon, err := canonicalJSON(hraw)
+			if err != nil {
+				return err
+			}
+			var ch commandHook
+			_ = json.Unmarshal(hraw, &ch)
+			layout.arrays[arrayID] = append(layout.arrays[arrayID], hr)
+			layout.sites = append(layout.sites, hookSite{
+				Event:     event,
+				Matcher:   meta.Matcher,
+				GroupIdx:  gi,
+				HookIdx:   hi,
+				ArrayID:   arrayID,
+				Range:     hr,
+				Canonical: canon,
+				Command:   ch.Command,
+			})
+		}
+	}
+	return nil
+}
+
+// siteID builds the deterministic removal-candidate ID for a site.
+func siteID(s hookSite) string {
+	sum := sha256.Sum256([]byte(s.Canonical))
+	return fmt.Sprintf("%s#g%d#h%d#%s", s.Event, s.GroupIdx, s.HookIdx, hex.EncodeToString(sum[:])[:8])
+}
+
+// planFile computes the per-file layout and the removable-duplicate set.
+// Duplicate identity is (event, matcher, canonical full hook object), seen
+// within this file only; the first occurrence in document order is kept.
+func planFile(path string, data []byte) (*fileLayout, []RemovalCandidate, error) {
+	layout, err := walkSettings(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	type dupKey struct{ event, matcher, canonical string }
+	seen := map[dupKey]bool{}
+	var removals []RemovalCandidate
+	for _, s := range layout.sites {
+		k := dupKey{s.Event, s.Matcher, s.Canonical}
+		if seen[k] {
+			removals = append(removals, RemovalCandidate{
+				ID:      siteID(s),
+				File:    path,
+				Event:   s.Event,
+				Matcher: s.Matcher,
+				Command: s.Command,
+			})
+			continue
+		}
+		seen[k] = true
+	}
+	return layout, removals, nil
+}
+
+// captureGuard fingerprints the file for the TOCTOU check.
+func captureGuard(path string, data []byte) (FileGuard, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return FileGuard{}, err
+	}
+	sum := sha256.Sum256(data)
+	return FileGuard{
+		ModTime: info.ModTime(),
+		Size:    info.Size(),
+		SHA256:  hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+// PlanDuplicateRemovals scans the given settings files and returns the fix
+// plan: exact intra-file duplicate removals, plus recommendations for
+// everything the fixer must not touch (near-duplicates and cross-file
+// layering). It performs no writes.
+func PlanDuplicateRemovals(paths []string) (*FixPlan, error) {
+	plan := &FixPlan{Guards: map[string]FileGuard{}}
+
+	type xfKey struct{ event, matcher, canonical string }
+	xfFirst := map[xfKey]string{} // key → first file it appeared in
+	xfFlagged := map[xfKey]bool{}
+	type nearKey struct{ event, matcher, command string }
+	nearFirst := map[nearKey]string{} // key → first canonical seen
+	nearFlagged := map[nearKey]bool{}
+
+	visited := map[string]bool{}
+	for _, path := range paths {
+		if visited[path] {
+			continue
+		}
+		visited[path] = true
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue // a missing settings file is normal
+			}
+			plan.SkippedFiles = append(plan.SkippedFiles, ParseError{File: path, Err: err})
+			continue
+		}
+		layout, removals, err := planFile(path, data)
+		if err != nil {
+			plan.SkippedFiles = append(plan.SkippedFiles, ParseError{
+				File: path,
+				Err:  fmt.Errorf("parse %s: %w", path, err),
+			})
+			continue
+		}
+		guard, err := captureGuard(path, data)
+		if err != nil {
+			plan.SkippedFiles = append(plan.SkippedFiles, ParseError{File: path, Err: err})
+			continue
+		}
+		plan.Guards[path] = guard
+		plan.Removals = append(plan.Removals, removals...)
+
+		for _, s := range layout.sites {
+			// Near-duplicate: same (event, matcher, command) but the full
+			// object differs (e.g. timeout). Recommendation only.
+			nk := nearKey{s.Event, s.Matcher, s.Command}
+			if first, ok := nearFirst[nk]; !ok {
+				nearFirst[nk] = s.Canonical
+			} else if first != s.Canonical && !nearFlagged[nk] {
+				nearFlagged[nk] = true
+				plan.Recommendations = append(plan.Recommendations, Recommendation{
+					Kind: "near-duplicate",
+					Message: fmt.Sprintf("%q on %s (matcher %q) appears with differing fields (e.g. timeout/type) — review manually, not auto-removed",
+						s.Command, s.Event, s.Matcher),
+				})
+			}
+
+			// Cross-file repeat: identical full object in another file is
+			// layering (shared vs local settings). Recommendation only.
+			xk := xfKey{s.Event, s.Matcher, s.Canonical}
+			if first, ok := xfFirst[xk]; !ok {
+				xfFirst[xk] = path
+			} else if first != path && !xfFlagged[xk] {
+				xfFlagged[xk] = true
+				plan.Recommendations = append(plan.Recommendations, Recommendation{
+					Kind: "cross-file",
+					Message: fmt.Sprintf("%q on %s (matcher %q) appears in both %s and %s — settings layering, review manually, not auto-removed",
+						s.Command, s.Event, s.Matcher, first, path),
+				})
+			}
+		}
+	}
+	return plan, nil
+}
+
+// ---------------------------------------------------------------------------
+// Apply
+// ---------------------------------------------------------------------------
+
+// applyWriteFile is the write seam for ApplyRemovals' main mutation. Tests
+// override it to simulate a corrupted write; backup restore deliberately
+// bypasses it.
+var applyWriteFile = atomicWriteFile
+
+// atomicWriteFile writes data to path via a temp file + rename in the same
+// directory, so readers never observe a partially-written settings file.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".hookwise-fix-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+// spliceRemovals removes the given sites from data, returning the new file
+// content. Removal is by byte range: for each maximal run of removed
+// elements within one array the cut extends to the next kept element (or
+// swallows the preceding separator when the run reaches the array tail), so
+// commas stay balanced and every byte outside the cuts survives verbatim.
+func spliceRemovals(data []byte, layout *fileLayout, remove []hookSite) []byte {
+	byArray := map[int][]int{}
+	for _, s := range remove {
+		byArray[s.ArrayID] = append(byArray[s.ArrayID], s.HookIdx)
+	}
+
+	var cuts []elemRange
+	for arrayID, idxs := range byArray {
+		elems := layout.arrays[arrayID]
+		sort.Ints(idxs)
+		for i := 0; i < len(idxs); {
+			j := i
+			for j+1 < len(idxs) && idxs[j+1] == idxs[j]+1 {
+				j++
+			}
+			a, b := idxs[i], idxs[j]
+			var cut elemRange
+			switch {
+			case b < len(elems)-1:
+				cut = elemRange{Start: elems[a].Start, End: elems[b+1].Start}
+			case a > 0:
+				cut = elemRange{Start: elems[a-1].End, End: elems[b].End}
+			default:
+				cut = elemRange{Start: elems[a].Start, End: elems[b].End}
+			}
+			cuts = append(cuts, cut)
+			i = j + 1
+		}
+	}
+
+	sort.Slice(cuts, func(i, j int) bool { return cuts[i].Start > cuts[j].Start })
+	out := append([]byte(nil), data...)
+	for _, c := range cuts {
+		out = append(out[:c.Start], out[c.End:]...)
+	}
+	return out
+}
+
+// scanBytes parses settings content the same way Scan does, without touching
+// the filesystem — used for the before/after validation gate.
+func scanBytes(data []byte) (*settingsFile, error) {
+	var sf settingsFile
+	if err := json.Unmarshal(data, &sf); err != nil {
+		return nil, err
+	}
+	return &sf, nil
+}
+
+// entryCountAndEvents returns the flattened hook-entry count and the set of
+// event categories present.
+func entryCountAndEvents(sf *settingsFile) (int, map[string]bool) {
+	count := 0
+	events := map[string]bool{}
+	for event, groups := range sf.Hooks {
+		for _, g := range groups {
+			if len(g.Hooks) > 0 {
+				events[event] = true
+			}
+			count += len(g.Hooks)
+		}
+	}
+	return count, events
+}
+
+// ApplyRemovals removes exactly the accepted duplicate candidates from the
+// settings file at path. guard must be the FileGuard captured for path by
+// PlanDuplicateRemovals; if the file changed since plan time the apply is
+// refused. Returns the number of entries removed and the backup file path.
+//
+// Safety chain: TOCTOU re-check → timestamped backup → byte-splice → atomic
+// write → re-scan gate (parseable, removed count matches, no event category
+// vanished). Any post-write gate failure restores the backup automatically.
+func ApplyRemovals(path string, acceptedIDs []string, guard FileGuard) (removed int, backupPath string, err error) {
+	if len(acceptedIDs) == 0 {
+		return 0, "", nil
+	}
+
+	// TOCTOU gate: refuse if the file changed since the plan was made. A live
+	// Claude Code session can rewrite settings.json at any moment.
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, "", fmt.Errorf("hooks: stat %s: %w", path, err)
+	}
+	if !info.ModTime().Equal(guard.ModTime) || info.Size() != guard.Size {
+		return 0, "", fmt.Errorf("hooks: %s changed since the plan was made (mtime/size differ) — re-run `hookwise audit --fix`", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, "", fmt.Errorf("hooks: read %s: %w", path, err)
+	}
+	sum := sha256.Sum256(data)
+	if hex.EncodeToString(sum[:]) != guard.SHA256 {
+		return 0, "", fmt.Errorf("hooks: %s changed since the plan was made (content differs) — re-run `hookwise audit --fix`", path)
+	}
+
+	// Re-derive the removable set from the (verified-identical) bytes and
+	// resolve the accepted IDs. Only IDs in the removable set are reachable:
+	// a keeper (first occurrence) or unknown ID is refused outright.
+	layout, removals, err := planFile(path, data)
+	if err != nil {
+		return 0, "", fmt.Errorf("hooks: re-plan %s: %w", path, err)
+	}
+	removable := map[string]bool{}
+	for _, r := range removals {
+		removable[r.ID] = true
+	}
+	siteByID := map[string]hookSite{}
+	for _, s := range layout.sites {
+		siteByID[siteID(s)] = s
+	}
+	var toRemove []hookSite
+	for _, id := range acceptedIDs {
+		if !removable[id] {
+			return 0, "", fmt.Errorf("hooks: %q is not a removable duplicate in %s — refusing to apply", id, path)
+		}
+		toRemove = append(toRemove, siteByID[id])
+	}
+
+	// Backup BEFORE any mutation, preserving the original file's mode.
+	backupPath, err = writeBackup(path, data, info.Mode().Perm())
+	if err != nil {
+		return 0, "", fmt.Errorf("hooks: backup %s: %w", path, err)
+	}
+
+	newData := spliceRemovals(data, layout, toRemove)
+
+	if err := applyWriteFile(path, newData, info.Mode().Perm()); err != nil {
+		return 0, backupPath, fmt.Errorf("hooks: write %s: %w", path, err)
+	}
+
+	// Post-write gate. Scan is fail-open (nil error on parse failure), so
+	// err==nil is NOT validation — the gates below are.
+	if gateErr := validateAfterWrite(path, data, len(toRemove)); gateErr != nil {
+		if restoreErr := atomicWriteFile(path, data, info.Mode().Perm()); restoreErr != nil {
+			return 0, backupPath, fmt.Errorf("hooks: %v; AND restoring backup failed: %v (backup preserved at %s)", gateErr, restoreErr, backupPath)
+		}
+		return 0, backupPath, fmt.Errorf("hooks: %w — original restored from backup", gateErr)
+	}
+
+	return len(toRemove), backupPath, nil
+}
+
+// writeBackup writes data to "<path>.bak-<RFC3339>" (suffixed on collision)
+// with O_EXCL so an existing backup is never clobbered.
+func writeBackup(path string, data []byte, perm os.FileMode) (string, error) {
+	stamp := time.Now().UTC().Format(time.RFC3339)
+	for i := 0; ; i++ {
+		candidate := fmt.Sprintf("%s.bak-%s", path, stamp)
+		if i > 0 {
+			candidate = fmt.Sprintf("%s.bak-%s.%d", path, stamp, i)
+		}
+		f, err := os.OpenFile(candidate, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+		if os.IsExist(err) {
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		if _, err := f.Write(data); err != nil {
+			_ = f.Close()
+			return "", err
+		}
+		if err := f.Close(); err != nil {
+			return "", err
+		}
+		return candidate, nil
+	}
+}
+
+// validateAfterWrite is the post-write gate: the rewritten file must parse
+// cleanly via the same scanner the rest of hookwise uses, the flattened
+// entry count must have dropped by exactly the accepted amount, and no hook
+// event category may have vanished.
+func validateAfterWrite(path string, before []byte, expectedRemoved int) error {
+	inv, scanErr := Scan([]string{path})
+	if scanErr != nil || len(inv.ParseErrors) != 0 {
+		return fmt.Errorf("rewritten %s does not scan cleanly", path)
+	}
+	beforeSF, err := scanBytes(before)
+	if err != nil {
+		return fmt.Errorf("original %s no longer parses: %v", path, err)
+	}
+	beforeCount, beforeEvents := entryCountAndEvents(beforeSF)
+
+	afterData, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("re-read %s: %v", path, err)
+	}
+	afterSF, err := scanBytes(afterData)
+	if err != nil {
+		return fmt.Errorf("rewritten %s does not parse: %v", path, err)
+	}
+	afterCount, afterEvents := entryCountAndEvents(afterSF)
+
+	if beforeCount-afterCount != expectedRemoved {
+		return fmt.Errorf("rewritten %s removed %d entries, expected %d", path, beforeCount-afterCount, expectedRemoved)
+	}
+	for ev := range beforeEvents {
+		if !afterEvents[ev] {
+			return fmt.Errorf("rewritten %s lost hook event category %s", path, ev)
+		}
+	}
+	return nil
+}

--- a/internal/hooks/fix.go
+++ b/internal/hooks/fix.go
@@ -573,10 +573,19 @@ func ApplyRemovals(path string, acceptedIDs []string, guard FileGuard) (removed 
 		siteByID[siteID(s)] = s
 	}
 	var toRemove []hookSite
+	seenIDs := map[string]bool{}
 	for _, id := range acceptedIDs {
 		if !removable[id] {
 			return 0, "", fmt.Errorf("hooks: %q is not a removable duplicate in %s — refusing to apply", id, path)
 		}
+		// Dedupe defensively: the same ID twice would yield two identical cut
+		// ranges, and splicing the same [start,end) a second time (after the
+		// first shifted the bytes) removes wrong, unrelated bytes. The CLI
+		// can't produce duplicates, but this is an exported API.
+		if seenIDs[id] {
+			continue
+		}
+		seenIDs[id] = true
 		toRemove = append(toRemove, siteByID[id])
 	}
 

--- a/internal/hooks/fix_test.go
+++ b/internal/hooks/fix_test.go
@@ -1,0 +1,308 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixFixture is a settings file exercising every planner branch at once:
+// unknown JSON keys at every level, an exact duplicate (g0h1), a key-order
+// duplicate that is canonically equal (g0h2), a near-duplicate differing
+// only in timeout (g0h3, must NOT be removed), and a cross-group exact
+// duplicate within the same file (g1h0). Arrays are single-line so expected
+// post-splice content can be written as an exact literal.
+const fixFixture = `{
+  "unknownTop": {"keep": true, "n": 1},
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Bash", "customGroupKey": "g1", "hooks": [{"type": "command", "command": "echo a", "timeout": 30, "custom": "x"}, {"type": "command", "command": "echo a", "timeout": 30, "custom": "x"}, {"timeout": 30, "command": "echo a", "type": "command", "custom": "x"}, {"type": "command", "command": "echo a", "timeout": 60}]},
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo a", "timeout": 30, "custom": "x"}]}
+    ],
+    "PostToolUse": [
+      {"matcher": "", "hooks": [{"type": "command", "command": "echo b"}]}
+    ]
+  },
+  "otherSetting": [1, 2, 3]
+}`
+
+// fixFixtureAfterAll is fixFixture with all three removable duplicates
+// spliced out: g0 keeps its first occurrence and the timeout-60 variant,
+// g1's array empties (the group itself is preserved).
+const fixFixtureAfterAll = `{
+  "unknownTop": {"keep": true, "n": 1},
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Bash", "customGroupKey": "g1", "hooks": [{"type": "command", "command": "echo a", "timeout": 30, "custom": "x"}, {"type": "command", "command": "echo a", "timeout": 60}]},
+      {"matcher": "Bash", "hooks": []}
+    ],
+    "PostToolUse": [
+      {"matcher": "", "hooks": [{"type": "command", "command": "echo b"}]}
+    ]
+  },
+  "otherSetting": [1, 2, 3]
+}`
+
+// fixFixtureAfterG1Only is fixFixture with only the cross-group duplicate
+// (g1h0) removed; g0's intra-group duplicates remain untouched.
+const fixFixtureAfterG1Only = `{
+  "unknownTop": {"keep": true, "n": 1},
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Bash", "customGroupKey": "g1", "hooks": [{"type": "command", "command": "echo a", "timeout": 30, "custom": "x"}, {"type": "command", "command": "echo a", "timeout": 30, "custom": "x"}, {"timeout": 30, "command": "echo a", "type": "command", "custom": "x"}, {"type": "command", "command": "echo a", "timeout": 60}]},
+      {"matcher": "Bash", "hooks": []}
+    ],
+    "PostToolUse": [
+      {"matcher": "", "hooks": [{"type": "command", "command": "echo b"}]}
+    ]
+  },
+  "otherSetting": [1, 2, 3]
+}`
+
+// writeFixSettings writes content as settings.json in a temp dir.
+func writeFixSettings(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// mustPlan plans over a single file and requires success.
+func mustPlan(t *testing.T, path string) *FixPlan {
+	t.Helper()
+	plan, err := PlanDuplicateRemovals([]string{path})
+	require.NoError(t, err)
+	return plan
+}
+
+// backupFiles globs the "<settings>.bak-*" siblings of path.
+func backupFiles(t *testing.T, path string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(path + ".bak-*")
+	require.NoError(t, err)
+	return matches
+}
+
+func TestPlanDetectsExactIntraFileDuplicates(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+
+	require.Len(t, plan.Removals, 3, "g0h1, g0h2 (key-order variant), g1h0 are the exact duplicates")
+	for _, r := range plan.Removals {
+		assert.Equal(t, path, r.File)
+		assert.Equal(t, "PreToolUse", r.Event)
+		assert.Equal(t, "Bash", r.Matcher)
+		assert.Equal(t, "echo a", r.Command)
+		assert.False(t, strings.HasPrefix(r.ID, "PreToolUse#g0#h0#"),
+			"the first occurrence must be kept, never offered for removal")
+	}
+
+	// The guard must fingerprint the file for the apply-time TOCTOU check.
+	guard, ok := plan.Guards[path]
+	require.True(t, ok)
+	assert.NotEmpty(t, guard.SHA256)
+	assert.EqualValues(t, len(fixFixture), guard.Size)
+}
+
+func TestPlanFullObjectInequalityIsRecommendationNotRemoval(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+
+	for _, r := range plan.Removals {
+		assert.NotContains(t, r.ID, "#g0#h3#",
+			"the timeout-60 variant differs in a field — must not be removable")
+	}
+	var nearDup bool
+	for _, rec := range plan.Recommendations {
+		if rec.Kind == "near-duplicate" {
+			nearDup = true
+			assert.Contains(t, rec.Message, "echo a")
+		}
+	}
+	assert.True(t, nearDup, "full-object inequality must surface as a near-duplicate recommendation")
+}
+
+func TestPlanCrossFileRepeatIsRecommendationOnly(t *testing.T) {
+	dir := t.TempDir()
+	content := `{"hooks": {"PreToolUse": [{"matcher": "", "hooks": [{"type": "command", "command": "echo shared"}]}]}}`
+	shared := filepath.Join(dir, "settings.json")
+	local := filepath.Join(dir, "settings.local.json")
+	require.NoError(t, os.WriteFile(shared, []byte(content), 0o600))
+	require.NoError(t, os.WriteFile(local, []byte(content), 0o600))
+
+	plan, err := PlanDuplicateRemovals([]string{shared, local})
+	require.NoError(t, err)
+
+	assert.Empty(t, plan.Removals,
+		"a hook in both settings.json and settings.local.json is layering, never auto-removed")
+	require.Len(t, plan.Recommendations, 1)
+	assert.Equal(t, "cross-file", plan.Recommendations[0].Kind)
+	assert.Contains(t, plan.Recommendations[0].Message, "echo shared")
+}
+
+func TestApplyAllAcceptedPreservesEverythingElseByteExact(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+	require.Len(t, plan.Removals, 3)
+
+	ids := make([]string, 0, 3)
+	for _, r := range plan.Removals {
+		ids = append(ids, r.ID)
+	}
+	removed, backup, err := ApplyRemovals(path, ids, plan.Guards[path])
+	require.NoError(t, err)
+	assert.Equal(t, 3, removed)
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, fixFixtureAfterAll, string(after),
+		"everything not removed — unknown keys included — must survive byte-identical")
+
+	// Backup must hold the exact original.
+	require.NotEmpty(t, backup)
+	bak, err := os.ReadFile(backup)
+	require.NoError(t, err)
+	assert.Equal(t, fixFixture, string(bak), "backup must be the pristine original")
+}
+
+func TestApplySubsetRemovesOnlyAccepted(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+
+	var g1ID string
+	for _, r := range plan.Removals {
+		if strings.HasPrefix(r.ID, "PreToolUse#g1#h0#") {
+			g1ID = r.ID
+		}
+	}
+	require.NotEmpty(t, g1ID, "cross-group duplicate must be in the plan")
+
+	removed, _, err := ApplyRemovals(path, []string{g1ID}, plan.Guards[path])
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, fixFixtureAfterG1Only, string(after),
+		"declined/unaccepted duplicates must remain byte-identical in place")
+
+	// The remaining duplicates are still discoverable on a fresh plan.
+	replan := mustPlan(t, path)
+	assert.Len(t, replan.Removals, 2)
+}
+
+func TestApplyTOCTOURefusesWhenFileChanged(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+	require.NotEmpty(t, plan.Removals)
+
+	// Same content, different mtime — a live session may have rewritten the
+	// file to identical-looking-but-not-fingerprinted state; refuse anyway.
+	require.NoError(t, os.Chtimes(path, time.Now().Add(time.Hour), time.Now().Add(time.Hour)))
+
+	removed, backup, err := ApplyRemovals(path, []string{plan.Removals[0].ID}, plan.Guards[path])
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "changed since the plan")
+	assert.Zero(t, removed)
+	assert.Empty(t, backup, "refusal must happen before any backup/write")
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, fixFixture, string(after), "refused apply must not touch the file")
+	assert.Empty(t, backupFiles(t, path))
+}
+
+func TestApplyContentChangeRefusedEvenWithSameSize(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+	require.NotEmpty(t, plan.Removals)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	// Same size, same mtime, different bytes — only sha256 catches this.
+	mutated := []byte(strings.Replace(fixFixture, `"keep": true`, `"keep": zrue`, 1))
+	require.Len(t, mutated, len(fixFixture))
+	require.NoError(t, os.WriteFile(path, mutated, 0o600))
+	require.NoError(t, os.Chtimes(path, info.ModTime(), info.ModTime()))
+
+	_, _, err = ApplyRemovals(path, []string{plan.Removals[0].ID}, plan.Guards[path])
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "changed since the plan")
+	assert.Empty(t, backupFiles(t, path))
+}
+
+func TestApplyRefusesKeeperOrUnknownID(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+
+	for _, badID := range []string{"PreToolUse#g0#h0#deadbeef", "nonsense"} {
+		removed, backup, err := ApplyRemovals(path, []string{badID}, plan.Guards[path])
+		require.Error(t, err, "ID %q must be refused", badID)
+		assert.Contains(t, err.Error(), "not a removable duplicate")
+		assert.Zero(t, removed)
+		assert.Empty(t, backup)
+	}
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, fixFixture, string(after))
+}
+
+func TestApplyCorruptedWriteRestoresBackup(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+	require.NotEmpty(t, plan.Removals)
+
+	orig := applyWriteFile
+	applyWriteFile = func(p string, _ []byte, perm os.FileMode) error {
+		return atomicWriteFile(p, []byte(`{"hooks": `), perm) // truncated JSON
+	}
+	defer func() { applyWriteFile = orig }()
+
+	removed, backup, err := ApplyRemovals(path, []string{plan.Removals[0].ID}, plan.Guards[path])
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "restored")
+	assert.Zero(t, removed)
+	require.NotEmpty(t, backup)
+
+	after, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, fixFixture, string(after),
+		"a write that fails post-write validation must be rolled back from the backup")
+}
+
+func TestPlanIdempotentAfterFullApply(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+	ids := make([]string, 0, len(plan.Removals))
+	for _, r := range plan.Removals {
+		ids = append(ids, r.ID)
+	}
+	_, _, err := ApplyRemovals(path, ids, plan.Guards[path])
+	require.NoError(t, err)
+
+	replan := mustPlan(t, path)
+	assert.Empty(t, replan.Removals, "second run must find nothing left to fix")
+}
+
+func TestPlanSkipsMalformedFileAndPlansNothingForIt(t *testing.T) {
+	path := writeFixSettings(t, `{"hooks": {`)
+	plan := mustPlan(t, path)
+	assert.Empty(t, plan.Removals)
+	require.Len(t, plan.SkippedFiles, 1)
+	assert.Equal(t, path, plan.SkippedFiles[0].File)
+	_, hasGuard := plan.Guards[path]
+	assert.False(t, hasGuard, "no guard for a file we refuse to plan against")
+}
+
+func TestPlanMissingFilesAreSkippedSilently(t *testing.T) {
+	plan, err := PlanDuplicateRemovals([]string{filepath.Join(t.TempDir(), "settings.json")})
+	require.NoError(t, err)
+	assert.Empty(t, plan.Removals)
+	assert.Empty(t, plan.SkippedFiles)
+}

--- a/internal/hooks/fix_test.go
+++ b/internal/hooks/fix_test.go
@@ -196,6 +196,31 @@ func TestApplySubsetRemovesOnlyAccepted(t *testing.T) {
 	assert.Len(t, replan.Removals, 2)
 }
 
+func TestApplyDuplicateAcceptedIDsAppliedOnce(t *testing.T) {
+	path := writeFixSettings(t, fixFixture)
+	plan := mustPlan(t, path)
+
+	var g1ID string
+	for _, r := range plan.Removals {
+		if strings.HasPrefix(r.ID, "PreToolUse#g1#h0#") {
+			g1ID = r.ID
+		}
+	}
+	require.NotEmpty(t, g1ID, "cross-group duplicate must be in the plan")
+
+	// The same accepted ID twice must splice its byte range exactly once —
+	// a second application of the identical [start,end) cut after the first
+	// shifted the bytes would silently corrupt unrelated content.
+	removed, _, err := ApplyRemovals(path, []string{g1ID, g1ID}, plan.Guards[path])
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "duplicate accepted IDs must count once")
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, fixFixtureAfterG1Only, string(after),
+		"file must be byte-identical to a single-application result")
+}
+
 func TestApplyTOCTOURefusesWhenFileChanged(t *testing.T) {
 	path := writeFixSettings(t, fixFixture)
 	plan := mustPlan(t, path)


### PR DESCRIPTION
## Summary
- Adds `hookwise audit --fix`: plans exact-duplicate hook removals across settings files and applies accepted ones by raw byte-splicing, preserving unknown JSON keys byte-identically.
- Grok design-gate amendments all implemented: intra-file dedup only (cross-file = recommendation), full-object equality (near-duplicates surfaced, never removed), sha256+mtime+size TOCTOU guard at apply time, explicit post-write re-parse gate, two-phase Plan/Apply API.
- Hardening fixup from review: ApplyRemovals dedupes accepted IDs defensively — the same ID twice would double-splice a shifted byte range and silently corrupt unrelated content (exported API; CLI cannot produce duplicates). Regression test included.

Closes #40

## Test plan
- fix_test.go covers: exact/key-order duplicate detection, near-duplicate recommendation-only, cross-file recommendation-only, byte-exact apply (all + subset), duplicate-ID dedupe, TOCTOU refusal (mtime + content), unknown-ID refusal, corrupted-write backup restore.
- `GOMEMLIMIT=4GiB go test -race -p 2 ./internal/hooks/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ