### PR TITLE
fix(tui): gate feed segment rendering on cache freshness (hw-ci08)

### DIFF
--- a/tui/hookwise_tui/tabs/status.py
+++ b/tui/hookwise_tui/tabs/status.py
@@ -14,7 +14,7 @@ from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Static, Switch
 
-from hookwise_tui.data import read_cache, read_config, write_config
+from hookwise_tui.data import is_fresh, read_cache, read_config, write_config
 from hookwise_tui.tabs.insights import _format_peak_hour
 
 
@@ -203,18 +203,29 @@ class StatusTab(Widget):
                 yield SegmentRow(seg, seg in active_set, has_data)
 
     @staticmethod
+    def _fresh_entry(cache: dict[str, Any], key: str) -> dict[str, Any] | None:
+        """Return the cache entry for key, or None if missing or past its TTL.
+
+        Mirrors the Go status line (feedData/IsEnvelopeFresh): stale feed
+        entries are treated as absent, never rendered from old data.
+        """
+        entry = cache.get(key)
+        if isinstance(entry, dict) and is_fresh(entry):
+            return entry
+        return None
+
+    @staticmethod
     def _segment_has_data(seg: str, cache: dict[str, Any]) -> bool:
         """Check if a segment has real data available in the cache."""
         if seg in STDIN_SEGMENTS:
             # These get data from live stdin; check if live output is fresh
             return StatusTab._read_live_output() is not None
         if seg in ("insights_friction", "insights_pace", "insights_trend"):
-            ins = cache.get("insights")
-            return isinstance(ins, dict) and bool(ins.get("total_sessions"))
+            ins = StatusTab._fresh_entry(cache, "insights")
+            return ins is not None and bool(ins.get("total_sessions"))
         if seg == "clock":
             return True  # Always has data
-        entry = cache.get(seg)
-        return isinstance(entry, dict) and len(entry) > 0
+        return StatusTab._fresh_entry(cache, seg) is not None
 
     def on_mount(self) -> None:
         self._refresh_preview()
@@ -379,8 +390,8 @@ class StatusTab(Widget):
 
         # -- session segment: shows session ID or active session indicator --
         if seg == "session":
-            session_entry = cache.get("session")
-            if isinstance(session_entry, dict):
+            session_entry = StatusTab._fresh_entry(cache, "session")
+            if session_entry is not None:
                 sid = session_entry.get("session_id", "")
                 if sid:
                     return f"\U0001f4bb {sid[:8]}"
@@ -388,8 +399,8 @@ class StatusTab(Widget):
 
         # -- mode_badge reads from builder_trap cache entry (not its own key) --
         if seg == "mode_badge":
-            bt = cache.get("builder_trap")
-            if not isinstance(bt, dict):
+            bt = StatusTab._fresh_entry(cache, "builder_trap")
+            if bt is None:
                 return ""
             mode = bt.get("current_mode", "")
             if not mode or mode == "neutral":
@@ -397,8 +408,8 @@ class StatusTab(Widget):
             return f"[{mode}]"
 
         # -- insights segments read from the shared "insights" cache entry --
-        insights = cache.get("insights")
-        if isinstance(insights, dict):
+        insights = StatusTab._fresh_entry(cache, "insights")
+        if insights is not None:
             if seg == "insights_friction":
                 recent_friction = 0
                 rs = insights.get("recent_session")
@@ -449,8 +460,8 @@ class StatusTab(Widget):
                 return f"\U0001f527 Top: {tool_names} | Peak: {_format_peak_hour(peak_hour)}"
 
         # -- other segments with direct cache entries --
-        entry = cache.get(seg)
-        if not isinstance(entry, dict):
+        entry = StatusTab._fresh_entry(cache, seg)
+        if entry is None:
             return ""
 
         if seg == "mantra":

--- a/tui/tests/test_status_live_output.py
+++ b/tui/tests/test_status_live_output.py
@@ -7,11 +7,17 @@ written by the TS status-line command, with proper freshness checks.
 from __future__ import annotations
 
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from hookwise_tui.tabs.status import StatusTab, _LAST_STATUS_OUTPUT_PATH, _LIVE_OUTPUT_MAX_AGE
+
+
+def _now_iso() -> str:
+    """A current updated_at: the renderer treats entries past TTL as absent."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class TestReadLiveOutput:
@@ -125,7 +131,7 @@ class TestWeatherSegmentFromGoProducer:
                 "weatherCode": 0,
                 "emoji": "\u2600\ufe0f",
                 "description": "Clear",
-                "updated_at": "2026-03-07T10:00:00Z",
+                "updated_at": _now_iso(),
                 "ttl_seconds": 300,
             }
         }
@@ -146,7 +152,7 @@ class TestWeatherSegmentFromGoProducer:
                 "weatherCode": 1,
                 "emoji": "\u26c5",
                 "description": "Partly Cloudy",
-                "updated_at": "2026-03-07T10:00:00Z",
+                "updated_at": _now_iso(),
                 "ttl_seconds": 300,
             }
         }
@@ -164,7 +170,7 @@ class TestWeatherSegmentFromGoProducer:
                 "weatherCode": 61,
                 "emoji": "\U0001f327\ufe0f",
                 "description": "Rain",
-                "updated_at": "2026-03-07T10:00:00Z",
+                "updated_at": _now_iso(),
                 "ttl_seconds": 300,
             }
         }
@@ -178,7 +184,7 @@ class TestWeatherSegmentFromGoProducer:
                 "temperatureUnit": "fahrenheit",
                 "windSpeed": 0,
                 "emoji": "\U0001f324\ufe0f",
-                "updated_at": "2026-03-07T10:00:00Z",
+                "updated_at": _now_iso(),
                 "ttl_seconds": 300,
             }
         }

--- a/tui/tests/test_status_segments.py
+++ b/tui/tests/test_status_segments.py
@@ -13,8 +13,27 @@ Python renderer adapts to it here.
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from hookwise_tui.tabs.status import StatusTab
+
+
+def _fresh() -> dict[str, Any]:
+    """Freshness fields FlattenForTUI stamps on every cache entry.
+
+    The renderer treats entries missing these (or past TTL) as absent,
+    mirroring the Go status line's IsEnvelopeFresh gate.
+    """
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return {"updated_at": now, "ttl_seconds": 300}
+
+
+def _stale() -> dict[str, Any]:
+    """Freshness fields for an entry whose TTL has expired."""
+    old = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    return {"updated_at": old, "ttl_seconds": 300}
 
 
 class TestCalendarSegment:
@@ -34,6 +53,7 @@ class TestCalendarSegment:
                     }
                 ],
                 "next_event": {"name": "Standup", "start": "2026-03-07T10:30:00Z"},
+                **_fresh(),
             }
         }
         out = StatusTab._render_segment("calendar", cache)
@@ -54,6 +74,7 @@ class TestCalendarSegment:
             "calendar": {
                 "events": [{"name": "Standup", "start": soon, "is_current": False}],
                 "next_event": {"name": "Standup", "start": soon},
+                **_fresh(),
             }
         }
         out = StatusTab._render_segment("calendar", cache)
@@ -75,6 +96,7 @@ class TestProjectSegment:
                 "branch": "main",
                 "last_commit": "abc1234",
                 "dirty": False,
+                **_fresh(),
             }
         }
         out = StatusTab._render_segment("project", cache)
@@ -86,13 +108,17 @@ class TestProjectSegment:
 
     def test_marks_dirty_working_tree(self) -> None:
         # The producer emits 'dirty' (working-tree state), not 'detached'.
-        cache = {"project": {"name": "hookwise", "branch": "main", "dirty": True}}
+        cache = {
+            "project": {"name": "hookwise", "branch": "main", "dirty": True, **_fresh()}
+        }
         out = StatusTab._render_segment("project", cache)
         assert "hookwise" in out
         assert "*" in out, "a dirty working tree must show a '*' marker (issue #155)"
 
     def test_clean_tree_has_no_dirty_marker(self) -> None:
-        cache = {"project": {"name": "hookwise", "branch": "main", "dirty": False}}
+        cache = {
+            "project": {"name": "hookwise", "branch": "main", "dirty": False, **_fresh()}
+        }
         out = StatusTab._render_segment("project", cache)
         assert "*" not in out, "a clean tree must not show the dirty marker"
 
@@ -107,7 +133,77 @@ class TestProjectSegment:
                 "name": "hookwise",
                 "branch": "main",
                 "last_commit_ts": int(time.time()) - 120,  # 2 minutes ago
+                **_fresh(),
             }
         }
         out = StatusTab._render_segment("project", cache)
         assert "ago" in out, "last_commit_ts must render an 'ago' suffix"
+
+
+class TestFreshnessGating:
+    """Stale cache entries must render as absent, matching the Go status line
+    (cmd_status_line.go feedData -> bridge.IsEnvelopeFresh). Without this gate
+    a days-old calendar event renders as current forever (scout hw-xthx #1)."""
+
+    @staticmethod
+    def _calendar_events() -> dict[str, Any]:
+        return {
+            "events": [
+                {
+                    "name": "Standup",
+                    "start": "2026-03-07T10:30:00Z",
+                    "end": "2999-01-01T00:00:00Z",
+                    "all_day": False,
+                    "is_current": True,
+                }
+            ],
+            "next_event": {"name": "Standup", "start": "2026-03-07T10:30:00Z"},
+        }
+
+    def test_stale_calendar_does_not_render(self) -> None:
+        cache = {"calendar": {**self._calendar_events(), **_stale()}}
+        out = StatusTab._render_segment("calendar", cache)
+        assert out == "", (
+            "an expired calendar entry must render as absent, not as a "
+            "current event (and not as 'Free')"
+        )
+
+    def test_fresh_calendar_renders_unchanged(self) -> None:
+        cache = {"calendar": {**self._calendar_events(), **_fresh()}}
+        out = StatusTab._render_segment("calendar", cache)
+        assert "Standup" in out
+
+    def test_entry_missing_freshness_fields_does_not_render(self) -> None:
+        # Go parity: IsEnvelopeFresh fails closed on a missing timestamp.
+        # FlattenForTUI stamps updated_at/ttl_seconds on every entry, so a
+        # bare entry is malformed and must be treated as absent.
+        cache = {"calendar": self._calendar_events()}
+        out = StatusTab._render_segment("calendar", cache)
+        assert out == ""
+
+    def test_stale_weather_does_not_render(self) -> None:
+        cache = {
+            "weather": {
+                "temperature": 72,
+                "temperatureUnit": "fahrenheit",
+                "emoji": "☀️",
+                **_stale(),
+            }
+        }
+        assert StatusTab._render_segment("weather", cache) == ""
+
+    def test_stale_insights_does_not_render(self) -> None:
+        cache = {"insights": {"total_sessions": 5, "friction_total": 0, **_stale()}}
+        assert StatusTab._render_segment("insights_friction", cache) == ""
+
+    def test_segment_has_data_false_for_stale_entry(self) -> None:
+        cache = {"calendar": {**self._calendar_events(), **_stale()}}
+        assert StatusTab._segment_has_data("calendar", cache) is False
+
+    def test_segment_has_data_true_for_fresh_entry(self) -> None:
+        cache = {"calendar": {**self._calendar_events(), **_fresh()}}
+        assert StatusTab._segment_has_data("calendar", cache) is True
+
+    def test_segment_has_data_false_for_stale_insights(self) -> None:
+        cache = {"insights": {"total_sessions": 5, **_stale()}}
+        assert StatusTab._segment_has_data("insights_pace", cache) is False


### PR DESCRIPTION
Fixes the top code-confirmed mechanism behind stale calendar data in the status surfaces (scout hw-xthx, blind spot #1): the TUI Status-tab cache-fallback preview rendered feed entries with no freshness check, so a days-old calendar event rendered as current forever. All cache reads now route through a _fresh_entry() helper gated on is_fresh(); stale/malformed entries render as absent, matching the Go status line. TestFreshnessGating covers expired/fresh/missing-fields/fails-closed cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ