### PR TITLE
refactor(core): delete dead config fields + unused path vars

### DIFF
--- a/docs/guide/feeds-guide.md
+++ b/docs/guide/feeds-guide.md
@@ -199,7 +199,6 @@ Reports whether the daemon is running, its PID, and uptime.
 daemon:
   auto_start: false           # start daemon automatically on SessionStart
   inactivity_timeout_minutes: 30  # stop after no activity
-  log_file: "~/.hookwise/daemon.log"
 ```
 
 The daemon includes stale PID cleanup -- if the PID file references a dead process, it is removed automatically.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -227,8 +227,8 @@ See the [Feeds Guide](./feeds-guide.md) for a deep dive into the feed platform a
 hookwise supports environment variable interpolation in config values:
 
 ```yaml
-settings:
-  state_dir: "${HOME}/.hookwise"
+analytics:
+  db_path: "${HOME}/.hookwise/analytics.db"
 ```
 
 The state directory itself can be overridden:

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -64,7 +64,6 @@ func GetDefaultConfig() HooksConfig {
 		Settings: SettingsConfig{
 			LogLevel:              "info",
 			HandlerTimeoutSeconds: DefaultHandlerTimeout,
-			StateDir:              DefaultStateDir,
 		},
 		Includes: []string{},
 		Feeds: FeedsConfig{
@@ -79,7 +78,6 @@ func GetDefaultConfig() HooksConfig {
 				IntervalSeconds:  300,
 				LookaheadMinutes: 120,
 				Calendars:        []string{"primary"},
-				CredentialsPath:  DefaultCalendarCredentialsPath,
 				// Resolved via GetStateDir() at config-load time (rather than
 				// the frozen DefaultCalendarTokenPath var) so HOOKWISE_STATE_DIR
 				// is honored whenever it's set before GetDefaultConfig() runs.
@@ -112,14 +110,12 @@ func GetDefaultConfig() HooksConfig {
 			Memories: MemoriesFeedConfig{
 				Enabled:         false,
 				IntervalSeconds: 3600,
-				DBPath:          DefaultDBPath,
 			},
 			Custom: []CustomFeedConfig{},
 		},
 		Daemon: DaemonConfig{
 			AutoStart:                true,
 			InactivityTimeoutMinutes: 120,
-			LogFile:                  DefaultDaemonLogPath,
 		},
 		TUI: TUIConfig{
 			AutoLaunch:   false,

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -1323,8 +1323,8 @@ sounds:
 	// Project config overrides with env vars and includes
 	projectDir := filepath.Join(tmpDir, "project")
 	projectConfig := `
-daemon:
-  log_file: "${HOOKWISE_CUSTOM_LOG}"
+analytics:
+  db_path: "${HOOKWISE_CUSTOM_LOG}"
 includes:
   - includes/extras.yaml
 guards:
@@ -1350,8 +1350,8 @@ guards:
 		t.Errorf("expected handler_timeout=30 from global, got %d", cfg.Settings.HandlerTimeoutSeconds)
 	}
 	// Env var interpolated
-	if cfg.Daemon.LogFile != "/var/log/hookwise.log" {
-		t.Errorf("expected interpolated daemon log_file, got %q", cfg.Daemon.LogFile)
+	if cfg.Analytics.DBPath != "/var/log/hookwise.log" {
+		t.Errorf("expected interpolated analytics db_path, got %q", cfg.Analytics.DBPath)
 	}
 	// Include resolved
 	if !cfg.Sounds.Enabled {
@@ -1782,7 +1782,6 @@ version: 1
 daemon:
   auto_start: false
   inactivity_timeout_minutes: 60
-  log_file: "/custom/daemon.log"
 `
 	if err := os.WriteFile(filepath.Join(tmpDir, "hookwise.yaml"), []byte(projectConfig), 0o644); err != nil {
 		t.Fatal(err)
@@ -1797,9 +1796,6 @@ daemon:
 	}
 	if cfg.Daemon.InactivityTimeoutMinutes != 60 {
 		t.Errorf("expected timeout=60, got %d", cfg.Daemon.InactivityTimeoutMinutes)
-	}
-	if cfg.Daemon.LogFile != "/custom/daemon.log" {
-		t.Errorf("expected custom log file, got %q", cfg.Daemon.LogFile)
 	}
 }
 

--- a/internal/core/constants.go
+++ b/internal/core/constants.go
@@ -10,29 +10,14 @@ var (
 	// DefaultStateDir is ~/.hookwise/
 	DefaultStateDir = filepath.Join(HomeDir(), ".hookwise")
 
-	// DefaultDBPath is ~/.hookwise/analytics.db
-	DefaultDBPath = filepath.Join(DefaultStateDir, "analytics.db")
-
 	// DefaultCachePath is ~/.hookwise/state/status-line-cache.json
 	DefaultCachePath = filepath.Join(DefaultStateDir, "state", "status-line-cache.json")
-
-	// DefaultLogPath is ~/.hookwise/logs/
-	DefaultLogPath = filepath.Join(DefaultStateDir, "logs")
-
-	// GlobalConfigPath is ~/.hookwise/config.yaml
-	GlobalConfigPath = filepath.Join(DefaultStateDir, "config.yaml")
 
 	// DefaultPIDPath is ~/.hookwise/daemon.pid
 	DefaultPIDPath = filepath.Join(DefaultStateDir, "daemon.pid")
 
 	// DefaultSocketPath is ~/.hookwise/daemon.sock
 	DefaultSocketPath = filepath.Join(DefaultStateDir, "daemon.sock")
-
-	// DefaultDaemonLogPath is ~/.hookwise/daemon.log
-	DefaultDaemonLogPath = filepath.Join(DefaultStateDir, "daemon.log")
-
-	// DefaultCalendarCredentialsPath is ~/.hookwise/calendar-credentials.json
-	DefaultCalendarCredentialsPath = filepath.Join(DefaultStateDir, "calendar-credentials.json")
 
 	// DefaultCalendarTokenPath is ~/.hookwise/calendar-token.json
 	DefaultCalendarTokenPath = filepath.Join(DefaultStateDir, "calendar-token.json")

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -152,7 +152,6 @@ type CostTrackingConfig struct {
 type SettingsConfig struct {
 	LogLevel              string `yaml:"log_level" json:"logLevel"` // "debug", "info", "warn", "error"
 	HandlerTimeoutSeconds int    `yaml:"handler_timeout_seconds" json:"handlerTimeoutSeconds"`
-	StateDir              string `yaml:"state_dir" json:"stateDir"`
 }
 
 // --- Guard Types ---
@@ -360,7 +359,6 @@ type CalendarFeedConfig struct {
 	IntervalSeconds  int      `yaml:"interval_seconds" json:"intervalSeconds"`
 	LookaheadMinutes int      `yaml:"lookahead_minutes" json:"lookaheadMinutes"`
 	Calendars        []string `yaml:"calendars" json:"calendars"`
-	CredentialsPath  string   `yaml:"credentials_path" json:"credentialsPath"`
 	TokenPath        string   `yaml:"token_path" json:"tokenPath"`
 }
 
@@ -397,9 +395,8 @@ type WeatherFeedConfig struct {
 }
 
 type MemoriesFeedConfig struct {
-	Enabled         bool   `yaml:"enabled" json:"enabled"`
-	IntervalSeconds int    `yaml:"interval_seconds" json:"intervalSeconds"`
-	DBPath          string `yaml:"db_path" json:"dbPath"`
+	Enabled         bool `yaml:"enabled" json:"enabled"`
+	IntervalSeconds int  `yaml:"interval_seconds" json:"intervalSeconds"`
 }
 
 type FeedsConfig struct {
@@ -413,9 +410,8 @@ type FeedsConfig struct {
 }
 
 type DaemonConfig struct {
-	AutoStart                bool   `yaml:"auto_start" json:"autoStart"`
-	InactivityTimeoutMinutes int    `yaml:"inactivity_timeout_minutes" json:"inactivityTimeoutMinutes"`
-	LogFile                  string `yaml:"log_file" json:"logFile"`
+	AutoStart                bool `yaml:"auto_start" json:"autoStart"`
+	InactivityTimeoutMinutes int  `yaml:"inactivity_timeout_minutes" json:"inactivityTimeoutMinutes"`
 }
 
 type TUIConfig struct {

--- a/internal/feeds/client.go
+++ b/internal/feeds/client.go
@@ -38,8 +38,8 @@ func isTestBinary(path string) bool {
 
 // defaultDaemonLogPath returns the daemon log file path. It reads
 // core.GetStateDir() at call time so HOOKWISE_STATE_DIR is honored, rather
-// than the frozen core.DefaultDaemonLogPath package var (mirrors PR #227's
-// tuiPIDPath pattern).
+// than a frozen package-level default (mirrors PR #227's tuiPIDPath
+// pattern).
 func defaultDaemonLogPath() string {
 	return filepath.Join(core.GetStateDir(), "daemon.log")
 }
@@ -84,7 +84,7 @@ func NewDaemonClient(socketPath string) *DaemonClient {
 //  1. Dial socket with connectTimeout
 //  2. If connected, return nil (daemon already running)
 //  3. If not, add random jitter (SPAWN-1: 0-200ms), spawn hookwise daemon run
-//     with Setsid:true (SPAWN-2), redirect stdout/stderr to DefaultDaemonLogPath
+//     with Setsid:true (SPAWN-2), redirect stdout/stderr to the daemon log file
 //  4. Poll socket every 100ms for up to readyTimeout
 //  5. Return error if timeout (caller fail-opens per ARCH-1)
 func (c *DaemonClient) EnsureDaemon(configPath string) error {
@@ -172,7 +172,7 @@ func (c *DaemonClient) spawnDaemon(configPath string) error {
 
 	// Redirect stdout/stderr to daemon log file. Resolved via
 	// core.GetStateDir() at call time so HOOKWISE_STATE_DIR is honored, rather
-	// than the frozen core.DefaultDaemonLogPath package var.
+	// than a frozen package-level default.
 	logFile, err := os.OpenFile(defaultDaemonLogPath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return fmt.Errorf("open daemon log: %w", err)

--- a/internal/feeds/client_statedir_test.go
+++ b/internal/feeds/client_statedir_test.go
@@ -23,12 +23,13 @@ func TestDefaultDaemonLogPath_HonorsStateDirOverride(t *testing.T) {
 }
 
 // TestDefaultDaemonLogPath_DefaultUnchanged verifies the no-override default
-// is byte-identical to the legacy core.DefaultDaemonLogPath value.
+// is byte-identical to the legacy default (the since-removed
+// core.DefaultDaemonLogPath package var, ~/.hookwise/daemon.log).
 func TestDefaultDaemonLogPath_DefaultUnchanged(t *testing.T) {
 	t.Setenv("HOOKWISE_STATE_DIR", "")
 
 	got := defaultDaemonLogPath()
-	assert.Equal(t, core.DefaultDaemonLogPath, got)
+	assert.Equal(t, filepath.Join(core.DefaultStateDir, "daemon.log"), got)
 }
 
 // TestDefaultDaemonSocketPath_HonorsStateDirOverride verifies that

--- a/internal/feeds/producer_calendar.go
+++ b/internal/feeds/producer_calendar.go
@@ -21,7 +21,7 @@ import (
 const defaultCalendarLookaheadMinutes = 120
 
 // CalendarProducer fetches upcoming events from Google Calendar API.
-// It implements ConfigAware to receive token/credentials paths from feed config.
+// It implements ConfigAware to receive the token path from feed config.
 type CalendarProducer struct {
 	mu         sync.Mutex
 	feedsCfg   core.FeedsConfig


### PR DESCRIPTION
## Summary
- Dead-config honesty cleanup: deletes YAML fields that were parsed but never read (users setting them were silently ignored), with verify-then-delete grep evidence per item in the commit message.
- Deleted: `state_dir` (real override is HOOKWISE_STATE_DIR), `feeds.memories.db_path`, `daemon.log_file`, `calendar.credentials_path`, plus orphaned constants (core.DefaultLogPath, GlobalConfigPath, DefaultDaemonLogPath, DefaultCalendarCredentialsPath, DefaultDBPath).
- Doc example in getting-started.md swapped to the live `analytics.db_path` key.

## Test plan
- Config round-trip/interpolation tests updated to exercise live keys.
- Guarded unit + integration gates green on the harvest tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ