### PR TITLE
fix(feeds): detect auth-dead calendar creds, freeze fallback ts (hw-b15m)

### DIFF
--- a/cmd/hookwise/cmd_doctor.go
+++ b/cmd/hookwise/cmd_doctor.go
@@ -165,6 +165,11 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		warnings += checkFeedConfigDrift(w, effectiveFeeds)
 	}
 
+	// Dead credentials: producers report auth-death (revoked/expired token)
+	// over GET /feeds. Only the daemon's runtime view carries this flag
+	// (feedsFromConfig never sets it), so this is a no-op on config fallback.
+	warnings += checkFeedAuthDead(w, effectiveFeeds)
+
 	// Back-compat: a project-level feeds: block is ignored by the singleton daemon
 	// (#89); tell the user to migrate it to the global config.
 	warnings += checkProjectFeedsIgnored(w, cwd)
@@ -361,6 +366,25 @@ func checkFeedConfigDrift(w io.Writer, daemonFeeds map[string]feeds.FeedStatus) 
 	fmt.Fprintf(w, "WARN  feed-config: daemon is polling a stale feed config (differs for: %s) — restart the daemon (hookwise daemon stop) to apply changes to %s\n",
 		strings.Join(names, ", "), filepath.Join(core.GetStateDir(), "config.yaml"))
 	return 1
+}
+
+// checkFeedAuthDead warns for feeds whose producer reports a dead credential
+// (e.g. the calendar OAuth refresh token was revoked — 401/invalid_grant).
+// Without this, a permanently-broken feed is indistinguishable from a healthy
+// one: the producer fails open with its cached envelope and never errors.
+// Returns the number of warnings emitted.
+func checkFeedAuthDead(w io.Writer, daemonFeeds map[string]feeds.FeedStatus) int {
+	names := make([]string, 0)
+	for name, fs := range daemonFeeds {
+		if fs.AuthDead {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Fprintf(w, "WARN  feed:%s: credential dead (revoked/expired token) — re-authenticate; the daemon re-reads the token file on its next poll\n", name)
+	}
+	return len(names)
 }
 
 // checkProjectFeedsIgnored warns when the project hookwise.yaml in cwd carries a

--- a/cmd/hookwise/cmd_doctor_effective_test.go
+++ b/cmd/hookwise/cmd_doctor_effective_test.go
@@ -127,3 +127,25 @@ feeds:
 	assert.True(t, m["weather"].Enabled)
 	assert.Equal(t, 900, m["weather"].IntervalSeconds)
 }
+
+// A producer-reported dead credential (FeedStatus.AuthDead, hw-b15m) must
+// surface as a doctor WARN — without it, a permanently-broken feed fails open
+// with cached data and looks healthy forever.
+func TestCheckFeedAuthDead(t *testing.T) {
+	var buf bytes.Buffer
+	healthy := map[string]feeds.FeedStatus{
+		"calendar": {Name: "calendar", Enabled: true},
+		"weather":  {Name: "weather", Enabled: true},
+	}
+	assert.Equal(t, 0, checkFeedAuthDead(&buf, healthy))
+	assert.Empty(t, buf.String())
+
+	buf.Reset()
+	dead := map[string]feeds.FeedStatus{
+		"calendar": {Name: "calendar", Enabled: true, AuthDead: true},
+		"weather":  {Name: "weather", Enabled: true},
+	}
+	assert.Equal(t, 1, checkFeedAuthDead(&buf, dead))
+	assert.Contains(t, buf.String(), "WARN  feed:calendar: credential dead")
+	assert.NotContains(t, buf.String(), "feed:weather")
+}

--- a/internal/feeds/feed_status.go
+++ b/internal/feeds/feed_status.go
@@ -83,6 +83,18 @@ type FeedStatus struct {
 	Name            string `json:"name"`
 	Enabled         bool   `json:"enabled"`
 	IntervalSeconds int    `json:"interval_seconds"`
+	// AuthDead is true when the producer implements AuthReporter and its
+	// credential is known-dead (e.g. revoked/expired OAuth refresh token).
+	// Doctor surfaces this as a WARN so a silently-frozen feed is visible.
+	AuthDead bool `json:"auth_dead,omitempty"`
+}
+
+// AuthReporter is an optional interface producers implement to report a dead
+// credential (revoked/expired token) so the daemon can expose it over
+// GET /feeds. Implementations must be safe for concurrent use — the socket
+// handler calls AuthDead while the poll loop runs the producer.
+type AuthReporter interface {
+	AuthDead() bool
 }
 
 // EffectiveFeeds returns the effective per-feed config the daemon is polling
@@ -98,11 +110,17 @@ func (d *Daemon) EffectiveFeeds() []FeedStatus {
 	out := make([]FeedStatus, 0, len(producers))
 	for _, p := range producers {
 		name := p.Name()
-		out = append(out, FeedStatus{
+		fs := FeedStatus{
 			Name:            name,
 			Enabled:         d.isEnabled(name),
 			IntervalSeconds: int(d.intervalFor(name) / time.Second),
-		})
+		}
+		// Runtime health beyond config: producers that track credential
+		// death report it here (AuthDead locks internally).
+		if ar, ok := p.(AuthReporter); ok {
+			fs.AuthDead = ar.AuthDead()
+		}
+		out = append(out, fs)
 	}
 	return out
 }

--- a/internal/feeds/feed_status_test.go
+++ b/internal/feeds/feed_status_test.go
@@ -124,3 +124,34 @@ func TestSocketFeeds_NoProviderReturnsEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
+
+// AuthDead must flow from an AuthReporter producer into EffectiveFeeds so
+// doctor can surface a dead credential (hw-b15m). The calendar producer is
+// the real implementation: mark it auth-dead and assert GET /feeds sees it.
+func TestDaemonEffectiveFeeds_SurfacesAuthDead(t *testing.T) {
+	registry := NewRegistry()
+	RegisterBuiltins(registry)
+
+	d := NewDaemon(core.DaemonConfig{}, core.FeedsConfig{
+		Calendar: core.CalendarFeedConfig{Enabled: true},
+	}, registry)
+
+	byName := map[string]FeedStatus{}
+	for _, f := range d.EffectiveFeeds() {
+		byName[f.Name] = f
+	}
+	require.Contains(t, byName, "calendar")
+	assert.False(t, byName["calendar"].AuthDead, "healthy producer must not report auth-dead")
+
+	// Flip the real producer to auth-dead and re-read.
+	for _, p := range registry.All() {
+		if cp, ok := p.(*CalendarProducer); ok {
+			cp.markAuthDead()
+		}
+	}
+	byName = map[string]FeedStatus{}
+	for _, f := range d.EffectiveFeeds() {
+		byName[f.Name] = f
+	}
+	assert.True(t, byName["calendar"].AuthDead, "auth-dead producer must be reported over EffectiveFeeds")
+}

--- a/internal/feeds/producer_calendar.go
+++ b/internal/feeds/producer_calendar.go
@@ -3,6 +3,7 @@ package feeds
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/vishnujayvel/hookwise/internal/core"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -33,6 +35,55 @@ type CalendarProducer struct {
 	oauthCfg *oauth2.Config
 	origTok  *oauth2.Token
 	svc      *calendar.Service
+
+	// authDead is set when the credential is known-dead (revoked/expired
+	// refresh token, HTTP 401). Cleared on the next successful poll. Read
+	// concurrently by EffectiveFeeds (GET /feeds), so guarded by mu.
+	authDead bool
+}
+
+// AuthDead reports whether the producer's credential is known-dead
+// (AuthReporter interface). Surfaced over GET /feeds so doctor can warn.
+func (p *CalendarProducer) AuthDead() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.authDead
+}
+
+// markAuthDead records a dead credential and drops the cached OAuth client
+// and Calendar service so the NEXT poll re-reads the token file from disk.
+// This is what lets a re-auth (fixed token file) take effect without a
+// daemon restart — ensureClient otherwise short-circuits forever on the
+// cached service built from the dead token.
+func (p *CalendarProducer) markAuthDead() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.authDead = true
+	p.client = nil
+	p.oauthCfg = nil
+	p.origTok = nil
+	p.svc = nil
+}
+
+// isAuthDeadError classifies an events-fetch error as a dead credential: a
+// token refresh rejected with invalid_grant (revoked/expired refresh token)
+// or an HTTP 401 from the token endpoint or the Calendar API. Transient
+// failures (5xx, network errors, timeouts) are NOT auth-dead.
+func isAuthDeadError(err error) bool {
+	var rerr *oauth2.RetrieveError
+	if errors.As(err, &rerr) {
+		if rerr.ErrorCode == "invalid_grant" {
+			return true
+		}
+		if rerr.Response != nil && rerr.Response.StatusCode == http.StatusUnauthorized {
+			return true
+		}
+	}
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) && gerr.Code == http.StatusUnauthorized {
+		return true
+	}
+	return false
 }
 
 func (p *CalendarProducer) Name() string { return "calendar" }
@@ -217,7 +268,12 @@ func (p *CalendarProducer) Produce(ctx context.Context) (interface{}, error) {
 	// daemon shutdown cancel in-flight requests while the token source remains alive.
 	events, err := eventsCall.Context(ctx).Do()
 	if err != nil {
-		core.Logger().Warn("calendar: API request failed", "error", err)
+		if isAuthDeadError(err) {
+			p.markAuthDead()
+			core.Logger().Error("calendar: credential dead (revoked/expired token) — re-auth required; token file will be re-read next poll", "error", err)
+		} else {
+			core.Logger().Warn("calendar: API request failed", "error", err)
+		}
 		return p.fallbackResult("api error"), nil
 	}
 
@@ -273,26 +329,32 @@ func (p *CalendarProducer) Produce(ctx context.Context) (interface{}, error) {
 
 	p.mu.Lock()
 	p.lastResult = result
+	p.authDead = false
 	p.mu.Unlock()
 
 	return result, nil
 }
 
 // fallbackResult returns cached data or an empty envelope (ARCH-1: fail-open).
+// The returned envelope's timestamp is NEVER re-stamped on failure: repeated
+// failing polls return the same envelope verbatim, so TTL expiry eventually
+// hides the segment instead of a broken producer looking fresh forever.
 func (p *CalendarProducer) fallbackResult(reason string) map[string]interface{} {
 	p.mu.Lock()
-	last := p.lastResult
-	p.mu.Unlock()
+	defer p.mu.Unlock()
 
-	if last != nil {
+	if p.lastResult != nil {
 		core.Logger().Debug("calendar: using cached fallback", "reason", reason)
-		return last
+		return p.lastResult
 	}
 
-	return NewEnvelope("calendar", map[string]interface{}{
+	// No prior success: build the empty envelope ONCE and cache it so its
+	// timestamp stays frozen across consecutive failing polls too.
+	p.lastResult = NewEnvelope("calendar", map[string]interface{}{
 		"events":     []interface{}{},
 		"next_event": nil,
 	})
+	return p.lastResult
 }
 
 // parseGoogleEventTime extracts a time.Time from a Google Calendar EventDateTime.

--- a/internal/feeds/producer_calendar_test.go
+++ b/internal/feeds/producer_calendar_test.go
@@ -3,9 +3,11 @@ package feeds
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+	"google.golang.org/api/googleapi"
 
 	"github.com/vishnujayvel/hookwise/internal/core"
 )
@@ -75,6 +78,10 @@ type calendarMockServer struct {
 	tokenCalls  int // counts how many token refresh calls were made
 	eventCalls  int // counts how many events list calls were made
 	eventSummary string
+	// tokenError, when non-empty, makes POST /token fail with HTTP 400 and
+	// this RFC 6749 error code (e.g. "invalid_grant" = revoked refresh token).
+	// Set before starting the server; never mutated afterwards.
+	tokenError string
 }
 
 func (m *calendarMockServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -82,6 +89,11 @@ func (m *calendarMockServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/token"):
 		m.tokenCalls++
 		w.Header().Set("Content-Type", "application/json")
+		if m.tokenError != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, `{"error":%q}`, m.tokenError)
+			return
+		}
 		fmt.Fprintf(w, `{"access_token":"fresh-token-%d","token_type":"Bearer","expires_in":3600}`, m.tokenCalls)
 
 	case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/calendars/"):
@@ -345,4 +357,216 @@ func TestCalendarProducer_TokenRefresh_IsAttemptedWhenExpired(t *testing.T) {
 
 	first := events[0].(map[string]interface{})
 	assert.Equal(t, "Refresh Check Meeting", first["name"])
+}
+
+// ---------------------------------------------------------------------------
+// Auth-dead detection (hw-b15m): classify 401/invalid_grant, drop the cached
+// service so the token file is re-read, keep the fail-open fallback but never
+// re-stamp its timestamp.
+// ---------------------------------------------------------------------------
+
+// TestIsAuthDeadError_Classification pins which failures count as a dead
+// credential (mark auth-dead, drop client) vs transient (retry next poll).
+func TestIsAuthDeadError_Classification(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"invalid_grant retrieve error", &oauth2.RetrieveError{ErrorCode: "invalid_grant"}, true},
+		{"invalid_grant wrapped in url.Error (real transport shape)",
+			&url.Error{Op: "Get", URL: "https://example.com", Err: &oauth2.RetrieveError{ErrorCode: "invalid_grant"}}, true},
+		{"401 from token endpoint", &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusUnauthorized}}, true},
+		{"503 from token endpoint is transient", &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusServiceUnavailable}}, false},
+		{"401 from calendar API", &googleapi.Error{Code: http.StatusUnauthorized}, true},
+		{"403 from calendar API is not auth-dead", &googleapi.Error{Code: http.StatusForbidden}, false},
+		{"500 from calendar API is transient", &googleapi.Error{Code: http.StatusInternalServerError}, false},
+		{"network error is transient", errors.New("dial tcp: connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isAuthDeadError(tc.err))
+		})
+	}
+}
+
+// TestCalendarProducer_RefreshFailure_InvalidGrant_MarksAuthDead exercises the
+// refresh-FAILURE path end-to-end: an expired access token forces a refresh,
+// the token endpoint rejects it with invalid_grant (revoked refresh token),
+// and the producer must (a) stay fail-open (no error, fallback envelope) and
+// (b) flag itself auth-dead for the feed-health path (AuthReporter).
+func TestCalendarProducer_RefreshFailure_InvalidGrant_MarksAuthDead(t *testing.T) {
+	mock := &calendarMockServer{tokenError: "invalid_grant"}
+	srv := httptest.NewServer(mock)
+	defer srv.Close()
+
+	tokenPath := writeTempTokenFile(t, srv.URL+"/token")
+
+	p := newCalendarProducerForTest(srv.URL + "/")
+	p.SetFeedsConfig(core.FeedsConfig{
+		Calendar: core.CalendarFeedConfig{
+			Enabled:   true,
+			TokenPath: tokenPath,
+			Calendars: []string{"primary"},
+		},
+	})
+
+	assert.False(t, p.AuthDead(), "producer must not start auth-dead")
+
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err, "ARCH-1: auth failure must not propagate as error")
+
+	env := result.(map[string]interface{})
+	data := env["data"].(map[string]interface{})
+	events := data["events"].([]interface{})
+	assert.Empty(t, events, "no prior success: fallback must be the empty envelope")
+
+	assert.True(t, p.AuthDead(),
+		"invalid_grant on refresh must mark the producer auth-dead")
+	assert.GreaterOrEqual(t, mock.tokenCalls, 1, "refresh must have been attempted")
+}
+
+// TestCalendarProducer_TokenRotation_PickedUpWithoutRestart is the re-auth
+// regression test: before the fix, ensureClient short-circuited on the cached
+// service forever, so fixing the token file on disk was invisible until a
+// daemon restart. After an auth-dead failure the cached service is dropped,
+// the token file is re-read on the next poll, and a rotated (valid) token
+// recovers the feed — and clears the auth-dead flag.
+func TestCalendarProducer_TokenRotation_PickedUpWithoutRestart(t *testing.T) {
+	badMock := &calendarMockServer{tokenError: "invalid_grant"}
+	srvBad := httptest.NewServer(badMock)
+	defer srvBad.Close()
+
+	goodMock := &calendarMockServer{eventSummary: "Post-Rotation Meeting"}
+	srvGood := httptest.NewServer(goodMock)
+	defer srvGood.Close()
+
+	// Token file initially points its token_uri at the failing endpoint —
+	// this is the on-disk state while the refresh token is revoked.
+	tokenPath := writeTempTokenFile(t, srvBad.URL+"/token")
+
+	// Events always go to the good server; only the credential is dead.
+	p := newCalendarProducerForTest(srvGood.URL + "/")
+	p.SetFeedsConfig(core.FeedsConfig{
+		Calendar: core.CalendarFeedConfig{
+			Enabled:          true,
+			TokenPath:        tokenPath,
+			Calendars:        []string{"primary"},
+			LookaheadMinutes: 120,
+		},
+	})
+
+	// Poll 1: refresh fails with invalid_grant → auth-dead, fallback.
+	_, err := p.Produce(context.Background())
+	require.NoError(t, err)
+	require.True(t, p.AuthDead(), "poll 1 must mark auth-dead")
+
+	// User re-authenticates: the token file is rewritten in place with a
+	// working credential (token_uri now points at the good endpoint).
+	pastExpiry := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	rotated := map[string]interface{}{
+		"token":         "expired-access-token",
+		"refresh_token": "fresh-valid-refresh-token",
+		"token_uri":     srvGood.URL + "/token",
+		"client_id":     "test-client-id",
+		"client_secret": "test-client-secret",
+		"expiry":        pastExpiry,
+	}
+	data, err := json.Marshal(rotated)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(tokenPath, data, 0600))
+
+	// Poll 2: NO restart, same producer instance. The rotated token file
+	// must be picked up because the dead client was dropped.
+	result, err := p.Produce(context.Background())
+	require.NoError(t, err)
+
+	env := result.(map[string]interface{})
+	events := env["data"].(map[string]interface{})["events"].([]interface{})
+	require.NotEmpty(t, events,
+		"rotated token file must be re-read on the next poll without a daemon restart")
+	assert.Equal(t, "Post-Rotation Meeting", events[0].(map[string]interface{})["name"])
+	assert.False(t, p.AuthDead(), "successful poll must clear the auth-dead flag")
+	assert.GreaterOrEqual(t, goodMock.tokenCalls, 1, "refresh must have hit the rotated token_uri")
+}
+
+// TestCalendarProducer_FallbackTimestampFrozen_AcrossFailingPolls verifies the
+// frozen-timestamp contract: once polls start failing, the fallback envelope
+// keeps the LAST SUCCESSFUL poll's timestamp verbatim across >=3 failing
+// polls. The daemon rewrites the cache file every poll (err is nil, ARCH-1),
+// so a re-stamped timestamp would keep the segment TTL-fresh forever; frozen,
+// TTL expiry eventually hides it.
+func TestCalendarProducer_FallbackTimestampFrozen_AcrossFailingPolls(t *testing.T) {
+	mock := &calendarMockServer{eventSummary: "Freeze Check Meeting"}
+	srv := httptest.NewServer(mock)
+
+	tokenPath := writeTempTokenFile(t, srv.URL+"/token")
+
+	p := newCalendarProducerForTest(srv.URL + "/")
+	p.SetFeedsConfig(core.FeedsConfig{
+		Calendar: core.CalendarFeedConfig{
+			Enabled:          true,
+			TokenPath:        tokenPath,
+			Calendars:        []string{"primary"},
+			LookaheadMinutes: 120,
+		},
+	})
+
+	// Poll 1: success — this stamps the envelope.
+	result1, err := p.Produce(context.Background())
+	require.NoError(t, err)
+	env1 := result1.(map[string]interface{})
+	ts1 := env1["timestamp"].(string)
+	require.NotEmpty(t, ts1)
+	events1 := env1["data"].(map[string]interface{})["events"].([]interface{})
+	require.NotEmpty(t, events1, "poll 1 must succeed")
+
+	// Kill the API: every subsequent poll fails (transient network error).
+	srv.Close()
+
+	// Envelope timestamps are RFC3339 at second precision — cross a second
+	// boundary so a re-stamped envelope would provably differ.
+	time.Sleep(1100 * time.Millisecond)
+
+	for i := 2; i <= 4; i++ {
+		result, err := p.Produce(context.Background())
+		require.NoError(t, err, "ARCH-1: failing poll %d must not error", i)
+		env := result.(map[string]interface{})
+		assert.Equal(t, ts1, env["timestamp"],
+			"failing poll %d must return the last successful envelope with its timestamp FROZEN", i)
+		events := env["data"].(map[string]interface{})["events"].([]interface{})
+		assert.NotEmpty(t, events, "failing poll %d must keep serving cached events (fail-open)", i)
+	}
+
+	assert.False(t, p.AuthDead(), "network failure is transient, not auth-dead")
+}
+
+// TestCalendarProducer_NoPriorSuccess_EmptyFallbackTimestampFrozen covers the
+// daemon-restarted-with-broken-auth case: with no cached success, the empty
+// fallback envelope must also keep a frozen timestamp across failing polls,
+// so a permanently-broken producer cannot render an eternally-fresh "Free".
+func TestCalendarProducer_NoPriorSuccess_EmptyFallbackTimestampFrozen(t *testing.T) {
+	p := newCalendarProducerForTest("http://unused.invalid/")
+	p.SetFeedsConfig(core.FeedsConfig{
+		Calendar: core.CalendarFeedConfig{
+			Enabled:   true,
+			TokenPath: "/nonexistent/path/calendar-token.json",
+			Calendars: []string{"primary"},
+		},
+	})
+
+	result1, err := p.Produce(context.Background())
+	require.NoError(t, err)
+	ts1 := result1.(map[string]interface{})["timestamp"].(string)
+	require.NotEmpty(t, ts1)
+
+	// Cross a second boundary so a re-stamp would provably differ.
+	time.Sleep(1100 * time.Millisecond)
+
+	for i := 2; i <= 3; i++ {
+		result, err := p.Produce(context.Background())
+		require.NoError(t, err, "ARCH-1: failing poll %d must not error", i)
+		assert.Equal(t, ts1, result.(map[string]interface{})["timestamp"],
+			"empty fallback envelope must not be re-stamped on failing poll %d", i)
+	}
 }


### PR DESCRIPTION
Blind spots #2+#3 from the calendar-staleness scout (hw-xthx): a revoked/expired OAuth refresh token was indistinguishable from a transient failure — silent frozen fallback forever, and re-auth required a daemon restart. Now: 401/invalid_grant classified as auth-dead (Error log), cached client dropped so the token file is re-read next poll, fallback envelopes never re-stamp timestamps (TTL expiry hides the segment), and doctor WARNs per auth-dead feed via the existing feed-health path. 224 lines of new producer tests incl. token-rotation-without-restart and frozen-ts across 3+ failing polls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ