### PR TITLE
docs: refresh README + docs for shipped features

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Every hook event passes through a three-phase execution engine. Guards protect, 
 
 <img src="screenshots/stats.png" alt="hookwise stats" width="600">
 
-**[Interactive TUI](docs/cli.md)** _(optional · experimental)_ -- A full-screen Python/[Textual](https://textual.textualize.io) dashboard with 8 tabs. It ships **separately** from the core binary (the core CLI, guards, analytics, and status line need no Python). Install it from the `tui/` directory (e.g. `uv tool install ./tui`); once `hookwise-tui` is on your PATH and `tui.auto_launch: true` is set, it opens in a separate terminal on session start.
+**[Interactive TUI](docs/cli.md)** _(optional · experimental)_ -- A full-screen Python/[Textual](https://textual.textualize.io) dashboard with 8 tabs. It ships **separately** from the core binary (the core CLI, guards, analytics, and status line need no Python). Install it from the `tui/` directory (e.g. `uv tool install ./tui`); once `hookwise-tui` is on your PATH, launch it on demand with `hookwise tui`, or set `tui.auto_launch: true` to open it in a separate terminal on session start.
 
 <div align="center">
 <img src="screenshots/tui-insights.png" alt="hookwise TUI — Claude Code usage insights with session metrics, trends, and tool breakdown" width="700">

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ One file. Claude Code reads it, understands it, and can even help you write new 
 | Analytics | SQLite, queryable | DIY | Display-only |
 | Workflow insights | Friction signals, session pulse | No | No |
 | Configuration | One YAML file | Scattered scripts | JSON/TUI |
-| Recipes | 12 built-in, shareable | N/A | N/A |
+| Recipes | 11 built-in, shareable | N/A | N/A |
 | Cost tracking | Budgets + alerts | DIY | Current session only |
 
 ## Quick Start
@@ -92,7 +92,8 @@ curl -fsSL https://raw.githubusercontent.com/vishnujayvel/hookwise/main/scripts/
 # …or build/install with Go:
 go install github.com/vishnujayvel/hookwise/cmd/hookwise@latest
 
-hookwise init --preset minimal
+hookwise init          # scaffold hookwise.yaml + inventory your existing hooks
+hookwise init --wire   # wire dispatch + status line into .claude/settings.json
 hookwise doctor
 ```
 
@@ -102,7 +103,11 @@ hookwise doctor
 <img src="screenshots/doctor-v1.3.png" alt="hookwise doctor output — all checks passed" width="600">
 </div>
 
-Then [register hookwise in `.claude/settings.json`](docs/guide/getting-started.md) — one dispatcher handles all 13 hook events.
+`hookwise doctor` checks your config, state directory, analytics DB, daemon liveness, and per-feed health — measured against the daemon's *effective* runtime config, not just what's on disk. It's honest about disabled subsystems: a feed you turned off reports as `disabled`, and $0 with cost tracking off is "expected", not a malfunction warning.
+
+`hookwise init --wire` registers the dispatcher and status line in `.claude/settings.json` for you — idempotently, with a pre-flight safety audit, an automatic backup, and `--dry-run` / `--unwire` escape hatches. One dispatcher handles all 13 hook events. Prefer to edit settings yourself? [Manual setup &rarr;](docs/guide/getting-started.md)
+
+Before it writes anything, `hookwise init` also inventories the hooks you already have (user settings are never modified) and saves the pre-init snapshot to `~/.hookwise/hook-audit.json`.
 
 ## How It Works
 
@@ -114,7 +119,7 @@ Every hook event passes through a three-phase execution engine. Guards protect, 
 
 ## What You Get
 
-**[Guard Rails](docs/features/guards.md)** -- Declarative rules with firewall semantics. `block` or `warn` with glob patterns and operators like `contains`, `matches`, `starts_with`.
+**[Guard Rails](docs/features/guards.md)** -- Declarative rules with firewall semantics. `block`, `confirm`, or `warn` with glob patterns and operators like `contains`, `matches`, `starts_with`.
 
 <img src="screenshots/guard-demo.gif" alt="Guard blocking a dangerous rm -rf" width="700">
 
@@ -122,18 +127,20 @@ Every hook event passes through a three-phase execution engine. Guards protect, 
 <img src="screenshots/guard-evaluation-flow.png" alt="Guard evaluation flow — hookwise.yaml rules are matched by tool name, then condition, resulting in block, confirm, or warn actions" width="500">
 </div>
 
+**Hook Audit** -- `hookwise audit` scans your Claude Code settings files and flags hook-safety issues: sprawl, missing binaries, network-dependent hooks on hot paths, and duplicate or overlapping hooks. `--json` emits a schema-versioned report for CI (exits 0 on PASS/WARN, 1 on FAIL); `--project-dir` scans a project's `.claude/` settings instead of your user-level settings.
+
 **[Coaching](docs/features/coaching.md)** -- Periodic **metacognition prompts** that break autopilot mode: *"Are you solving the right problem, or the most interesting one?"* Research on AI-assisted programming shows students who plan before coding outperform those who jump straight to debugging ([AIED 2025](https://arxiv.org/abs/2509.03171)) — hookwise makes planning-first the default.
 
-**[Status Line](docs/features/status-line.md)** -- 21 composable segments powered by a [background daemon](docs/features/feeds.md) with 8 built-in feed producers. Mix `session`, `cost`, `project`, `calendar`, `news`, `insights`, and more. Peripheral vision for your development flow — you don't stare at it, but you glance at it.
+**[Status Line](docs/features/status-line.md)** -- Composable segments powered by a [background daemon](docs/features/feeds.md) with 6 built-in feed producers plus custom feeds. Mix `cost`, `project`, `calendar`, `weather`, `news`, `insights`, and more. Peripheral vision for your development flow — you don't stare at it, but you glance at it.
 
 <img src="screenshots/status-line-insights.gif" alt="hookwise status line — friction tips, pace metrics, and calendar awareness" width="700">
 
 **[Workflow Insights](docs/features/feeds.md)** -- Surfaces friction patterns with actionable tips, pace metrics, and session health. The data your workflow already generates but never shows you.
 
-**[Feed Platform](docs/features/feeds.md)** -- A background daemon polls 8 producers on staggered intervals and writes to an atomic cache bus with per-key TTL. Status line segments read from cache with `isFresh()` checks. If a feed is unavailable or stale, its segments silently disappear (fail-open).
+**[Feed Platform](docs/features/feeds.md)** -- A background daemon polls 6 built-in producers (plus your custom feeds) on staggered intervals and writes to an atomic cache bus with per-key TTL. Status line segments read from cache with `isFresh()` checks. If a feed is unavailable or stale, its segments silently disappear (fail-open). The daemon is a singleton shared by every project, so feeds are configured once, in the global `~/.hookwise/config.yaml` — `hookwise doctor` reports feed health against the daemon's *actual* runtime config and warns if a project file carries a `feeds:` block (which the daemon ignores).
 
 <div align="center">
-<img src="screenshots/feed-architecture.png" alt="Feed platform architecture — data sources flow through a background daemon with 8 producers into an atomic cache bus, then to the 21-segment status line" width="600">
+<img src="screenshots/feed-architecture.png" alt="Feed platform architecture — data sources flow through a background daemon into an atomic cache bus, then to the status line segments" width="600">
 </div>
 
 **[Analytics](docs/features/analytics.md)** -- SQLite-backed session tracking: tool calls, duration, cost, daily budgets. Close the perception gap between how fast you *feel* and how fast you *are*.
@@ -148,7 +155,7 @@ Every hook event passes through a three-phase execution engine. Guards protect, 
 
 ## Configuration
 
-Everything lives in `hookwise.yaml`. Four presets: `minimal`, `coaching`, `analytics`, `full`. [Full reference &rarr;](docs/guide/getting-started.md)
+Everything lives in `hookwise.yaml`. [Full reference &rarr;](docs/guide/getting-started.md)
 
 ```yaml
 version: 1
@@ -160,10 +167,10 @@ guards:
 coaching:
   metacognition: { enabled: true, interval_seconds: 300 }
 analytics: { enabled: true }
-status_line: { enabled: true, segments: [session, cost, project, calendar] }
+status_line: { enabled: true, segments: [cost, project, calendar] }
 ```
 
-Global config at `~/.hookwise/config.yaml` applies everywhere. Project-level `hookwise.yaml` overrides per workspace.
+Global config at `~/.hookwise/config.yaml` applies everywhere. Project-level `hookwise.yaml` overrides per workspace — with one exception: the `feeds:` block only takes effect in the global config, because the feed daemon is a shared singleton. A project-level `feeds:` block is ignored, and `hookwise doctor` warns about it.
 
 ## Testing
 
@@ -180,7 +187,7 @@ Go test helpers in `pkg/hookwise/testing`. [Details &rarr;](docs/cli.md)
 
 ## Recipes
 
-12 built-in -- [see all](recipes/) or [create your own](docs/guide/creating-a-recipe.md):  `block-dangerous-commands`, `metacognition-prompts`, `commit-without-tests`, and more.
+11 built-in -- [see all](recipes/) or [create your own](docs/guide/creating-a-recipe.md):  `block-dangerous-commands`, `metacognition-prompts`, `commit-without-tests`, and more.
 
 ## Security
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,20 +49,18 @@ graph LR
     end
 
     subgraph Daemon[Background Daemon]
-        D1[Feed Registry<br/>8 producers]
-        D2[pulse 30s]
-        D3[project 60s]
-        D4[calendar 5m]
-        D5[news 30m]
-        D6[insights 2m]
-        D7[practice 60s]
-        D8[weather 15m]
-        D9[memories 1h]
+        D1[Feed Registry<br/>6 built-in producers + custom]
+        D3[project]
+        D4[calendar]
+        D5[news]
+        D6[insights]
+        D8[weather]
+        D9[memories]
     end
 
     Sources --> D1
     D1 --> CB[Cache Bus<br/>Atomic JSON<br/>Per-key TTL<br/>isFresh check]
-    CB --> SL[Status Line<br/>21 segments]
+    CB --> SL[Status Line<br/>composable segments]
 
     style Sources fill:#D0EBFF,stroke:#1971C2,stroke-width:2px
     style Daemon fill:#D3F9D8,stroke:#2B8A3E,stroke-width:2px
@@ -102,7 +100,7 @@ tests/            # 1400+ tests across 61 test files
   performance/    # Benchmarks and import boundary tests
   cli/            # CLI command tests
 
-recipes/          # 12 built-in recipes
+recipes/          # 11 built-in recipes
 examples/         # 4 example configs (minimal, coaching, analytics, full)
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,7 +88,7 @@ Full-screen terminal UI built with Python Textual, shipped **separately** from t
 | `7` | Recipes | Recipe browser grouped by category |
 | `8` | Status | Status line preview and segment configurator |
 
-Press `q` to exit the TUI. Install from the `tui/` directory (e.g. `uv tool install ./tui`), then run `hookwise-tui`.
+Press `q` to exit the TUI. Install from the `tui/` directory (e.g. `uv tool install ./tui`), then launch it with `hookwise tui` (or run `hookwise-tui` directly).
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,10 +5,17 @@ All commands are invoked as `hookwise <command>`.
 ## Commands
 
 ```
-hookwise init [--preset minimal|coaching|analytics|full]
-                          Generate hookwise.yaml and state directory
+hookwise init             Scaffold hookwise.yaml, ensure the state directory, and
+                          inventory existing hooks (report: ~/.hookwise/hook-audit.json)
 
-hookwise doctor           Health check: config, state dir, handlers
+hookwise init --wire      Wire dispatch + status line into .claude/settings.json
+                          (idempotent; --dry-run to preview, --unwire to remove)
+
+hookwise audit            Scan Claude Code hook config for health issues
+                          (--json for CI; exits 0 on PASS/WARN, 1 on FAIL)
+
+hookwise doctor           Health check: config, state dir, analytics DB, daemon,
+                          per-feed health vs the daemon's effective config
 ```
 
 <div align="center">
@@ -16,39 +23,29 @@ hookwise doctor           Health check: config, state dir, handlers
 </div>
 
 ```
-hookwise status           Show current configuration summary
-```
-
-<div align="center">
-<img src="../screenshots/status-v1.2.png" alt="hookwise status output showing guards, coaching, features, and feeds" width="600">
-</div>
-
-```
-hookwise stats            Session analytics: tool calls, duration, cost
+hookwise stats            Analytics dashboard for today: tool calls, duration, cost
 
 hookwise test             Run guard rule tests against scenarios
 
-hookwise tui              Launch the interactive TUI for config management
+hookwise dispatch <event> Dispatch a hook event (called by Claude Code)
 
-hookwise feeds [--once]   Live feed dashboard: daemon status, feed health, cache bus
-                          Auto-refreshes every 3s; press q to quit. Use --once for snapshot.
+hookwise status-line      Render the status line (called by Claude Code)
 
-hookwise setup <target>   Set up external integrations (e.g., hookwise setup calendar)
-
-hookwise daemon <start|stop|status>
+hookwise daemon <start|stop>
                           Manage the background feed daemon
 
-hookwise migrate          Migrate from Python hookwise (v0.1.0)
+hookwise snapshot         Point-in-time VACUUM INTO copy of the analytics DB
+
+hookwise log              Show analytics snapshot history
+
+hookwise diff <from> <to> Row-count changes between two analytics snapshots
+
+hookwise notifications    Show recent notification history
+
+hookwise upgrade          Migrate data from a TypeScript hookwise installation
 ```
 
-## Presets
-
-| Preset | What you get |
-|--------|-------------|
-| `minimal` | Guards only -- just the safety rails |
-| `coaching` | Guards + metacognition + builder's trap + communication |
-| `analytics` | Guards + SQLite session tracking |
-| `full` | Everything enabled |
+See the [CLI Reference](reference/cli-reference.md) for per-command flags.
 
 ## Testing Utilities
 
@@ -78,7 +75,7 @@ Test helpers available in `pkg/hookwise/testing`:
 
 ## Interactive TUI
 
-Full-screen terminal UI built with Python Textual -- 8 tabs:
+Full-screen terminal UI built with Python Textual, shipped **separately** from the core binary as `hookwise-tui` (the core CLI needs no Python) -- 8 tabs:
 
 | Key | Tab | Description |
 |-----|-----|-------------|
@@ -91,7 +88,7 @@ Full-screen terminal UI built with Python Textual -- 8 tabs:
 | `7` | Recipes | Recipe browser grouped by category |
 | `8` | Status | Status line preview and segment configurator |
 
-Press `q` to exit the TUI. Install: `cd tui && pip install -e .`
+Press `q` to exit the TUI. Install from the `tui/` directory (e.g. `uv tool install ./tui`), then run `hookwise-tui`.
 
 ---
 

--- a/docs/features/feeds.md
+++ b/docs/features/feeds.md
@@ -4,28 +4,26 @@ A background daemon polls feed producers on configurable intervals and writes re
 
 ## Producers
 
-8 built-in feed producers:
+6 built-in feed producers:
 
-| Producer | Default Interval | What it provides |
-|----------|-----------------|-----------------|
-| `pulse` | 30s | Session heartbeat and idle time detection |
-| `project` | 60s | Git repo name, branch, last commit age |
-| `calendar` | 300s | Current/next calendar event and free time |
-| `news` | 1800s | Hacker News top stories (rotates) |
-| `insights` | 120s | Claude Code usage metrics from `~/.claude/usage-data/` |
-| `practice` | 60s | Daily practice rep count and last practice time |
-| `weather` | 900s | Local temperature, conditions, and wind speed |
-| `memories` | 3600s | "On this day" session history and nostalgia |
+| Producer | What it provides |
+|----------|-----------------|
+| `project` | Git repo name, branch, last commit age |
+| `news` | Hacker News top stories (rotates) |
+| `calendar` | Current/next calendar event and free time |
+| `weather` | Local temperature, conditions, and wind speed |
+| `memories` | "On this day" session history and nostalgia |
+| `insights` | Claude Code usage metrics from `~/.claude/usage-data/` |
+
+Each enabled feed polls at its configured `interval_seconds`, defaulting to 60s when unset. User-defined custom feed producers can be added under `feeds.custom`.
 
 ## Feed Configuration
 
-Configure feeds in `hookwise.yaml`:
+Feeds are polled by a single shared daemon, so they are configured in the **global** config at `~/.hookwise/config.yaml` — not in a project's `hookwise.yaml`. A `feeds:` block in a project config is ignored for polling, and `hookwise doctor` warns about it and lists the keys to move.
 
 ```yaml
+# ~/.hookwise/config.yaml
 feeds:
-  pulse:
-    enabled: true
-    interval_seconds: 30
   project:
     enabled: true
     interval_seconds: 60
@@ -35,6 +33,8 @@ feeds:
     staleness_days: 30
     usage_data_path: "~/.claude/usage-data"
 ```
+
+`hookwise doctor` reports feed health against the daemon's *effective* runtime config (queried from the running daemon), falling back to the on-disk global config when the daemon is down — and warns when the daemon is polling a stale config after a global-config edit.
 
 ## Insights Producer
 
@@ -72,7 +72,9 @@ Missing directory, malformed JSON files, and permission errors all result in gra
 
 ## Daemon Behavior
 
-The daemon starts automatically with `hookwise dispatch` and shuts down after a configurable period of inactivity (default: 120 minutes). Set `daemon.inactivity_timeout_minutes` in `hookwise.yaml` to adjust.
+The daemon is auto-started by `hookwise status-line` when it isn't running (or start it explicitly with `hookwise daemon start`), and shuts down after a configurable period of inactivity (default: 120 minutes). Set `daemon.inactivity_timeout_minutes` in the global `~/.hookwise/config.yaml` to adjust.
+
+The daemon is a singleton — one socket, one cache, one process per state directory — and its entire config comes from the global config file, independent of which project started it.
 
 ## Architecture
 

--- a/docs/features/status-line.md
+++ b/docs/features/status-line.md
@@ -1,6 +1,6 @@
 # Composable Status Line
 
-21 segments you can mix and match to build a personalized status line.
+Composable segments you can mix and match to build a personalized status line.
 
 <div align="center">
 <img src="../../screenshots/status-line-demo.gif" alt="Status line color progression from green to red" width="700">
@@ -8,50 +8,23 @@
 <em>Status line adapts -- green at start, yellow mid-session, red when overdue</em>
 </div>
 
-## Core Segments
+## Built-in Segments
 
 | Segment | Shows |
 |---------|-------|
-| `clock` | Current time |
-| `cost` | Session cost estimate |
-| `builder_trap` | Alert level + nudge message |
-| `mantra` | Rotating motivational prompt |
-| `practice` | Daily practice rep counter |
-| `streak` | Coding streak counter |
-
-## Two-Tier Segments
-
-| Segment | Shows |
-|---------|-------|
-| `context_bar` | Context window usage bar |
-| `mode_badge` | Current mode (coding/tooling/etc.) |
-| `duration` | Total session duration |
-| `practice_breadcrumb` | Time since last practice |
-
-## Feed Platform Segments
-
-| Segment | Shows |
-|---------|-------|
-| `pulse` | Session heartbeat |
-| `project` | Repo + branch + last commit |
+| `cost` | Today's estimated cost (from the analytics DB; omitted when $0) |
+| `project` | Repo + branch + last commit (derived live from the current directory) |
 | `calendar` | Current/next event |
+| `weather` | Local temperature, conditions, and wind indicator |
 | `news` | Hacker News headlines |
-
-## Insights Segments
-
-| Segment | Shows |
-|---------|-------|
+| `insights` | Claude Code usage summary |
 | `insights_friction` | Friction health: warns on recent friction, shows clean status otherwise |
 | `insights_pace` | Productivity: messages/day, total lines, session count |
 | `insights_trend` | Patterns: top tools and peak coding hour |
 
-## Additional Segments
+Feed-backed segments read from the [feed daemon's](feeds.md) cache and silently disappear when their feed is stale, disabled, or has no real data (fail-open).
 
-| Segment | Shows |
-|---------|-------|
-| `weather` | Local temperature, conditions, and wind indicator |
-| `memories` | "On this day" session history and nostalgia |
-| `ai_ratio` | AI authorship percentage with progress bar |
+A cross-session **fleet badge** is appended automatically when 2 or more Claude Code sessions are live — it is not configured as a segment.
 
 ## Configuration
 
@@ -59,10 +32,12 @@
 status_line:
   enabled: true
   segments:
-    - builder_trap
     - cost
     - project
+    - calendar
 ```
+
+Unknown segment names render as a gray placeholder label. The old `session` segment was removed — configs that still list it render nothing for it.
 
 ---
 

--- a/docs/guide/analytics-guide.md
+++ b/docs/guide/analytics-guide.md
@@ -107,7 +107,7 @@ With `--streaks`, you see:
 
 ## TUI Analytics Tab
 
-The TUI (`hookwise tui`, tab 4: Analytics) provides a visual dashboard with the same data:
+The TUI (`hookwise-tui`, tab 4: Analytics) provides a visual dashboard with the same data:
 
 - Daily summary table
 - Tool usage breakdown

--- a/docs/guide/feeds-guide.md
+++ b/docs/guide/feeds-guide.md
@@ -9,42 +9,21 @@ The feed platform is a background data aggregation system introduced in hookwise
 ```
 Daemon (background process)
   ├── Feed Registry (registration + lookup)
-  │     ├── pulse     (heartbeat / idle detection)
   │     ├── project   (git branch + last commit)
   │     ├── calendar  (Google Calendar events)
   │     ├── news      (Hacker News top stories)
   │     ├── insights  (Claude Code usage metrics)
-  │     ├── practice  (daily practice reps)
   │     ├── weather   (local conditions via Open-Meteo)
   │     ├── memories  ("On this day" session history)
   │     └── custom[]  (user-defined shell commands)
   │
-  └── Cache Bus (per-key atomic merge + TTL reads)
-        └── ~/.hookwise/state/status-line-cache.json
+  └── Cache Bus (per-feed atomic writes + TTL reads)
+        └── ~/.hookwise/state/<feed>.json
 ```
 
 The daemon polls each producer at its configured interval, merges results into the cache bus, and the status line reads from the cache on every render.
 
 ## Producers
-
-### Pulse
-
-The heartbeat producer tracks session liveness. It writes a timestamp on every dispatch event and the daemon checks for staleness.
-
-```yaml
-feeds:
-  pulse:
-    enabled: true
-    interval_seconds: 30
-    thresholds:
-      green: 30     # seconds since last activity
-      yellow: 60
-      orange: 120
-      red: 300
-      skull: 600
-```
-
-The status line shows a colored indicator based on how long since the last activity.
 
 ### Project
 
@@ -75,13 +54,7 @@ feeds:
       - primary
 ```
 
-Requires a one-time setup:
-
-```bash
-hookwise setup calendar
-```
-
-This stores credentials at `~/.hookwise/calendar-credentials.json`.
+Requires a one-time setup: place your Google OAuth client credentials at `~/.hookwise/calendar-credentials.json` (path configurable via `credentials_path`) and the OAuth token at `~/.hookwise/calendar-token.json`. The producer refreshes and writes back the token automatically; if credentials are missing, the calendar segments simply stay empty (fail-open).
 
 ### News
 
@@ -145,17 +118,12 @@ The cache bus is the central data store for all feed data. It provides:
 - **TTL-aware reads** -- `isFresh()` checks `updated_at + ttl_seconds` against the current time
 - **Fail-open on corruption** -- corrupt or missing cache files are treated as empty objects
 
-Cache location: `~/.hookwise/state/status-line-cache.json`
+Cache location: one JSON file per feed under `~/.hookwise/state/` (e.g. `~/.hookwise/state/project.json`).
 
-Each entry in the cache has this shape:
+Each cached feed has this shape:
 
 ```json
 {
-  "pulse": {
-    "updated_at": "2026-02-23T10:00:00.000Z",
-    "ttl_seconds": 30,
-    "idle_minutes": 2
-  },
   "project": {
     "updated_at": "2026-02-23T10:00:00.000Z",
     "ttl_seconds": 60,
@@ -188,10 +156,10 @@ Sends SIGTERM to the daemon process and removes the PID file.
 ### Status
 
 ```bash
-hookwise daemon status
+hookwise doctor
 ```
 
-Reports whether the daemon is running, its PID, and uptime.
+Doctor dials the daemon socket and reports whether the daemon is running, its PID, and uptime — plus per-feed health against the daemon's effective config.
 
 ### Configuration
 
@@ -208,36 +176,33 @@ The daemon includes stale PID cleanup -- if the PID file references a dead proce
 
 Producers do not all poll at the same time. The daemon staggers their schedules to avoid burst I/O. Each producer runs on its own interval independently.
 
-## Feed Dashboard
+## Feed Health
 
-View live feed health with:
+View feed health with:
 
 ```bash
-hookwise feeds
+hookwise doctor
 ```
 
 This shows:
-- Daemon status (running/stopped)
-- Each feed's last update time and freshness
-- Cache bus size and key count
+- Daemon status (running/stopped, PID, uptime)
+- Each feed's freshness (`OK` / `stale` / `disabled` / `placeholder data`)
+- Which config the report is measured against (the daemon's runtime config when it's up, the on-disk global config otherwise)
 
-Use `--once` for a snapshot that exits immediately:
-
-```bash
-hookwise feeds --once
-```
+The TUI's Feeds tab (`hookwise-tui`, key `5`) offers a live auto-refreshing view of the same data.
 
 ## Troubleshooting
 
 **Daemon not starting**
-- Check if another daemon is already running: `hookwise daemon status`
+- Check if another daemon is already running: `hookwise doctor`
 - Check the log file: `cat ~/.hookwise/daemon.log`
 - Verify the PID file is not stale: `cat ~/.hookwise/daemon.pid`
 
 **Stale feed data**
 - The daemon may have stopped. Restart it: `hookwise daemon start`
 - Check TTL values -- very short TTLs may show stale data between polls
-- Run `hookwise feeds` to see which feeds are fresh vs. stale
+- Run `hookwise doctor` to see which feeds are fresh vs. stale
+- If you edited `~/.hookwise/config.yaml` after the daemon started, doctor will warn that the daemon is polling a stale config — run `hookwise daemon stop` and let it restart to apply the change
 
 **No usage-data directory**
 - The insights producer needs `~/.claude/usage-data/` to exist

--- a/docs/guide/feeds-guide.md
+++ b/docs/guide/feeds-guide.md
@@ -54,7 +54,7 @@ feeds:
       - primary
 ```
 
-Requires a one-time setup: place your Google OAuth client credentials at `~/.hookwise/calendar-credentials.json` (path configurable via `credentials_path`) and the OAuth token at `~/.hookwise/calendar-token.json`. The producer refreshes and writes back the token automatically; if credentials are missing, the calendar segments simply stay empty (fail-open).
+Requires a one-time setup: place your Google OAuth client credentials at `~/.hookwise/calendar-credentials.json` and the OAuth token at `~/.hookwise/calendar-token.json`. The producer refreshes and writes back the token automatically; if credentials are missing, the calendar segments simply stay empty (fail-open).
 
 ### News
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -26,25 +26,27 @@ go build -o /usr/local/bin/hookwise ./cmd/hookwise/
 Navigate to your project directory and run:
 
 ```bash
-hookwise init --preset minimal
+hookwise init
 ```
 
-This creates two things:
-- `hookwise.yaml` in your project root (the configuration file)
-- `~/.hookwise/` state directory (for analytics, logs, and cache)
-
-Available presets:
-
-| Preset | Description |
-|--------|-------------|
-| `minimal` | Guards only -- blocks dangerous commands |
-| `coaching` | Guards + metacognition prompts + builder's trap detection |
-| `analytics` | Guards + SQLite session tracking and authorship metrics |
-| `full` | All features enabled |
+This does three things:
+- **Scans your existing Claude Code hooks first** and saves the pre-init inventory to `~/.hookwise/hook-audit.json` — so you have a record of what was configured before hookwise touched anything. The scan is read-only; your Claude Code settings are never modified.
+- Creates `hookwise.yaml` in your project root (the configuration file)
+- Ensures the `~/.hookwise/` state directory exists (for analytics, logs, and cache)
 
 ### 2. Register hooks in Claude Code
 
-Add hookwise as a hook handler in your Claude Code settings (`.claude/settings.json`):
+The recommended way is `--wire`, which edits `.claude/settings.json` for you — idempotently, after a pre-flight safety audit, with a backup:
+
+```bash
+hookwise init --wire              # wires dispatch hooks + statusLine
+hookwise init --wire --dry-run    # preview the diff first
+hookwise init --unwire            # removes hookwise's hooks, touching nothing else
+```
+
+By default `--wire` registers the `PreToolUse` and `PostToolUse` events (customize with `--events`) and the statusLine entry (skip with `--no-status-line`). If the pre-flight finds FAIL-level issues it refuses to write unless you pass `--force`.
+
+Alternatively, add hookwise as a hook handler manually in `.claude/settings.json`:
 
 ```json
 {
@@ -80,24 +82,17 @@ Add hookwise as a hook handler in your Claude Code settings (`.claude/settings.j
 hookwise doctor
 ```
 
-This runs 9 checks:
-- Go binary is installed and on PATH
-- Claude directory exists (`~/.claude/`)
-- Configuration file exists and is valid YAML
-- State directory has correct permissions
-- Status line segments resolve correctly
-- Daemon process is running
-- Insights data is accessible
-- Calendar credentials are valid
-- Python 3 is available (for TUI)
+Doctor checks that your configuration file exists and is valid YAML, the state directory and analytics database are healthy, and the feed daemon is running. It reports per-feed health against the daemon's *effective* runtime config (what the daemon is actually polling — falling back to the on-disk global config when the daemon is down), warns when the daemon is polling a stale config or when a project-level `feeds:` block is being ignored, and cross-checks your status-line segments against feed data.
 
-### 4. Check your configuration
+Doctor is honest about disabled subsystems: a disabled feed reports as `disabled` (not as a stale-cache warning), and $0 cost with cost tracking off is "expected", not a malfunction.
+
+### 4. Audit your hook setup
 
 ```bash
-hookwise status
+hookwise audit
 ```
 
-This shows a summary of your current configuration: which features are enabled, how many guard rules are active, and which recipes are included.
+This inventories every hook across your Claude Code settings files and flags safety issues: missing binaries, network-dependent hooks on hot paths, and duplicate or overlapping hooks. Add `--json` for a schema-versioned report (useful in CI — exits 0 on PASS/WARN, 1 on FAIL), or `--project-dir <dir>` to scan a project's `.claude/` settings instead of your user-level settings.
 
 ## Basic Configuration
 
@@ -175,13 +170,13 @@ See [Creating a Recipe](./creating-a-recipe.md) for writing your own.
 
 ## Feeds and Insights
 
-hookwise includes a feed platform with a background daemon that aggregates data from multiple sources:
+hookwise includes a feed platform with a background daemon that aggregates data from multiple sources.
+
+The daemon is a singleton shared by every project, so feeds are configured in the **global** config at `~/.hookwise/config.yaml` — not in a project's `hookwise.yaml`. A project-level `feeds:` block is ignored for polling, and `hookwise doctor` warns about it.
 
 ```yaml
+# ~/.hookwise/config.yaml
 feeds:
-  pulse:
-    enabled: true
-    interval_seconds: 30
   project:
     enabled: true
     interval_seconds: 60
@@ -190,14 +185,10 @@ feeds:
     interval_seconds: 300
   news:
     enabled: true
-    source: hackernews
     interval_seconds: 600
   insights:
     enabled: true
     interval_seconds: 120
-  practice:
-    enabled: true
-    interval_seconds: 60
   weather:
     enabled: true
     interval_seconds: 900
@@ -215,8 +206,10 @@ hookwise daemon start
 Check feed health:
 
 ```bash
-hookwise feeds
+hookwise doctor
 ```
+
+Doctor queries the daemon's runtime feed config, so what it reports is what the daemon is actually polling — including a warning if you edited the global config after the daemon started.
 
 The insights producer reads your Claude Code usage data from `~/.claude/usage-data/` and surfaces metrics like session frequency, tool friction, and pace trends in your status line.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,9 +21,9 @@ features:
   - title: Coaching
     details: Metacognition prompts, builder's trap detection, and communication coaching to keep you focused and productive.
   - title: Feed Platform
-    details: Background daemon with 8 built-in producers (pulse, project, calendar, news, insights, practice, weather, memories) and a TTL-aware cache bus.
+    details: Background daemon with 6 built-in producers (project, news, calendar, weather, memories, insights) plus custom feeds, and a TTL-aware cache bus.
   - title: Status Line
-    details: Two-tier status line with 21 segments. Renders in your Claude Code prompt with live data from the cache bus.
+    details: Composable status line segments. Renders in your Claude Code prompt with live data from the cache bus.
   - title: Recipes
     details: Pre-built, shareable hook configurations. Include community recipes or create your own with guards, handlers, and config.
 ---

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -130,6 +130,16 @@ hookwise status-line [--project-dir <dir>]
 
 Loads config and the feed cache, then renders a single ANSI-colored status line to stdout. Auto-starts the feed daemon if it isn't running.
 
+## tui
+
+Launch the interactive TUI dashboard.
+
+```bash
+hookwise tui [--launch-method <newWindow|background>]
+```
+
+Launches the `hookwise-tui` dashboard if it is not already running, using the same singleton guard as session auto-launch (concurrent invocations spawn at most one TUI). Requires `hookwise-tui` on your PATH — the TUI ships separately from the core binary; install it from the `tui/` directory (e.g. `uv tool install ./tui`). See the [TUI Guide](tui-guide.md).
+
 ## daemon
 
 Manage the background feed daemon.

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1,195 +1,225 @@
 # CLI Reference
 
-hookwise provides 12 CLI commands. All commands are invoked as `hookwise <command>`.
+All commands are invoked as `hookwise <command>`. Run `hookwise <command> --help` for the authoritative flag list.
 
 ## init
 
 Initialize hookwise in the current directory.
 
 ```bash
-hookwise init [--preset <name>]
+hookwise init
+```
+
+Without flags, `init` does three things:
+
+1. **Scans your existing Claude Code hooks** before writing anything, and saves the pre-init inventory (hooks, findings, parse errors) to `~/.hookwise/hook-audit.json`. The scan is advisory — it never modifies your Claude Code settings, and a scan failure never aborts init.
+2. Creates a default `hookwise.yaml` in the current directory (skipped if one already exists).
+3. Ensures the `~/.hookwise/` state directory exists.
+
+### init --wire / --unwire
+
+Wire hookwise into Claude Code's `settings.json` — idempotently and safely:
+
+```bash
+hookwise init --wire                # wire dispatch hooks + statusLine
+hookwise init --wire --dry-run      # preview the settings.json diff without writing
+hookwise init --unwire              # remove hookwise's own hooks, touching nothing else
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--preset <name>` | Use a preset configuration: `minimal`, `coaching`, `analytics`, `full` |
+| `--wire` | Wire hookwise into Claude Code settings.json |
+| `--unwire` | Remove hookwise hooks from Claude Code settings.json |
+| `--dry-run` | Print what would change without writing |
+| `--events <list>` | Hook events to wire, comma-separated (default `PreToolUse,PostToolUse`) |
+| `--no-status-line` | Skip wiring the statusLine entry |
+| `--settings <path>` | Override path to Claude Code settings.json |
+| `--force` | Wire even if pre-flight finds FAIL-level issues |
 
-Creates `hookwise.yaml` in the current directory and `~/.hookwise/` state directory.
+Wiring runs a pre-flight safety audit first and refuses to proceed on FAIL-level findings unless `--force` is given. A backup of settings.json is written before any change.
 
-**Presets:**
+## audit
 
-| Preset | Includes |
-|--------|----------|
-| `minimal` | Guards only |
-| `coaching` | Guards + metacognition + builder's trap |
-| `analytics` | Guards + SQLite session tracking |
-| `full` | All features (guards, coaching, analytics, feeds, insights, status line, cost tracking) |
+Scan Claude Code hook configuration for health issues.
+
+```bash
+hookwise audit [--json] [--project-dir <dir>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit a schema-versioned JSON report (`schema_version: 1`) instead of text |
+| `--project-dir <dir>` | Scan `<dir>/.claude/settings.json` + `settings.local.json` instead of the user-level settings |
+
+Scans settings files for hook-safety issues: inventory/sprawl, missing binaries, network-dependent hooks on hot paths, and duplicate or overlapping hooks. The report includes a full hook inventory (by event, matcher, command, source file), findings with levels, and a `PASS` / `WARN` / `FAIL` summary.
+
+**Exit codes:** 0 on PASS or WARN, 1 on FAIL — suitable for CI gates. Malformed settings files become FAIL findings rather than crashes.
 
 ## doctor
 
-Check system health and configuration.
+Run system health checks.
 
 ```bash
 hookwise doctor
 ```
 
-Validates:
+Checks:
+
 - `hookwise.yaml` exists and parses correctly
-- State directory (`~/.hookwise/`) exists with correct permissions
-- All referenced handlers are accessible
-- Recipe includes resolve correctly
-- Feed configuration is valid
-- Daemon status
+- State directory exists
+- Analytics DB opens and is queryable
+- Daemon liveness (socket dial)
+- **Feed config source** — when the daemon is running, doctor queries its runtime feed config (`GET /feeds`) and reports against what the daemon is *actually* polling; when it isn't, doctor falls back to the on-disk global config and says so
+- **Feed config drift** — warns when the daemon is polling a stale config (you edited `~/.hookwise/config.yaml` after daemon startup) and suggests a restart
+- **Project `feeds:` block** — warns if the project `hookwise.yaml` carries feed settings, which the singleton daemon ignores (move them to the global config)
+- Per-feed health (fresh / stale / placeholder / no data) and status-line segment cross-check
+- Existing Claude Code hook settings parse cleanly
+- **Cost-tracking honesty** — sessions recorded today with $0 computed *while cost tracking is enabled* is flagged as a likely dead cost writer; with cost tracking disabled (the default), $0 is reported as expected, not a malfunction
 
-## status
-
-Show current configuration summary.
-
-```bash
-hookwise status [--config <path>]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--config <path>` | Path to config file (default: `hookwise.yaml` in cwd) |
-
-Displays which features are enabled, guard rule count, included recipes, and feed status.
-
-## status-line
-
-Render the two-tier status line. Reads a JSON payload from stdin (provided by Claude Code).
-
-```bash
-echo '{"session_id":"abc","context_window":{"used_percentage":0.67}}' | hookwise status-line
-```
-
-This command is called automatically by Claude Code hooks -- you rarely need to invoke it manually.
+Doctor is honest about disabled subsystems: a disabled feed reports as `INFO disabled`, not as a stale-cache warning.
 
 ## stats
 
-Display session analytics and tool usage.
+Display today's analytics dashboard.
 
 ```bash
-hookwise stats [--json] [--agents] [--cost] [--streaks]
+hookwise stats [--data-dir <path>]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--json` | Output structured JSON |
-| `--agents` | Include multi-agent activity summary |
-| `--cost` | Include cost breakdown |
-| `--streaks` | Include coding streak information |
+| `--data-dir <path>` | Path to the analytics SQLite DB file (defaults to config `analytics.db_path` / `~/.hookwise/analytics.db`) |
 
-Requires analytics to be enabled in `hookwise.yaml`.
+Opens the analytics database and displays today's daily summary and tool breakdown. Requires analytics to be enabled in `hookwise.yaml`.
 
 ## test
 
-Run the hookwise guard test suite.
+Evaluate guard test scenarios.
 
 ```bash
-hookwise test
-```
-
-Loads test scenarios from `hookwise.yaml` and runs them against your guard rules, reporting pass/fail for each scenario.
-
-## tui
-
-Launch the interactive terminal UI.
-
-```bash
-hookwise tui
-```
-
-Opens a full-screen interface with 8 tabs:
-
-| Key | Tab | Description |
-|-----|-----|-------------|
-| `1` | Dashboard | Session status, feature toggles, quick stats |
-| `2` | Guards | Rule browser, test interface, match visualization |
-| `3` | Coaching | Metacognition, builder's trap, communication status |
-| `4` | Analytics | Daily summary, tool breakdown, authorship metrics |
-| `5` | Feeds | Live feed data, daemon health, cache bus state |
-| `6` | Insights | AI-generated insights, trend analysis |
-| `7` | Recipes | Installed recipes, details, active includes |
-| `8` | Status | Status line preview, segment configuration |
-
-Press `q` or `Escape` to exit.
-
-## migrate
-
-Migrate from Python hookwise (v0.1.0).
-
-```bash
-hookwise migrate [--dry-run]
+hookwise test [--project-dir <dir>]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--dry-run` | Preview changes without applying them |
+| `--project-dir <dir>` | Project directory (defaults to cwd) |
 
-Replaces the Python hookwise entry in Claude's `settings.json` with the Go binary and validates your config against the current schema.
-
-See the [Migration guide](/reference/migration) for full details.
+Loads config, creates synthetic test payloads for each guard rule, evaluates them, and reports pass/fail.
 
 ## dispatch
 
 Dispatch a hook event. This is the fast-path command called by Claude Code on every hook event.
 
 ```bash
-hookwise dispatch <event-type>
+hookwise dispatch <EventType> [--project-dir <dir>]
 ```
 
 Reads the hook payload from stdin as JSON and routes it through the three-phase execution pipeline (guard, context, side effect).
 
 **Event types:** `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `Notification`, `Stop`, `SubagentStart`, `SubagentStop`, `PreCompact`, `SessionStart`, `SessionEnd`, `PermissionRequest`, `Setup`
 
-This command is registered in `.claude/settings.json` -- see [Getting Started](/guide/getting-started) for setup instructions.
+This command is registered in `.claude/settings.json` — `hookwise init --wire` does it for you, or see [Getting Started](/guide/getting-started) for manual setup.
+
+## status-line
+
+Render the status line. Called automatically by Claude Code's `statusLine` setting.
+
+```bash
+hookwise status-line [--project-dir <dir>]
+```
+
+Loads config and the feed cache, then renders a single ANSI-colored status line to stdout. Auto-starts the feed daemon if it isn't running.
 
 ## daemon
 
 Manage the background feed daemon.
 
 ```bash
-hookwise daemon <start|stop|status> [--config <path>]
+hookwise daemon <start|stop>
 ```
 
 | Subcommand | Description |
 |------------|-------------|
-| `start` | Start the daemon as a detached background process |
-| `stop` | Send SIGTERM and remove the PID file |
-| `status` | Show daemon PID and running state |
+| `start` | Start the feed daemon (connect-or-start) |
+| `stop` | Stop the feed daemon |
 
-| Flag | Description |
-|------|-------------|
-| `--config <path>` | Path to config file |
+The daemon is a singleton — one socket, one cache, one process per state directory. Its feed configuration comes from the **global** config (`~/.hookwise/config.yaml`) only, regardless of which project directory started it; a project-level `feeds:` block is ignored (`hookwise doctor` warns about this). It polls feed producers at their configured intervals and writes results to the cache bus.
 
-The daemon polls feed producers at their configured intervals and writes results to the cache bus.
+## snapshot
 
-## feeds
-
-Live feed dashboard showing daemon health and cache bus state.
+Take a point-in-time snapshot of the analytics database.
 
 ```bash
-hookwise feeds [--once] [--config <path>]
+hookwise snapshot [--data-dir <path>] [--snapshots-dir <dir>] [--retention <n>]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--once` | Show a snapshot and exit (no auto-refresh) |
-| `--config <path>` | Path to config file |
+| `--data-dir <path>` | Path to the analytics SQLite DB file |
+| `--snapshots-dir <dir>` | Directory to write snapshots to (defaults to `~/.hookwise/snapshots`) |
+| `--retention <n>` | Number of snapshots to keep (defaults to config `snapshot_retention`) |
 
-Displays each feed's status, last update time, freshness, and cached data.
+Writes a consistent `VACUUM INTO` copy of the analytics database and prunes older snapshots beyond the retention limit.
 
-## setup
+## log
 
-Set up external integrations.
+Show analytics snapshot history.
 
 ```bash
-hookwise setup <target>
+hookwise log [--limit <n>] [--snapshots-dir <dir>]
 ```
 
-| Target | Description |
-|--------|-------------|
-| `calendar` | Configure Google Calendar OAuth for the calendar feed |
+| Flag | Description |
+|------|-------------|
+| `--limit <n>` | Maximum number of snapshots to show, 0 = all (default 10) |
+| `--snapshots-dir <dir>` | Path to snapshots directory |
 
-Stores credentials at `~/.hookwise/calendar-credentials.json`.
+Displays recent snapshots (newest first). Snapshots are created periodically by the daemon via `VACUUM INTO`.
+
+## diff
+
+Show row-count changes between two analytics snapshots.
+
+```bash
+hookwise diff <from-ref> <to-ref> [--snapshots-dir <dir>]
+```
+
+Refs accept `latest` (newest snapshot), `prev` (second-newest), an exact snapshot name, or a date prefix like `20260101` (newest match wins).
+
+```bash
+hookwise diff prev latest
+hookwise diff 20260101 20260102
+```
+
+## notifications
+
+Display notification history.
+
+```bash
+hookwise notifications [--limit <n>] [--data-dir <path>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--limit <n>` | Maximum number of notifications to show (default 20) |
+| `--data-dir <path>` | Path to the analytics SQLite DB file |
+
+Shows recent notifications from the budget producer, stored in the analytics database and surfaced via the status line or this command.
+
+## upgrade
+
+Migrate data from a TypeScript hookwise installation.
+
+```bash
+hookwise upgrade [--dry-run] [--data-dir <path>] [--project-dir <dir>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Preview migration without making changes |
+| `--data-dir <path>` | Path to the analytics SQLite DB file |
+| `--project-dir <dir>` | Project directory for config validation |
+
+Detects an existing TypeScript hookwise installation, imports the data into the Go SQLite analytics database, and validates config parity. Original files are never modified (non-destructive).
+
+See the [Migration guide](/reference/migration) for full details.

--- a/docs/reference/migration.md
+++ b/docs/reference/migration.md
@@ -12,7 +12,7 @@ This guide walks you through migrating from the original Python hookwise (v0.1.0
 | Test framework | pytest | `go test` + contract fixtures |
 | Testing API | `GuardTester` (Python) | `hwtesting.GuardTester` (Go) |
 | TUI | Textual | Python Textual (unchanged) |
-| Recipes | 7 built-in | 12 built-in |
+| Recipes | 7 built-in | 11 built-in |
 | Event support | 7 events | All 13 Claude Code events |
 | Analytics | SQLite (TypeScript-era) | SQLite (modernc.org/sqlite, WAL mode, ~19 MB binary) |
 | Distribution | pip/PyPI | Go binary via GitHub Releases |
@@ -46,22 +46,24 @@ go build -ldflags "-X main.version=$(git describe --tags)" -o /usr/local/bin/hoo
 
 ### 2. Run the migration command
 
-hookwise includes an automated migration tool:
+hookwise includes an automated data-migration tool:
 
 ```bash
-hookwise migrate
+hookwise upgrade
 ```
 
 This will:
-- Replace the Python hookwise entry in Claude's `settings.json` with the Go binary
-- Validate your existing `hookwise.yaml` against the current schema
-- Report any incompatibilities
+- Detect an existing pre-Go hookwise installation (`~/.hookwise/analytics.db` and `~/.hookwise/state/cost-state.json`)
+- Import the data into the Go SQLite analytics database
+- Validate config parity
 
-Use `--dry-run` to preview changes without applying them:
+Original files are never modified (the migration is non-destructive). Use `--dry-run` to preview what would be migrated without making changes:
 
 ```bash
-hookwise migrate --dry-run
+hookwise upgrade --dry-run
 ```
+
+To point hookwise at Claude Code's `settings.json`, use `hookwise init --wire` (see the [CLI Reference](cli-reference.md)).
 
 ### 3. Update handler scripts
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -115,7 +115,7 @@ hookwise is designed for single-user use. The state directory should be owned by
 
 ## TUI Not Launching
 
-**Symptom:** `hookwise-tui` exits immediately or shows rendering errors.
+**Symptom:** `hookwise tui` (or `hookwise-tui` directly) exits immediately or shows rendering errors.
 
 **Terminal requirements:**
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -9,7 +9,7 @@ Common issues and their solutions.
 **Check for an existing daemon:**
 
 ```bash
-hookwise daemon status
+hookwise doctor
 ```
 
 If a daemon is already running, stop it first:
@@ -37,12 +37,12 @@ Look for startup errors such as missing config, invalid feed definitions, or per
 
 ## Stale Feed Data
 
-**Symptom:** Status line shows outdated information. `hookwise feeds` shows feeds as stale.
+**Symptom:** Status line shows outdated information. `hookwise doctor` shows feeds as stale.
 
 **Is the daemon running?**
 
 ```bash
-hookwise daemon status
+hookwise doctor
 ```
 
 If stopped, restart it:
@@ -115,7 +115,7 @@ hookwise is designed for single-user use. The state directory should be owned by
 
 ## TUI Not Launching
 
-**Symptom:** `hookwise tui` exits immediately or shows rendering errors.
+**Symptom:** `hookwise-tui` exits immediately or shows rendering errors.
 
 **Terminal requirements:**
 

--- a/docs/reference/tui-guide.md
+++ b/docs/reference/tui-guide.md
@@ -10,16 +10,16 @@ The TUI is a separate Python package bundled in the `tui/` directory:
 cd tui && pip install -e .
 ```
 
-Or install from the venv that ships with hookwise:
+Or install it as a standalone tool (e.g. with uv):
 
 ```bash
-hookwise tui  # Auto-detects the bundled venv
+uv tool install ./tui
 ```
 
 ## Launching the TUI
 
 ```bash
-hookwise tui
+hookwise-tui
 ```
 
 ## Navigation

--- a/docs/reference/tui-guide.md
+++ b/docs/reference/tui-guide.md
@@ -19,8 +19,10 @@ uv tool install ./tui
 ## Launching the TUI
 
 ```bash
-hookwise-tui
+hookwise tui
 ```
+
+This launches the dashboard via the same singleton guard as session auto-launch, so concurrent invocations spawn at most one TUI. It requires `hookwise-tui` on your PATH (installed above); you can also run `hookwise-tui` directly.
 
 ## Navigation
 


### PR DESCRIPTION
## Summary
- Refreshes README + docs/ to match what is actually shipped: audit command, init hook-scan, daemon canonical global config, doctor honesty, TUI install/launch story.
- Includes fixes for both review blockers: restores `hookwise tui` documentation (the subcommand ships in this batch — cli-reference section, tui-guide, troubleshooting, cli.md, README) and drops the stale `credentials_path` mention deleted by the dead-config cleanup.

## Test plan
- Docs-only change; grep-swept for references to deleted config fields (state_dir, credentials_path, log_file) — remaining mentions are live keys only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ