### PR TITLE
fix(perf): scale config-load latency budget under -race

### DIFF
--- a/internal/perf/perf_test.go
+++ b/internal/perf/perf_test.go
@@ -292,8 +292,16 @@ settings:
 	t.Logf("Config loading avg latency: %.1f us over %d iterations", avgUs, iterations)
 	// Note: YAML parsing can be slower than 500us depending on hardware.
 	// We use a 2ms budget here as a practical limit for CI.
-	assert.Less(t, avgUs, 2000.0,
-		"Config loading should complete in <2ms (got %.1f us)", avgUs)
+	budgetUs := 2000.0
+	if raceEnabled {
+		// Race instrumentation slows file I/O + YAML parsing enough that
+		// full-package runs measured 2.6-5.3ms (solo: ~1.9ms, at 93% of
+		// budget). Scale the budget so the assertion still catches gross
+		// regressions without flaking on instrumentation overhead (hw-ups).
+		budgetUs *= 5
+	}
+	assert.Less(t, avgUs, budgetUs,
+		"Config loading should complete in <%.0fms (got %.1f us)", budgetUs/1000, avgUs)
 }
 
 // =========================================================================

--- a/internal/perf/race_off_test.go
+++ b/internal/perf/race_off_test.go
@@ -1,0 +1,6 @@
+//go:build integration && !race
+
+package perf
+
+// raceEnabled reports whether the race detector is compiled in.
+const raceEnabled = false

--- a/internal/perf/race_on_test.go
+++ b/internal/perf/race_on_test.go
@@ -1,0 +1,8 @@
+//go:build integration && race
+
+package perf
+
+// raceEnabled reports whether the race detector is compiled in.
+// Race instrumentation slows hot paths 2-10x, so latency budgets
+// must be scaled to avoid false failures.
+const raceEnabled = true


### PR DESCRIPTION
## Summary
- `TestConfigLoading_Latency` asserts a 2ms average, but race instrumentation slows file I/O + YAML parsing enough that full-package `-race` runs measured 2.6–5.3ms — and even a solo `-race` run sits at ~1.9ms (93% of budget). Reproduced on untouched main: a latent flake in the guarded gate, not a regression.
- Fix: standard `//go:build race` file-pair idiom exposing a `raceEnabled` const; budget ×5 (10ms) only when instrumentation is on. The 2ms budget is untouched for normal builds and still catches gross regressions under race.
- Alternatives rejected with evidence: serializing the test doesn't help (solo -race already at 93%); dropping -race loses race coverage of the LoadConfig path.

## Test plan
- Rig gate: 4/4 consecutive full-package `-race` runs green; non-race passes at 155µs against the original 2ms budget; `go vet -tags integration` clean.
- Local re-verify on this branch: `GOMEMLIMIT=4GiB go test -race -p 2 -tags integration -run TestConfigLoading_Latency -count=3` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated configuration-loading performance checks to use an adjusted latency budget when race detection is enabled.
  * Added integration test coverage for performance measurements in both race-enabled and standard builds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->