### PR TITLE
fix(daemon): serialize socket arbitration with flock to close TOCTOU

### DIFF
--- a/internal/feeds/socket.go
+++ b/internal/feeds/socket.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/vishnujayvel/hookwise/internal/core"
@@ -24,6 +25,7 @@ type SocketServer struct {
 	shutdownOnce sync.Once
 	startedAt    time.Time
 	mu           sync.Mutex
+	boundInfo    os.FileInfo // socket file identity captured at bind time
 }
 
 // SetFeedsProvider wires the function that GET /feeds calls to report the
@@ -44,10 +46,50 @@ func NewSocketServer(socketPath string, shutdownFn func(), startedAt time.Time) 
 	}
 }
 
+// acquireArbitrationLock takes an exclusive flock on a sidecar lock file
+// next to the socket. bind(2)+listen(2) via net.Listen is not atomic: a
+// socket that is bound but not yet listening refuses connections and is
+// indistinguishable from a stale one, so two racing daemons could each
+// classify the other's live socket as stale and both "win" the bind. The
+// flock spans the whole stat/dial/remove/bind sequence so arbitration is
+// serialized across processes. The lock file is deliberately never removed:
+// unlinking a lock file while another process may be flocking it reopens
+// the race on a fresh inode.
+//
+// Acquisition is non-blocking with a retry deadline rather than a bare
+// LOCK_EX: a hung-but-alive holder (SIGSTOP, wedged filesystem) would
+// otherwise stall Start and Shutdown indefinitely — Daemon.Stop budgets
+// 10s for the whole shutdown. A dead holder is not a concern; the OS
+// releases the flock on process exit.
+func (s *SocketServer) acquireArbitrationLock(timeout time.Duration) (*os.File, error) {
+	f, err := os.OpenFile(s.socketPath+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return f, nil
+		}
+		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
+			f.Close()
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			f.Close()
+			return nil, fmt.Errorf("timed out after %s waiting for holder of %s", timeout, s.socketPath+".lock")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 // Start binds the unix socket, sets permissions to 0600, registers HTTP
 // routes, and begins serving. Before binding, it performs stale socket
 // detection: if a socket file exists but cannot be connected to, it is
-// removed to allow a fresh bind (SOCKET-3).
+// removed to allow a fresh bind (SOCKET-3). The detect-remove-bind sequence
+// runs under a cross-process flock so concurrent starts cannot misclassify
+// a bound-but-not-yet-listening socket as stale.
 func (s *SocketServer) Start() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -56,6 +98,14 @@ func (s *SocketServer) Start() error {
 	if err := core.EnsureDir(filepath.Dir(s.socketPath), core.DefaultDirMode); err != nil {
 		return fmt.Errorf("feeds: ensure socket dir: %w", err)
 	}
+
+	// 5s bound: a healthy holder's critical section is at most one failed
+	// 500ms dial plus a few syscalls, so even a queue of racers drains fast.
+	lock, err := s.acquireArbitrationLock(5 * time.Second)
+	if err != nil {
+		return fmt.Errorf("feeds: acquire socket arbitration lock: %w", err)
+	}
+	defer lock.Close() // closing the fd releases the flock
 
 	// Stale socket detection (SOCKET-3): if the file exists, try to connect.
 	if _, err := os.Stat(s.socketPath); err == nil {
@@ -78,6 +128,23 @@ func (s *SocketServer) Start() error {
 		return fmt.Errorf("feeds: bind socket: %w", err)
 	}
 	s.listener = listener
+
+	// Go's UnixListener unlinks the path unconditionally on Close — if another
+	// daemon has replaced the file by then, that would delete the successor's
+	// live socket. Disable it; Shutdown owns removal with an identity check.
+	if ul, ok := listener.(*net.UnixListener); ok {
+		ul.SetUnlinkOnClose(false)
+	}
+
+	// Capture the bound socket file's identity so Shutdown only ever removes
+	// the file this instance created, never a successor's. On stat failure
+	// boundInfo stays nil and Shutdown skips removal — the file is then
+	// reclaimed by the next Start's stale detection.
+	if fi, statErr := os.Stat(s.socketPath); statErr == nil {
+		s.boundInfo = fi
+	} else {
+		core.Logger().Warn("feeds: could not capture bound socket identity; shutdown will not remove the socket file", "path", s.socketPath, "error", statErr)
+	}
 
 	// Set socket file permissions to 0600 (SOCKET-2).
 	if err := os.Chmod(s.socketPath, 0o600); err != nil {
@@ -127,10 +194,23 @@ func (s *SocketServer) Shutdown(ctx context.Context) error {
 		}
 	}
 
-	// Remove the socket file.
-	if err := os.Remove(s.socketPath); err != nil && !os.IsNotExist(err) {
-		if firstErr == nil {
-			firstErr = fmt.Errorf("feeds: remove socket: %w", err)
+	// Remove the socket file — only under the arbitration flock, and only if
+	// it is still the file this instance bound. If another daemon has since
+	// replaced it, removing by path would delete the other daemon's live
+	// socket. If the lock cannot be acquired, skip removal entirely: an
+	// unlocked check-and-remove is the same TOCTOU this lock exists to close,
+	// and leaving a stale file for the next Start's stale detection is
+	// strictly safer.
+	if lock, lockErr := s.acquireArbitrationLock(2 * time.Second); lockErr == nil {
+		defer lock.Close()
+		if fi, statErr := os.Stat(s.socketPath); statErr == nil {
+			if s.boundInfo != nil && os.SameFile(s.boundInfo, fi) {
+				if err := os.Remove(s.socketPath); err != nil && !os.IsNotExist(err) {
+					if firstErr == nil {
+						firstErr = fmt.Errorf("feeds: remove socket: %w", err)
+					}
+				}
+			}
 		}
 	}
 

--- a/internal/feeds/socket_test.go
+++ b/internal/feeds/socket_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -178,6 +179,57 @@ func TestSocketServer_ShutdownRemovesSocketFile(t *testing.T) {
 
 	_, err = os.Stat(socketPath)
 	assert.True(t, os.IsNotExist(err), "socket file should be removed after shutdown")
+}
+
+func TestSocketServer_ConcurrentStartOneWinner(t *testing.T) {
+	// Regression for the SOCKET-3 TOCTOU race: net.Listen is bind+listen,
+	// not atomic, so a bound-but-not-yet-listening socket refuses dials and
+	// looked stale to racing starters — two daemons could both "win". The
+	// arbitration flock must serialize the detect-remove-bind sequence.
+	socketPath := filepath.Join(socketTempDir(t), "d.sock")
+
+	const racers = 8
+	servers := make([]*SocketServer, racers)
+	errs := make([]error, racers)
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		servers[i] = NewSocketServer(socketPath, func() {}, time.Now())
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = servers[i].Start()
+		}(i)
+	}
+	wg.Wait()
+
+	winners := 0
+	for i, err := range errs {
+		if err == nil {
+			winners++
+			t.Cleanup(func() { _ = servers[i].Shutdown(context.Background()) })
+		}
+	}
+	assert.Equal(t, 1, winners, "exactly one concurrent Start must win the bind")
+}
+
+func TestSocketServer_ShutdownSparesSuccessorSocket(t *testing.T) {
+	// If another daemon replaced the socket file after this instance bound it,
+	// Shutdown must not remove the successor's file — neither via the explicit
+	// remove (identity-checked) nor via Go's unlink-on-close (disabled).
+	socketPath := filepath.Join(socketTempDir(t), "d.sock")
+
+	srv := NewSocketServer(socketPath, func() {}, time.Now())
+	require.NoError(t, srv.Start())
+
+	// Simulate a successor taking over the path.
+	require.NoError(t, os.Remove(socketPath))
+	require.NoError(t, os.WriteFile(socketPath, []byte("successor"), 0o600))
+
+	require.NoError(t, srv.Shutdown(context.Background()))
+
+	content, err := os.ReadFile(socketPath)
+	require.NoError(t, err, "successor's file must survive the predecessor's shutdown")
+	assert.Equal(t, "successor", string(content))
 }
 
 func TestSocketServer_ShutdownOnlyPOST(t *testing.T) {


### PR DESCRIPTION
## Summary
- Root cause (from the hw-u5l investigation of flaky `TestDaemon_ConcurrentStartOnlyOneWins`): `net.Listen("unix")` is bind+listen non-atomic, so a bound-but-not-yet-listening socket refuses dials and looks stale to SOCKET-3 detection — two racing daemon starts could each unlink the other's live socket and both "win" (reproduced 5/100 under `-race`). Production impact: the orphaned first daemon becomes unreachable via /shutdown until idle timeout.
- Fix: exclusive flock on a sidecar `<socket>.lock` (deliberately never unlinked) spanning the whole stat/dial/remove/bind sequence; LOCK_NB + retry deadline so a hung-but-alive holder can't stall `Start` (5s) or `Daemon.Stop`'s 10s budget (2s).
- Shutdown hardening: `SetUnlinkOnClose(false)` (Go's path-based auto-unlink could delete a successor's socket) + identity-checked (`os.SameFile`) removal under the same flock; lock-acquisition failure skips removal entirely rather than falling back to an unlocked remove-by-path.
- Adversarially reviewed (APPROVE-WITH-NITS); both MAJORs — blocking flock without timeout, and the unlocked Shutdown fallback — are fixed in this diff.

Closes #240

## Test plan
- `TestDaemon_ConcurrentStartOnlyOneWins -count=300`: 0 failures (was 5/100 before the fix).
- New: `TestSocketServer_ConcurrentStartOneWinner` (8 racers, exactly one winner), `TestSocketServer_ShutdownSparesSuccessorSocket` (covers both the identity-checked remove and disabled unlink-on-close).
- Full guarded gates green: `GOMEMLIMIT=4GiB go test -race -p 2 ./...` exit 0; integration tier (integration/chaos/feeds) all ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ