### PR TITLE
test(perf): fix stale 500us comments to match 2ms budget

### DIFF
--- a/internal/perf/perf_test.go
+++ b/internal/perf/perf_test.go
@@ -204,7 +204,8 @@ func BenchmarkGuardEvaluation_WithConditions(b *testing.B) {
 // Benchmark 4: Config loading
 // =========================================================================
 //
-// Benchmarks LoadConfig() to verify it completes within 500 microseconds.
+// Benchmarks LoadConfig() to verify it completes within the enforced 2ms
+// budget (measured ~850us on Apple Silicon).
 
 func BenchmarkConfigLoading(b *testing.B) {
 	tmpDir := b.TempDir()
@@ -249,7 +250,8 @@ settings:
 	}
 }
 
-// TestConfigLoading_Latency verifies config loading completes within 500 microseconds.
+// TestConfigLoading_Latency verifies config loading completes within the
+// enforced 2ms budget (measured ~850us on Apple Silicon).
 func TestConfigLoading_Latency(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOOKWISE_STATE_DIR", filepath.Join(tmpDir, ".hookwise-state"))


### PR DESCRIPTION
## Summary
- The config-load scout (hw-t37) found the "500 microseconds" target exists only as comments in perf_test.go — no spec document contains it, and the enforced assertion is already 2ms. Both comments now state the enforced 2ms budget and the ~850us measured figure.
- Comment-only change; no assertions or benchmark code altered.

## Test plan
- `GOMEMLIMIT=4GiB go test -race -p 2 ./internal/perf/` green (validated by the rig's guarded gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the documented performance targets for configuration loading.
  * Updated the benchmark reference to approximately 850 microseconds and the enforced latency budget to 2 milliseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->