### PR TITLE
feat(scripts): add branch containment reporter (hw-k268)

### DIFF
--- a/scripts/branch-containment-report.sh
+++ b/scripts/branch-containment-report.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# branch-containment-report.sh — Measurement instrument ONLY.
+#
+# Reports whether each local branch matching polecat/* or gc-gastown* is
+# content-contained in github/main. This script contains NO deletion code
+# by design: it never deletes, moves, or rewrites any ref. The prune
+# decision is a separate human act, made from this report's evidence.
+#
+# Evidence methods, tried in order per branch:
+#   1. ancestry   — git merge-base --is-ancestor <branch> <base>
+#   2. patch-id   — git cherry <base> <branch> (all commits patch-equivalent)
+#   3. range-diff — git range-diff <base>...<branch> pairing summary
+#
+# Output: exactly one line per matching branch, one of:
+#   CONTAINED <branch> via=<ancestry|patch-id|range-diff>
+#   AHEAD <branch> n=<count>       (count = commits only on the branch)
+#   NOT-PROVEN <branch>            (ambiguous or evidence tooling failed)
+#
+# Usage:
+#   scripts/branch-containment-report.sh [--base <ref>] [--fetch]
+#     --base <ref>   containment target (default: github/main)
+#     --fetch        run 'git fetch github' first — the ONLY network
+#                    operation this script may perform (off by default)
+
+set -uo pipefail
+
+BASE_REF="github/main"
+DO_FETCH=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --base)
+            [ $# -ge 2 ] || { echo "error: --base requires a ref" >&2; exit 2; }
+            BASE_REF="$2"; shift 2 ;;
+        --fetch)
+            DO_FETCH=1; shift ;;
+        *)
+            echo "error: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ "$DO_FETCH" -eq 1 ]; then
+    git fetch github || { echo "error: git fetch github failed" >&2; exit 2; }
+fi
+
+if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+    echo "error: base ref not found: $BASE_REF (try --fetch)" >&2
+    exit 2
+fi
+
+# Classify one branch and print its single verdict line.
+classify() {
+    local branch="$1"
+
+    # Method 1: ancestry — branch tip reachable from base.
+    if git merge-base --is-ancestor "$branch" "$BASE_REF" 2>/dev/null; then
+        echo "CONTAINED $branch via=ancestry"
+        return
+    fi
+
+    # Method 2: patch-id — every branch commit has a patch-equivalent
+    # commit in base ('git cherry' marks unmatched commits with '+').
+    local cherry_out cherry_ok=1
+    cherry_out=$(git cherry "$BASE_REF" "$branch" 2>/dev/null) || cherry_ok=0
+    if [ "$cherry_ok" -eq 1 ] && ! printf '%s\n' "$cherry_out" | grep -q '^+'; then
+        echo "CONTAINED $branch via=patch-id"
+        return
+    fi
+
+    # Method 3: range-diff — fuzzy commit pairing since the merge base.
+    # -s suppresses inner diffs so only pairing header lines remain.
+    local rd_out
+    if ! rd_out=$(git range-diff --no-color -s "${BASE_REF}...${branch}" 2>/dev/null); then
+        echo "NOT-PROVEN $branch"
+        return
+    fi
+
+    # Header lines look like:  "1:  abc1234 = 1:  abc1234 subject"
+    # (left/right side may be "-:  -------" for unpaired commits).
+    # The pairing marker (= ! < >) is always the third field.
+    local markers n_new n_mod
+    markers=$(printf '%s\n' "$rd_out" | awk '$3 ~ /^[=!<>]$/ { print $3 }')
+    n_new=$(printf '%s\n' "$markers" | grep -c '>')
+    n_mod=$(printf '%s\n' "$markers" | grep -c '!')
+
+    if [ "$n_mod" -gt 0 ]; then
+        # Some branch commit pairs with a base commit but the content
+        # differs — containment can be neither proven nor ruled out.
+        echo "NOT-PROVEN $branch"
+    elif [ "$n_new" -gt 0 ]; then
+        echo "AHEAD $branch n=$n_new"
+    else
+        # Every branch-side commit paired equal ('<' lines are commits
+        # only in base, which is expected as base moves ahead).
+        echo "CONTAINED $branch via=range-diff"
+    fi
+}
+
+found_any=0
+while IFS= read -r branch; do
+    [ -n "$branch" ] || continue
+    found_any=1
+    classify "$branch"
+done < <(git for-each-ref --format='%(refname:short)' \
+    'refs/heads/polecat/*' 'refs/heads/gc-gastown*')
+
+if [ "$found_any" -eq 0 ]; then
+    echo "note: no local branches match polecat/* or gc-gastown*" >&2
+fi
+
+exit 0

--- a/scripts/test-branch-containment-report.sh
+++ b/scripts/test-branch-containment-report.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# test-branch-containment-report.sh — Tests for branch-containment-report.sh
+#
+# Builds a throwaway toy git repo in a temp dir (never touches the real
+# repo) with a synthetic github/main ref and branches engineered to hit
+# every verdict path: CONTAINED (ancestry + patch-id), AHEAD, NOT-PROVEN.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/branch-containment-report.sh"
+
+passed=0
+failed=0
+total=0
+
+assert_line() {
+    local name="$1"
+    local expected="$2"
+
+    total=$((total + 1))
+    if printf '%s\n' "$REPORT" | grep -qxF "$expected"; then
+        echo "  ✓ $name"
+        passed=$((passed + 1))
+    else
+        echo "  ✗ $name — expected line '$expected' not found"
+        failed=$((failed + 1))
+    fi
+}
+
+commit_file() {
+    local file="$1" content="$2" msg="$3"
+    printf '%s\n' "$content" > "$file"
+    git add "$file"
+    git commit -q -m "$msg"
+}
+
+# --- Fixture: toy repo -------------------------------------------------
+
+TMPDIR_FIXTURE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_FIXTURE"' EXIT
+
+cd "$TMPDIR_FIXTURE" || exit 1
+git init -q repo
+cd repo || exit 1
+git config user.email "test@example.com"
+git config user.name "Toy Fixture"
+git config commit.gpgsign false
+git checkout -q -b main
+
+commit_file base.txt "base v1" "chore: base commit 1"
+C1=$(git rev-parse HEAD)
+commit_file base.txt "base v2" "chore: base commit 2"
+C2=$(git rev-parse HEAD)
+
+# Branch A — CONTAINED via=ancestry: tip is an ancestor of main.
+git branch polecat/contained-ancestry "$C1"
+
+# Branch B — CONTAINED via=patch-id: commit cherry-picked into main,
+# so the SHA differs but the patch-id matches (new file → identical diff).
+git checkout -q -b polecat/contained-patchid "$C1"
+commit_file picked.txt "picked content" "feat: add picked file"
+PICKED=$(git rev-parse HEAD)
+git checkout -q main
+git cherry-pick "$PICKED" >/dev/null
+
+# Branch C — AHEAD n=2: two commits that never reached main, touching
+# files unrelated to anything on main so range-diff cannot pair them.
+git checkout -q -b polecat/ahead "$C2"
+commit_file ahead1.txt "unmerged work one" "feat: unmerged work 1"
+commit_file ahead2.txt "unmerged work two" "feat: unmerged work 2"
+
+# Branch D — NOT-PROVEN: branch commit and a main commit share a subject
+# and near-identical content (one line differs), so range-diff pairs
+# them as modified ('!') — containment can't be proven either way.
+git checkout -q -b gc-gastown-notproven "$C2"
+{
+    printf 'line %d\n' 1 2 3 4 5 6 7 8 9
+    printf 'tail: branch flavour\n'
+} > feature.txt
+git add feature.txt
+git commit -q -m "feat: add feature file"
+git checkout -q main
+{
+    printf 'line %d\n' 1 2 3 4 5 6 7 8 9
+    printf 'tail: main flavour\n'
+} > feature.txt
+git add feature.txt
+git commit -q -m "feat: add feature file"
+
+# A non-matching branch that must NOT appear in the report.
+git branch unrelated-branch "$C2"
+
+# Synthesize the github/main remote-tracking ref locally (no network).
+git update-ref refs/remotes/github/main main
+git checkout -q main
+
+# --- Run the reporter --------------------------------------------------
+
+echo "=== branch-containment-report.sh tests ==="
+echo ""
+
+REPORT=$(bash "$TARGET" 2>/dev/null)
+STATUS=$?
+echo "$REPORT" | sed 's/^/    | /'
+echo ""
+
+echo "Group 1: verdict paths"
+assert_line "ancestor branch → CONTAINED via=ancestry" \
+    "CONTAINED polecat/contained-ancestry via=ancestry"
+assert_line "cherry-picked branch → CONTAINED via=patch-id" \
+    "CONTAINED polecat/contained-patchid via=patch-id"
+assert_line "unmerged branch → AHEAD n=2" \
+    "AHEAD polecat/ahead n=2"
+assert_line "modified-twin branch → NOT-PROVEN" \
+    "NOT-PROVEN gc-gastown-notproven"
+
+echo "Group 2: report hygiene"
+total=$((total + 1))
+if [ "$STATUS" -eq 0 ]; then
+    echo "  ✓ exit code 0"
+    passed=$((passed + 1))
+else
+    echo "  ✗ exit code 0 — got $STATUS"
+    failed=$((failed + 1))
+fi
+
+total=$((total + 1))
+line_count=$(printf '%s\n' "$REPORT" | grep -c .)
+if [ "$line_count" -eq 4 ]; then
+    echo "  ✓ exactly one line per matching branch (4 lines)"
+    passed=$((passed + 1))
+else
+    echo "  ✗ expected 4 report lines, got $line_count"
+    failed=$((failed + 1))
+fi
+
+total=$((total + 1))
+if printf '%s\n' "$REPORT" | grep -q "unrelated-branch"; then
+    echo "  ✗ non-matching branch leaked into report"
+    failed=$((failed + 1))
+else
+    echo "  ✓ non-matching branch excluded"
+    passed=$((passed + 1))
+fi
+
+echo "Group 3: safety rails"
+total=$((total + 1))
+# The measurement instrument must contain no ref-deleting git invocations.
+if grep -nE 'branch[[:space:]]+-[dD]|push|update-ref[[:space:]]+-d|worktree[[:space:]]+(remove|prune)' "$TARGET"; then
+    echo "  ✗ deletion/push code found in reporter (lines above)"
+    failed=$((failed + 1))
+else
+    echo "  ✓ reporter contains no deletion or push commands"
+    passed=$((passed + 1))
+fi
+
+total=$((total + 1))
+BAD=$(bash "$TARGET" --base does/not-exist 2>&1)
+if [ $? -eq 2 ] && printf '%s' "$BAD" | grep -q "base ref not found"; then
+    echo "  ✓ missing base ref → exit 2 with clear error"
+    passed=$((passed + 1))
+else
+    echo "  ✗ missing base ref handling wrong: $BAD"
+    failed=$((failed + 1))
+fi
+
+echo ""
+echo "=== $passed/$total passed, $failed failed ==="
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
Dry-run measurement instrument for the 23 stranded polecat branches (GCI-003, bead hw-k268): proves per-branch whether content is contained in github/main via ancestry, patch-id, or range-diff. Contains zero deletion code by design — the prune decision stays human. Includes toy-repo shell tests covering all three verdict paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reporting tool to assess whether local development branches are contained in a selected base branch.
  * Reports branches as contained, ahead, or not proven, including the verification method where applicable.
  * Supports selecting a custom base reference and optionally fetching the latest remote data.
  * Provides clear errors for invalid arguments, unavailable base references, or failed fetches.

* **Tests**
  * Added automated coverage for containment verdicts, output quality, unrelated branches, and safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->