### PR TITLE
docs: rebuild boundaries.md inventory + correct TUI tab count

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ One file. Claude Code reads it, understands it, and can even help you write new 
 |---|---------|-----------------|------------------|
 | Guard rails | Declarative YAML | Manual bash | No |
 | Testing | GuardTester + HookRunner | Manual | N/A |
-| Coaching | Metacognition prompts | No | No |
 | Analytics | SQLite, queryable | DIY | Display-only |
 | Workflow insights | Friction signals, session pulse | No | No |
 | Configuration | One YAML file | Scattered scripts | JSON/TUI |
@@ -147,7 +146,7 @@ Every hook event passes through a three-phase execution engine. Guards protect, 
 
 <img src="screenshots/stats.png" alt="hookwise stats" width="600">
 
-**[Interactive TUI](docs/cli.md)** _(optional · experimental)_ -- A full-screen Python/[Textual](https://textual.textualize.io) dashboard with 8 tabs. It ships **separately** from the core binary (the core CLI, guards, analytics, and status line need no Python). Install it from the `tui/` directory (e.g. `uv tool install ./tui`); once `hookwise-tui` is on your PATH, launch it on demand with `hookwise tui`, or set `tui.auto_launch: true` to open it in a separate terminal on session start.
+**[Interactive TUI](docs/cli.md)** _(optional · experimental)_ -- A full-screen Python/[Textual](https://textual.textualize.io) dashboard with 7 tabs. It ships **separately** from the core binary (the core CLI, guards, analytics, and status line need no Python). Install it from the `tui/` directory (e.g. `uv tool install ./tui`); once `hookwise-tui` is on your PATH, launch it on demand with `hookwise tui`, or set `tui.auto_launch: true` to open it in a separate terminal on session start.
 
 <div align="center">
 <img src="screenshots/tui-insights.png" alt="hookwise TUI — Claude Code usage insights with session metrics, trends, and tool breakdown" width="700">

--- a/docs/boundaries.md
+++ b/docs/boundaries.md
@@ -18,10 +18,8 @@ This document defines what hookwise controls and what it does not. It exists for
 |-----------|-------------|-------------|
 | `hookwise.yaml` config | `internal/core/config.go` | Project-level and global YAML configuration (gopkg.in/yaml.v3) with deep merge, env var interpolation, snake_case/camelCase conversion |
 | Config validation | `internal/core/config.go` (`ValidateConfig`) | Structural validation of all 14 top-level sections with path-based error reporting |
-| Config write-back | `internal/core/config.go` (`SaveConfig`) | Atomic YAML serialization (temp file + rename) |
-| Recipe system | `internal/core/recipes.go` | Load, validate, and merge recipes from `recipes/` directories (12 built-in across 6 categories: safety, quality, productivity, behavioral, compliance, gamification) |
-| Include resolution | `internal/core/config.go` (`ResolveIncludes`) | Merge included YAML files and recipe directories into the base config |
-| Config migration | `internal/core/config.go` (`ApplyV010Compat`) | v0.1.0 backward compatibility transforms (Python-era `.py` script references) |
+| Include resolution | `internal/core/config.go` (`ResolveIncludes`) | Merge included YAML files (including recipe files) into the base config |
+| Recipe library | `recipes/` | 11 built-in recipes across 6 categories (safety, quality, productivity, behavioral, compliance, gamification), consumed as YAML config includes |
 
 ### Execution Layer
 
@@ -29,66 +27,64 @@ This document defines what hookwise controls and what it does not. It exists for
 |-----------|-------------|-------------|
 | Three-phase dispatcher | `internal/core/dispatcher.go` | Entry point for all 13 Claude Code hook events: Guards -> Context Injection -> Side Effects |
 | Guard evaluation | `internal/core/guards.go` | First-match-wins firewall rules with glob matching (gobwas/glob), 6 condition operators (`contains`, `starts_with`, `ends_with`, `==`, `equals`, `matches`), `when`/`unless` clauses |
-| Handler execution | `internal/core/dispatcher.go` | Executes builtin, script (os/exec), and inline handler types with timeout enforcement |
+| Handler execution | `internal/core/handlers.go` | Executes builtin, script (os/exec), and inline handler types with timeout enforcement |
 | Context injection | `internal/core/dispatcher.go` (`executeContextPhase`) | Merges `additionalContext` strings from context-phase handlers into hook output |
-| Greeting | `internal/core/greeting.go` | Weighted random quote selection from configured categories or custom quotes file |
-| Metacognition prompts | `internal/core/metacognition.go` | Time-based and behavioral-trigger reminders (rapid acceptance detection, builder's trap alerts) |
-| Communication coaching | `internal/core/communication.go` | Grammar analysis and communication style nudges |
-| Builder's trap detection | `internal/core/builder_trap.go` | Mode classification (tooling vs. practice), time accumulation, alert level computation |
 
 ### Data Layer
 
 | Component | Source Files | Description |
 |-----------|-------------|-------------|
-| Analytics SQLite DB | `internal/analytics/sqlite.go` | Session tracking, tool call logging, authorship ledger (`~/.hookwise/analytics.db`); WAL mode, periodic VACUUM INTO snapshots |
-| Analytics engine | `internal/analytics/session.go` | Session start/end lifecycle, event recording |
-| Stats queries | `internal/analytics/stats.go` | Daily summaries, tool breakdowns, authorship summaries |
-| Coaching state | `internal/core/` | JSON-based session state for metacognition intervals and builder's trap mode tracking |
-| Cache bus | `internal/feeds/cache_bus.go` | Filesystem-based inter-process communication via atomic JSON reads/writes with per-key TTL |
-| Transcript backup | `internal/core/transcript.go` | Timestamped JSON files of hook payloads with max directory size enforcement |
-| Cost state | `internal/core/cost.go` | Per-session and daily cost accumulation with budget enforcement |
-| Agent spans | `internal/core/agents.go` | Multi-agent lifecycle tracking in the analytics DB, file conflict detection, Mermaid diagram generation |
+| Analytics SQLite DB | `internal/analytics/sqlite.go` | Session tracking and tool call logging (`~/.hookwise/analytics.db`); WAL mode, single-writer connection (ARCH-2) |
+| Analytics snapshots | `internal/analytics/snapshot.go`, `internal/analytics/history.go` | Point-in-time `VACUUM INTO` snapshots of the analytics DB, with history and row-count diffing (`snapshot`/`diff`/`log` commands) |
+| Cost state | `internal/analytics/state.go` (`CostState`, `UpdateCostState`), `internal/pricing/` | Per-session and daily USD cost accumulation from token usage, with budget enforcement |
+| Transcript usage parsing | `internal/transcript/` | Parses Claude Code `.jsonl` transcripts to aggregate token usage for cost computation |
+| Go→TUI cache bridge | `internal/bridge/bridge.go` | Collects fresh feed envelopes and writes the merged TUI cache (`~/.hookwise/status-line-cache.json`) via `FlattenForTUI` |
+| Notifications | `internal/notifications/` | Notification service and producers (e.g. budget threshold checks) persisted in the analytics DB, surfaced via `hookwise notifications` |
 
 ### Display Layer
 
 | Component | Source Files | Description |
 |-----------|-------------|-------------|
-| Status line segments | `internal/core/segments.go` | 20 built-in segment renderers, each a pure function `(cache, config) => string` |
-| Two-tier renderer | `internal/core/two_tier.go` | Line 1 (fixed: context_bar, mode_badge, cost, duration) + Line 2 (rotating: 9 contextual feeds) |
-| ANSI color system | `internal/core/ansi.go` | Conditional ANSI colorization for segment output |
-| TUI application | `tui/hookwise_tui/` | 8-tab Python Textual app (Dashboard, Guards, Coaching, Analytics, Status, Feeds, Insights, Recipes) with custom widgets (FeatureCard, FeedHealth, Sparkline) |
-| TUI launcher | `internal/core/tui_launcher.go` | Detached process spawning (os/exec with SysProcAttr) with PID-based duplicate prevention, macOS Terminal.app integration |
+| Status line renderer | `cmd/hookwise/cmd_status_line.go` | Config-ordered segment rendering with 9 built-in segments (`cost`, `project`, `calendar`, `weather`, `news`, `insights`, `insights_friction`, `insights_pace`, `insights_trend`) and conditional ANSI colorization |
+| Fleet badge | `internal/fleet/fleet.go`, `cmd/hookwise/cmd_status_line_fleet.go` | Read-only cross-session "fleet status" snapshot aggregated from live session data |
+| TUI application | `tui/hookwise_tui/` | 7-tab Python Textual app (Dashboard, Guards, Analytics, Feeds, Insights, Recipes, Status) with a read-only data layer |
+| TUI launcher | `cmd/hookwise/cmd_tui.go` | Launches the separately-installed `hookwise-tui` (PATH lookup) through the singleton mtime-marker guard; `newWindow` or `background` launch methods |
 
 ### Feed Platform
 
 | Component | Source Files | Description |
 |-----------|-------------|-------------|
-| Feed registry | `internal/feeds/registry.go` | Map-backed registration and lookup for feed definitions with duplicate rejection |
-| Daemon process | `internal/feeds/daemon_process.go` | Background Go process that polls producers on staggered intervals |
-| Daemon manager | `internal/feeds/daemon_manager.go` | Start/stop/status lifecycle management with PID file (signal 0 liveness checks) |
-| 8 built-in producers | `internal/feeds/producers/` | pulse (30s), project (60s), calendar (5m), news (30m), insights (2m), practice (2m), weather (10m), memories (1h) |
-| Custom feed producer | `internal/feeds/registry.go` (`CreateCommandProducer`) | Wraps user-authored shell commands as feed producers |
+| Feed registry | `internal/feeds/producer.go` (`Registry`) | Map-backed registration and lookup for feed producers |
+| Daemon process | `internal/feeds/daemon.go`, `internal/feeds/socket.go` | Background Go process that polls producers on staggered intervals and serves feed state over a local socket |
+| Daemon lifecycle | `cmd/hookwise/cmd_daemon.go` | `start`/`stop` subcommands (connect-or-start) with PID-file liveness checks (`~/.hookwise/daemon.pid`), plus a hidden foreground `run`; includes the TUI singleton watchdog |
+| 6 built-in producers | `internal/feeds/builtin.go`, `internal/feeds/producer_*.go` | project (60s), insights (2m), calendar (5m), weather (10m), news (30m), memories (1h) |
+| Custom feed producer | `internal/feeds/custom.go` (`NewCustomProducer`) | Wraps user-authored shell commands as feed producers |
 
 ### CLI Layer
 
-| Component | Source Files | Description |
-|-----------|-------------|-------------|
-| `hookwise init` | `cmd/hookwise/main.go` | Initialize hookwise.yaml and register hooks in settings.json |
-| `hookwise doctor` | `cmd/hookwise/main.go` | Validate config, check dependencies, verify hook registration |
-| `hookwise status` | `cmd/hookwise/main.go` | Show current status line output |
-| `hookwise stats` | `cmd/hookwise/main.go` | Query and display analytics data |
-| `hookwise test` | `cmd/hookwise/main.go` | Run guard rules against test scenarios |
-| `hookwise daemon` | `cmd/hookwise/main.go` | Start/stop/status for the feed daemon |
-| `hookwise setup` | `cmd/hookwise/main.go` | Configure external integrations (Google Calendar OAuth) |
-| `hookwise tui` | `cmd/hookwise/main.go` | Launch the TUI application |
-| `hookwise migrate` | `cmd/hookwise/main.go` | Migrate config between versions |
+| Command | Source File | Description |
+|---------|------------|-------------|
+| `hookwise dispatch` | `cmd/hookwise/cmd_dispatch.go` | Dispatch a hook event (called by Claude Code) |
+| `hookwise init` | `cmd/hookwise/cmd_init.go` | Create a default `hookwise.yaml` in the current directory and wire hooks into settings.json |
+| `hookwise doctor` | `cmd/hookwise/cmd_doctor.go` | Run system health checks |
+| `hookwise status-line` | `cmd/hookwise/cmd_status_line.go` | Render the status line |
+| `hookwise stats` | `cmd/hookwise/cmd_stats.go` | Show analytics dashboard for today |
+| `hookwise test` | `cmd/hookwise/cmd_test_runner.go` | Evaluate guard test scenarios |
+| `hookwise audit` | `cmd/hookwise/cmd_audit.go` | Scan Claude Code hook configuration for health issues (`--fix` applies repairs) |
+| `hookwise daemon` | `cmd/hookwise/cmd_daemon.go` | Manage the feed daemon: `start`, `stop`, and a hidden foreground `run` (no `status` subcommand) |
+| `hookwise snapshot` | `cmd/hookwise/cmd_snapshot.go` | Take a point-in-time snapshot of the analytics database |
+| `hookwise diff` | `cmd/hookwise/cmd_diff.go` | Show row-count changes between two analytics snapshots |
+| `hookwise log` | `cmd/hookwise/cmd_log.go` | Show analytics snapshot history |
+| `hookwise notifications` | `cmd/hookwise/cmd_notifications.go` | Display notification history |
+| `hookwise upgrade` | `cmd/hookwise/cmd_upgrade.go` | Migrate data from a TypeScript hookwise installation |
+| `hookwise tui` | `cmd/hookwise/cmd_tui.go` | Launch the interactive TUI |
 
 ### Testing Utilities
 
 | Component | Source Files | Description |
 |-----------|-------------|-------------|
 | HookRunner | `pkg/hookwise/testing/hook_runner.go` | Programmatic hook dispatch for integration tests |
-| HookResult | `pkg/hookwise/testing/hook_result.go` | Structured assertion helpers for dispatch results |
+| HookResult | `pkg/hookwise/testing/hook_runner.go` | Structured assertion helpers for dispatch results |
 | GuardTester | `pkg/hookwise/testing/guard_tester.go` | Fluent API for testing guard rule evaluation |
 
 ---
@@ -100,9 +96,9 @@ This document defines what hookwise controls and what it does not. It exists for
 | Boundary | Why it is out of scope |
 |----------|----------------------|
 | Claude Code itself | Hookwise consumes hook events emitted by Claude Code but cannot modify Claude Code's behavior, model selection, or reasoning. Hookwise influences Claude Code only through the `additionalContext` field in hook output. |
-| `settings.json` schema | Hookwise writes `hooks` and `statusLine.instructions` entries to `.claude/settings.json`, but Anthropic defines the schema. Hookwise must track schema changes reactively. |
+| `settings.json` schema | Hookwise writes `hooks` and `statusLine` entries to `.claude/settings.json`, but Anthropic defines the schema. Hookwise must track schema changes reactively. |
 | Hook event types | The 13 event types (`UserPromptSubmit`, `PreToolUse`, `PostToolUse`, etc.) are defined by Anthropic. Hookwise cannot create new event types or modify event payloads before they arrive. |
-| Context window management | Hookwise can read context window usage (via `_stdin` cache) and display it, but cannot control compaction, context size, or model selection. |
+| Context window management | Hookwise can read what hook payloads report and display it, but cannot control compaction, context size, or model selection. |
 | Tool call arguments | Hookwise can block, confirm, or warn on tool calls, but never modifies tool call arguments. The `PreToolUse` hook output supports `permissionDecision` (allow/deny/ask) but not argument rewriting. |
 | Claude Code's prompt or system message | Hookwise injects `additionalContext` but does not control the base system prompt, model temperature, or other inference parameters. |
 
@@ -114,19 +110,17 @@ This document defines what hookwise controls and what it does not. It exists for
 | Hacker News API | The news producer reads top stories. Hookwise does not post, vote, or interact with HN. |
 | Open-Meteo Weather API | The weather producer reads forecasts. Hookwise does not submit data. |
 | Network connectivity | Feed producers degrade gracefully (return `null` on failure, TTL expiry hides stale data) but hookwise cannot diagnose or fix network issues. |
-| RSS feeds | The news producer can consume RSS URLs but hookwise does not host or manage feed sources. |
 
 ### User Environment
 
 | Boundary | Why it is out of scope |
 |----------|----------------------|
 | Git operations | The project producer reads git state (`git rev-parse`, `git log`) but hookwise never runs `git commit`, `git push`, `git checkout`, or any write operation against the repository. |
-| User's source code | Hookwise observes tool calls (file edits, bash commands) via `PostToolUse` payloads but never reads, modifies, or creates files in the user's project. The only files hookwise writes are in `~/.hookwise/` and `.claude/settings.json`. |
-| Other coding agents | The `AgentObserver` tracks sub-agent lifecycle spans for observability but does not start, stop, configure, or communicate with external agents (Gemini, Codex, Cursor agents). |
+| User's source code | Hookwise observes tool calls (file edits, bash commands) via `PostToolUse` payloads but never reads, modifies, or creates the user's own project files. The only files hookwise writes are in `~/.hookwise/`, `.claude/settings.json`, and the `hookwise.yaml` created by `hookwise init`. |
+| Other coding agents | Hookwise receives `SubagentStart`/`SubagentStop` hook events for observability but does not start, stop, configure, or communicate with external agents (Gemini, Codex, Cursor agents). |
 | IDE/editor state | Hookwise has no VS Code, Cursor, or JetBrains extension. It operates entirely through Claude Code's hook system and the terminal. |
 | Terminal emulator | The TUI renders via Textual/Python in whatever terminal is available. Hookwise does not control terminal settings, font, or color scheme. |
-| Python runtime | The TUI requires Python 3.10+ with Textual installed. Hookwise bundles a venv but falls back to system `python3`. Hookwise does not install or manage system Python. The Go binary writes JSON cache that the TUI reads. |
-| Practice Tracker DB | The practice producer reads from `~/.practice-tracker/practice-tracker.db` but hookwise does not write to or manage this database. |
+| Python runtime | The TUI is a separate Python/Textual package (`hookwise-tui`, installed from the repo with `uv tool install ./tui`) that the Go binary looks up on PATH. Hookwise does not install or manage system Python. The Go binary writes JSON cache that the TUI reads. |
 
 ---
 
@@ -147,21 +141,20 @@ This document defines what hookwise controls and what it does not. It exists for
   |     v                                                                     |
   | +----------------------------+                                            |
   | |  hookwise dispatcher       |  internal/core/dispatcher.go               |
-  | |  (entry point: dispatch()) |                                            |
+  | |  (entry point: Dispatch()) |                                            |
   | +---+------+------+---------+                                             |
   |     |      |      |                                                       |
   |     v      v      v                                                       |
   |  Phase 1  Phase 2  Phase 3                                                |
   |  GUARDS   CONTEXT  SIDE EFFECTS                                           |
   |     |      |      |                                                       |
-  |     |      |      +---> Analytics DB  (~/.hookwise/analytics.db)                 |
-  |     |      |      +---> Coaching State (JSON in ~/.hookwise/)             |
-  |     |      |      +---> Transcript Backup (JSON files)                    |
-  |     |      |      +---> Cost Accumulation                                 |
-  |     |      |      +---> TUI Launch (on SessionStart)                      |
-  |     |      |      +---> Sound Effects                                     |
+  |     |      |      +---> Analytics DB  (~/.hookwise/analytics.db)          |
+  |     |      |      +---> Cost Accumulation (CostState + pricing)           |
+  |     |      |      +---> Notifications (analytics DB)                      |
+  |     |      |      +---> User-configured script handlers                   |
+  |     |      |            (non-blocking goroutines, ARCH-7)                 |
   |     |      |                                                              |
-  |     |      +---> additionalContext (greeting, metacognition, coaching)     |
+  |     |      +---> additionalContext (context-phase handlers)               |
   |     |                                                                     |
   |     +---> block / confirm / warn  (PreToolUse only)                       |
   |           Guards: declarative YAML rules + handler-based guards           |
@@ -170,43 +163,42 @@ This document defines what hookwise controls and what it does not. It exists for
   | +----------------------------+     +----------------------------+         |
   | |  Feed Daemon               |     |  External Data Sources     |         |
   | |  (background process)      |     |  (OUT OF SCOPE)            |         |
-  | |  internal/feeds/           |     |                            |         |
-  | |  daemon_process.go         |     |  Git repo state            |         |
-  | |                            |     |  Google Calendar API       |         |
-  | |  8 producers:              |<----|  Hacker News API           |         |
-  | |  pulse    (30s)            |     |  Open-Meteo Weather API    |         |
-  | |  project  (60s)            |     |  Claude Code usage-data    |         |
-  | |  calendar (5m)             |     |  Practice Tracker DB       |         |
-  | |  news     (30m)            |     |  Analytics DB              |         |
-  | |  insights (2m)             |     +----------------------------+         |
-  | |  practice (2m)             |                                            |
-  | |  weather  (10m)            |                                            |
+  | |  internal/feeds/daemon.go  |     |                            |         |
+  | |                            |     |  Git repo state            |         |
+  | |  6 producers:              |     |  Google Calendar API       |         |
+  | |  project  (60s)            |<----|  Hacker News API           |         |
+  | |  insights (2m)             |     |  Open-Meteo Weather API    |         |
+  | |  calendar (5m)             |     |  Claude Code usage-data    |         |
+  | |  weather  (10m)            |     |  Analytics DB              |         |
+  | |  news     (30m)            |     +----------------------------+         |
   | |  memories (1h)             |                                            |
   | +----------+-----------------+                                            |
   |            |                                                              |
   |            v                                                              |
   | +----------------------------+                                            |
-  | |  Cache Bus                 |  ~/.hookwise/status-cache.json             |
-  | |  Atomic JSON, per-key TTL  |                                            |
+  | |  Cache Bridge              |  internal/bridge/bridge.go                 |
+  | |  Atomic JSON, TTL-aware    |  ~/.hookwise/status-line-cache.json        |
   | +----------+-----------------+                                            |
   |            |                                                              |
   |            v                                                              |
   | +----------------------------+      +----------------------------+        |
   | |  Status Line Renderer      |      |  TUI (Python Textual)      |        |
-  | |  20 built-in segments      |      |  8 tabs, reads cache +     |        |
-  | |  Two-tier layout           |      |  analytics DB              |        |
+  | |  9 built-in segments       |      |  7 tabs, reads cache +     |        |
+  | |  config-ordered            |      |  analytics DB              |        |
   | |  ANSI colors               |      |  Read-only data layer      |        |
   | +----------+-----------------+      +----------------------------+        |
   |            |                                                              |
   |            v                                                              |
-  |   Claude Code statusLine.instructions  (.claude/settings.json)            |
+  |   Claude Code statusLine  (.claude/settings.json)                         |
   |   (hookwise writes content; Claude Code owns the display)                 |
   |                                                                           |
   | +----------------------------+                                            |
   | |  CLI                       |                                            |
-  | |  init, doctor, status,     |                                            |
-  | |  stats, test, daemon,      |----> All subsystems above                  |
-  | |  setup, tui, migrate       |                                            |
+  | |  dispatch, init, doctor,   |                                            |
+  | |  status-line, stats, test, |----> All subsystems above                  |
+  | |  audit, daemon, snapshot,  |                                            |
+  | |  diff, log, notifications, |                                            |
+  | |  upgrade, tui              |                                            |
   | +----------------------------+                                            |
   |                                                                           |
   | +----------------------------+                                            |
@@ -222,29 +214,28 @@ This document defines what hookwise controls and what it does not. It exists for
 
 | Component | Hookwise Owns | Hookwise Reads | Hookwise Has No Access |
 |-----------|--------------|----------------|----------------------|
-| `hookwise.yaml` | Creates, validates, migrates, writes back | -- | -- |
-| `.claude/settings.json` | Writes `hooks` entries and `statusLine.instructions` | Reads to detect existing config | Schema definition (Anthropic owns) |
-| `~/.hookwise/analytics.db` | Creates, writes sessions/events/authorship (SQLite WAL) | Queries for stats/TUI display | -- |
-| `~/.hookwise/status-cache.json` | Creates, writes (cache bus atomic merges) | Reads for status line rendering | -- |
+| `hookwise.yaml` | Creates (`hookwise init`), loads, validates | -- | -- |
+| `.claude/settings.json` | Writes `hooks` and `statusLine` entries | Reads to detect existing config | Schema definition (Anthropic owns) |
+| `~/.hookwise/analytics.db` | Creates, writes sessions/events/cost state (SQLite WAL) | Queries for stats/TUI display | -- |
+| `~/.hookwise/status-line-cache.json` | Creates, writes (atomic merged writes via the cache bridge) | Reads for status line rendering | -- |
 | `~/.hookwise/daemon.pid` | Creates, writes, removes (lifecycle management) | Reads for liveness checks | -- |
 | `~/.hookwise/tui.pid` | Creates, writes, removes (lifecycle management) | Reads for duplicate prevention | -- |
-| `~/.hookwise/daemon.log` | Creates, writes, rotates | Reads for CLI `daemon status` | -- |
+| `~/.hookwise/daemon.log` | Creates, writes | Reads for diagnostics | -- |
 | Hook event payloads (stdin) | -- | Reads and parses JSON from stdin | Cannot modify event shape or timing |
 | Git repository | -- | Reads branch, HEAD, last commit timestamp | Never runs git write operations |
 | Google Calendar | -- | Reads events via API (OAuth token stored locally) | Cannot create/modify/delete events |
-| Hacker News / RSS | -- | Reads top stories / feed items | Cannot post or interact |
+| Hacker News | -- | Reads top stories | Cannot post or interact |
 | Weather API | -- | Reads temperature, wind, conditions | Cannot submit data |
-| Practice Tracker DB | -- | Reads practice session data | Cannot write practice data |
 | Claude Code usage-data | -- | Reads `~/.claude/usage-data` files for insights | Cannot modify usage records |
-| User's source code | -- | -- | Never reads or writes project files |
+| User's source code | -- | -- | Never reads or writes the user's project files |
 | Claude Code model/context | -- | -- | No access to model selection, context window, or inference parameters |
-| Other AI agents | -- | Observes sub-agent lifecycle via hook events | Cannot start, stop, or configure external agents |
+| Other AI agents | -- | Observes `SubagentStart`/`SubagentStop` hook events | Cannot start, stop, or configure external agents |
 
 ---
 
 ## Boundary Principles
 
-1. **Read, don't write.** Hookwise reads git state, file contents in tool call payloads, and external API data but never modifies user code, git history, or external service state. The only files hookwise writes are in `~/.hookwise/` and `.claude/settings.json`.
+1. **Read, don't write.** Hookwise reads git state, file contents in tool call payloads, and external API data but never modifies user code, git history, or external service state. The only files hookwise writes are in `~/.hookwise/`, `.claude/settings.json`, and the `hookwise.yaml` created by `hookwise init`.
 
 2. **Configure, don't control.** Hookwise configures Claude Code's status line content and hook dispatch, but does not control Claude Code's behavior. The `additionalContext` field is a suggestion, not an instruction override. Claude Code decides how to use it.
 
@@ -252,11 +243,11 @@ This document defines what hookwise controls and what it does not. It exists for
 
 4. **Observe, don't intercept.** Guards can block, confirm, or warn, but hookwise never silently modifies tool call arguments. The dispatcher outputs `permissionDecision` (allow/deny/ask) and `permissionDecisionReason` -- it never rewrites `tool_input`.
 
-5. **Inform, don't silently swallow.** (Lesson from v1.3 retro, Bug #164.) Fail-open must not mean fail-silent. When a component degrades, hookwise should surface a diagnostic signal (cache bus key, status line segment, log entry) so the user knows something is degraded, even though the session continues unimpeded.
+5. **Inform, don't silently swallow.** (Lesson from v1.3 retro, Bug #164.) Fail-open must not mean fail-silent. When a component degrades, hookwise should surface a diagnostic signal (cache key, status line segment, log entry) so the user knows something is degraded, even though the session continues unimpeded.
 
-6. **Own the data layer, not the display.** Hookwise owns the analytics database, cache bus, and coaching state. It generates status line content as a string. But Claude Code owns how and where that string is displayed. Hookwise cannot control font, layout, or rendering of the status line within Claude Code's UI.
+6. **Own the data layer, not the display.** Hookwise owns the analytics database and the feed cache. It generates status line content as a string. But Claude Code owns how and where that string is displayed. Hookwise cannot control font, layout, or rendering of the status line within Claude Code's UI.
 
-7. **Composition over extension.** New capabilities should be composable from existing subsystems (guards, feeds, segments, recipes) rather than requiring new architectural layers. A new feed producer is a function. A new guard is a YAML rule. A new recipe is a directory with `hooks.yaml`.
+7. **Composition over extension.** New capabilities should be composable from existing subsystems (guards, feeds, segments, recipes) rather than requiring new architectural layers. A new feed producer is a function. A new guard is a YAML rule. A new recipe is a directory of YAML config.
 
 ---
 
@@ -268,12 +259,12 @@ The following are examples of features that would violate hookwise's boundaries.
 
 - **Auto-fixing lint errors detected by guards.** A guard can warn "this bash command has no error handling," but hookwise must not rewrite the command to add `set -e`. That crosses from observation into code modification.
 - **Auto-committing on session end.** The project producer reads git state, but hookwise must never run `git commit` or `git push` on behalf of the user.
-- **Creating GitHub issues from coaching alerts.** Hookwise can surface "you've been in tooling mode for 90 minutes" but should not create external artifacts (issues, PRs, Slack messages) without an explicit integration layer.
+- **Creating GitHub issues from coaching alerts.** A coaching-style nudge could surface "you've been in tooling mode for 90 minutes," but hookwise should not create external artifacts (issues, PRs, Slack messages) without an explicit integration layer.
 
 ### Features that would violate "Configure, don't control"
 
-- **Prompt injection via additionalContext.** Using `additionalContext` to override Claude Code's system prompt, force a specific coding style, or hijack the model's behavior. The context field is for nudges (metacognition prompts, greeting quotes), not directives.
-- **Automatic context window compaction.** Hookwise can display context usage via `context_bar`, but triggering compaction or managing context size is Claude Code's responsibility.
+- **Prompt injection via additionalContext.** Using `additionalContext` to override Claude Code's system prompt, force a specific coding style, or hijack the model's behavior. The context field is for nudges, not directives.
+- **Automatic context window compaction.** Hookwise can display context usage, but triggering compaction or managing context size is Claude Code's responsibility.
 
 ### Features that would violate "Observe, don't intercept"
 
@@ -287,7 +278,7 @@ The following are examples of features that would violate hookwise's boundaries.
 
 ### Features that would cross the TUI boundary
 
-- **TUI writing to hookwise.yaml.** (Identified in retro, Lesson #6.) The TUI data layer (`tui/hookwise_tui/data.py`) is explicitly read-only. Adding a write path requires careful design because the TUI is a Python process reading a Go-managed YAML file with no shared type system. This is a planned v1.4 feature but is currently out of scope.
+- **TUI writing to hookwise.yaml.** (Identified in retro, Lesson #6.) The TUI data layer (`tui/hookwise_tui/data.py`) is explicitly read-only. Adding a write path requires careful design because the TUI is a Python process reading a Go-managed YAML file with no shared type system. This is currently out of scope.
 - **TUI controlling the daemon directly.** The TUI can display daemon health but should not start/stop the daemon (that is the CLI's job). Adding daemon control to the TUI would create two control planes for the same process.
 
 ### General scope creep patterns

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,18 +75,17 @@ Test helpers available in `pkg/hookwise/testing`:
 
 ## Interactive TUI
 
-Full-screen terminal UI built with Python Textual, shipped **separately** from the core binary as `hookwise-tui` (the core CLI needs no Python) -- 8 tabs:
+Full-screen terminal UI built with Python Textual, shipped **separately** from the core binary as `hookwise-tui` (the core CLI needs no Python) -- 7 tabs:
 
 | Key | Tab | Description |
 |-----|-----|-------------|
 | `1` | Dashboard | Feature overview with enabled/disabled status |
 | `2` | Guards | Guard rules table with action descriptions |
-| `3` | Coaching | Coaching features with user-friendly explanations |
-| `4` | Analytics | Sparkline trends, tool breakdown, cost tracking |
-| `5` | Feeds | Live feed dashboard with auto-refresh and health indicators |
-| `6` | Insights | Claude Code usage metrics, trends, and daily AI summary |
-| `7` | Recipes | Recipe browser grouped by category |
-| `8` | Status | Status line preview and segment configurator |
+| `3` | Analytics | Sparkline trends, tool breakdown, cost tracking |
+| `4` | Feeds | Live feed dashboard with auto-refresh and health indicators |
+| `5` | Insights | Claude Code usage metrics, trends, and daily AI summary |
+| `6` | Recipes | Recipe browser grouped by category |
+| `7` | Status | Status line preview and segment configurator |
 
 Press `q` to exit the TUI. Install from the `tui/` directory (e.g. `uv tool install ./tui`), then launch it with `hookwise tui` (or run `hookwise-tui` directly).
 

--- a/docs/reference/tui-guide.md
+++ b/docs/reference/tui-guide.md
@@ -32,15 +32,14 @@ This launches the dashboard via the same singleton guard as session auto-launch,
 |-----|--------|
 | `1` | Switch to Dashboard tab |
 | `2` | Switch to Guards tab |
-| `3` | Switch to Coaching tab |
-| `4` | Switch to Analytics tab |
-| `5` | Switch to Feeds tab |
-| `6` | Switch to Insights tab |
-| `7` | Switch to Recipes tab |
-| `8` | Switch to Status tab |
+| `3` | Switch to Analytics tab |
+| `4` | Switch to Feeds tab |
+| `5` | Switch to Insights tab |
+| `6` | Switch to Recipes tab |
+| `7` | Switch to Status tab |
 | `q` | Quit the TUI |
 
-Tabs are numbered 1-8. Press the corresponding number key to switch instantly.
+Tabs are numbered 1-7. Press the corresponding number key to switch instantly.
 
 ## Tabs
 
@@ -48,8 +47,8 @@ Tabs are numbered 1-8. Press the corresponding number key to switch instantly.
 
 Feature overview showing all hookwise capabilities:
 
-- **Feature cards** -- Each feature (Analytics, Guards, Coaching, Feeds, Status Line, Cost Tracking, Greeting, Transcript Backup) displayed with description and enabled/disabled badge
-- **Configuration summary** -- Guard count, active coaching modules, active feeds
+- **Feature cards** -- Each feature (Analytics, Guards, Feeds, Status Line, Cost Tracking, Greeting) displayed with description and enabled/disabled badge
+- **Configuration summary** -- Guard count, active feeds
 - **Quick status** -- See at a glance what's on and what's off
 
 ### 2. Guards
@@ -60,16 +59,7 @@ Guard rules table with action descriptions:
 - **Rule table** -- All configured guard rules with match patterns, actions, reasons, and conditions
 - **First-match-wins** -- Rules are evaluated top-to-bottom
 
-### 3. Coaching
-
-Three coaching features with user-friendly explanations:
-
-- **Metacognition** -- "Periodic nudges to reflect on your approach -- prevents autopilot coding"
-- **Builder's Trap** -- "Alerts when you've been in tooling/config too long without shipping value"
-- **Communication Coach** -- "Grammar and clarity checks on your prompts (pattern-based, no LLM cost)"
-- Each card shows current configuration values (interval, thresholds, tone)
-
-### 4. Analytics
+### 3. Analytics
 
 Coding patterns, tool usage, and AI authorship:
 
@@ -80,7 +70,7 @@ Coding patterns, tool usage, and AI authorship:
 
 See the [Analytics Guide](/guide/analytics-guide) for details on what is tracked and how authorship scoring works.
 
-### 5. Feeds
+### 4. Feeds
 
 Live feed dashboard with auto-refresh (every 3 seconds):
 
@@ -92,7 +82,7 @@ Live feed dashboard with auto-refresh (every 3 seconds):
 
 See the [Feeds Guide](/guide/feeds-guide) for architecture details and configuration.
 
-### 6. Insights
+### 5. Insights
 
 Claude Code usage analytics (dedicated tab, new in v1.2):
 
@@ -103,7 +93,7 @@ Claude Code usage analytics (dedicated tab, new in v1.2):
 - **Daily AI summary** -- LLM-generated narrative about your coding patterns, top insight, and suggested focus area (uses Haiku, ~$0.01/day)
 - **Refresh button** -- Manually regenerate the daily summary
 
-### 7. Recipes
+### 6. Recipes
 
 Recipe browser grouped by category:
 
@@ -111,7 +101,7 @@ Recipe browser grouped by category:
 - **Recipe tree** -- All available recipes organized by category (safety, coaching, productivity, etc.)
 - **Recipe descriptions** -- What each recipe configures
 
-### 8. Status
+### 7. Status
 
 Status line preview and segment configurator:
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -37,12 +37,12 @@ They communicate via a **shared filesystem cache** (JSON file), not HTTP or IPC.
 | **Textual** | >=1.0.0 | Full-featured terminal UI framework (tabs, widgets, CSS) | Rich widget library, CSS-based styling, async-native |
 | **Rich** | >=13.0 | Text formatting, tables, syntax highlighting within TUI | Textual's rendering foundation |
 | **PyYAML** | >=6.0 | Reads `hookwise.yaml` from Python side | Standard YAML parser for Python |
-| **Anthropic SDK** | >=0.40.0 | Claude API calls for coaching tab suggestions | Official SDK for Claude integration |
+| **Anthropic SDK** | >=0.40.0 | Claude API calls for the Insights tab's daily AI summary | Official SDK for Claude integration |
 
 **Key patterns:**
 
 - Uses `hatchling` as build backend
-- TUI has 8 tabs: Dashboard, Guards, Feeds, Analytics, Coaching, Recipes, Insights, Status
+- TUI has 7 tabs: Dashboard, Guards, Analytics, Feeds, Insights, Recipes, Status
 - Custom widgets: `FeatureCard`, `Sparkline`, `FeedHealth`, `WeatherBackground`
 
 ## Layer 3: Build and Bundling


### PR DESCRIPTION
## Summary
- Rebuilds `docs/boundaries.md` from verified source (hw-lgd): drops nonexistent commands (setup/migrate/daemon-status), fixes the producer list to the 6 built-ins in `internal/feeds/builtin.go`, corrects source paths, and documents `hookwise tui` against `cmd/hookwise/cmd_tui.go`.
- Follow-up correction the rebuild exposed: cli.md, tui-guide.md, tech-stack.md, and the README still described an 8-tab TUI with a Coaching tab. Ground truth (`tui/hookwise_tui/app.py` bindings) is 7 tabs, keys 1-7 — coaching was deleted in #112/#113. Also drops the Coaching row from the README comparison table and fixes the Anthropic SDK purpose (Insights daily summary).

## Test plan
- Docs-only; every inventory row verified against current source per the hw-006 hard rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ