### PR TITLE
feat: add publish-check commit-subject gate (hw-vwpw)

### DIFF
--- a/scripts/publish-check.sh
+++ b/scripts/publish-check.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# publish-check.sh — local commit-subject gate for the publish flow
+#
+# Verifies every commit subject in a ref range:
+#   (a) is <= 72 characters (commitlint header-max-length)
+#   (b) starts with an allowed conventional-commit type
+#
+# Usage:
+#   scripts/publish-check.sh [<range>]
+#
+# Default range: commits ahead of github/main on the current branch
+# (falls back to origin/main if the github remote is absent).
+#
+# The allowed type enum is parsed from the repo's commitlint config
+# (commitlint.config.js or .commitlintrc.yml, whichever exists). If no
+# config is found or parsing yields nothing, falls back to:
+#   feat fix docs test refactor chore
+#
+# Exit 0 = all subjects pass
+# Exit 1 = offenders found (each printed with its length / bad type)
+# Exit 2 = usage/environment error (unresolvable range, not a repo)
+#
+# Testing:
+#   Run: bash scripts/test-publish-check.sh
+
+set -uo pipefail
+
+MAX_LEN=72
+FALLBACK_TYPES="feat fix docs test refactor chore"
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "publish-check: not inside a git repository" >&2
+    exit 2
+}
+
+# --- Resolve the ref range ---
+
+if [ $# -ge 1 ]; then
+    RANGE="$1"
+else
+    RANGE=""
+    for base in github/main origin/main; do
+        if git rev-parse --verify --quiet "$base" >/dev/null; then
+            RANGE="$base..HEAD"
+            break
+        fi
+    done
+    if [ -z "$RANGE" ]; then
+        echo "publish-check: cannot resolve a base ref (github/main or origin/main); pass a range explicitly" >&2
+        exit 2
+    fi
+fi
+
+# --- Parse the allowed type enum from the commitlint config ---
+
+# Both parsers scope to the type-enum block and keep bare lowercase
+# tokens, dropping commitlint's severity/condition entries (2, always).
+parse_types_js() {
+    # commitlint.config.js: quoted strings inside the type-enum array.
+    sed -n '/type-enum/,/\]/p' "$1" 2>/dev/null |
+        grep -oE "['\"][a-z]+['\"]" |
+        tr -d "'\"" |
+        grep -vxE 'always|never' || true
+}
+
+parse_types_yml() {
+    # .commitlintrc.yml: list items under the type-enum key, until the
+    # next sibling rule key ends the block.
+    awk '
+        /^[[:space:]]*type-enum:/ { inblock = 1; next }
+        inblock && /^[[:space:]]*-/ {
+            line = $0
+            gsub(/^[[:space:]]+/, "", line)
+            gsub(/^(-[[:space:]]+)+/, "", line)
+            gsub(/["'\'']/, "", line)
+            if (line ~ /^[a-z]+$/ && line != "always" && line != "never") print line
+            next
+        }
+        inblock && /^[[:space:]]*[A-Za-z-]+:/ { inblock = 0 }
+    ' "$1" 2>/dev/null || true
+}
+
+types=""
+if [ -f "$repo_root/commitlint.config.js" ]; then
+    types=$(parse_types_js "$repo_root/commitlint.config.js")
+elif [ -f "$repo_root/.commitlintrc.yml" ]; then
+    types=$(parse_types_yml "$repo_root/.commitlintrc.yml")
+fi
+if [ -z "$types" ]; then
+    types=$(tr ' ' '\n' <<<"$FALLBACK_TYPES")
+fi
+
+type_alt=$(printf '%s\n' "$types" | paste -sd'|' -)
+subject_re="^(${type_alt})(\([^)]*\))?!?: .+"
+
+# --- Check every commit subject in the range ---
+
+subjects=$(git log --no-merges --format='%s' "$RANGE" -- 2>&1) || {
+    echo "publish-check: invalid range '$RANGE'" >&2
+    echo "$subjects" >&2
+    exit 2
+}
+
+if [ -z "$subjects" ]; then
+    echo "publish-check: PASS — no commits in range $RANGE"
+    exit 0
+fi
+
+offenders=0
+checked=0
+while IFS= read -r subject; do
+    checked=$((checked + 1))
+    len=${#subject}
+    if [ "$len" -gt "$MAX_LEN" ]; then
+        echo "  ✗ subject is $len chars (max $MAX_LEN): $subject"
+        offenders=$((offenders + 1))
+        continue
+    fi
+    if ! printf '%s' "$subject" | grep -qE "$subject_re"; then
+        echo "  ✗ bad type (allowed: $type_alt): $subject"
+        offenders=$((offenders + 1))
+    fi
+done <<EOF
+$subjects
+EOF
+
+if [ "$offenders" -gt 0 ]; then
+    echo "publish-check: FAIL — $offenders of $checked commit subject(s) in $RANGE violate the gate"
+    exit 1
+fi
+
+echo "publish-check: PASS — $checked commit subject(s) in $RANGE ok"
+exit 0

--- a/scripts/test-publish-check.sh
+++ b/scripts/test-publish-check.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# test-publish-check.sh — Tests for publish-check.sh
+#
+# Each scenario builds a throwaway git repo with empty commits on a topic
+# branch off main, then runs the gate against an explicit or default range.
+# Mirrors the test-tenet-gate.sh harness.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/publish-check.sh"
+
+passed=0
+failed=0
+total=0
+REPO=""
+
+cleanup() {
+    [ -n "$REPO" ] && rm -rf "$REPO"
+}
+trap cleanup EXIT
+
+# --- Test helpers ---
+
+new_repo() {
+    cleanup
+    REPO=$(mktemp -d "${TMPDIR:-/tmp}/publish-check-test.XXXXXX")
+    git -C "$REPO" -c init.defaultBranch=main init -q
+    repo_commit "chore: base commit"
+    git -C "$REPO" checkout -q -b topic
+}
+
+repo_commit() {
+    git -C "$REPO" -c user.email=test@test -c user.name=test \
+        commit -q --allow-empty -m "$1"
+}
+
+# assert <name> <expected_exit> <expected_pattern> [range...]
+# Runs the gate inside $REPO; no range args → default-range resolution.
+assert() {
+    local name="$1"
+    local expected_exit="$2"
+    local expected_pattern="$3"
+    shift 3
+
+    total=$((total + 1))
+
+    local output
+    local exit_code
+    output=$(cd "$REPO" && bash "$TARGET" "$@" 2>&1)
+    exit_code=$?
+
+    local ok=1
+    local reason=""
+
+    if [ "$exit_code" -ne "$expected_exit" ]; then
+        ok=0
+        reason="expected exit $expected_exit, got $exit_code"
+    fi
+
+    if [ -n "$expected_pattern" ] && ! echo "$output" | grep -q "$expected_pattern"; then
+        ok=0
+        reason="${reason:+$reason; }pattern '$expected_pattern' not found"
+    fi
+
+    if [ "$ok" -eq 1 ]; then
+        echo "  ✓ $name"
+        passed=$((passed + 1))
+    else
+        echo "  ✗ $name — $reason"
+        echo "    output: $(echo "$output" | head -3)"
+        failed=$((failed + 1))
+    fi
+}
+
+echo "=== publish-check.sh tests ==="
+echo ""
+
+# --- Group 1: Passing fixtures ---
+echo "Group 1: Valid subjects pass"
+
+new_repo
+repo_commit "feat: add the publish gate (hw-vwpw)"
+repo_commit "fix(scripts): handle empty ranges"
+assert "Valid subjects → PASS" \
+    0 "PASS" main..HEAD
+
+new_repo
+# "feat: " (6) + 66 x's = exactly 72 chars — the boundary must pass.
+repo_commit "feat: $(printf 'x%.0s' $(seq 1 66))"
+assert "Exactly-72-char subject → PASS" \
+    0 "PASS" main..HEAD
+
+new_repo
+assert "Empty range → PASS" \
+    0 "no commits in range" main..HEAD
+
+echo ""
+
+# --- Group 2: Refusal fixtures ---
+echo "Group 2: Offending subjects are refused"
+
+new_repo
+# "feat: " (6) + 67 x's = 73 chars — one over the limit.
+repo_commit "feat: $(printf 'x%.0s' $(seq 1 67))"
+assert "73-char subject → FAIL, reports length 73" \
+    1 "73 chars" main..HEAD
+
+new_repo
+repo_commit "yolo: not a real commit type"
+assert "Disallowed type → FAIL" \
+    1 "bad type" main..HEAD
+
+new_repo
+repo_commit "no conventional prefix at all"
+assert "Missing type prefix → FAIL" \
+    1 "bad type" main..HEAD
+
+new_repo
+repo_commit "feat: good subject"
+repo_commit "yolo: bad subject"
+assert "Mixed good+bad commits → FAIL, counts one offender" \
+    1 "1 of 2" main..HEAD
+
+echo ""
+
+# --- Group 3: Type enum comes from the commitlint config ---
+echo "Group 3: Config parsing"
+
+new_repo
+cat > "$REPO/.commitlintrc.yml" <<'YML'
+rules:
+  type-enum:
+    - 2
+    - always
+    - - feat
+      - wibble
+  header-max-length:
+    - 2
+    - always
+    - 72
+YML
+git -C "$REPO" add .commitlintrc.yml
+repo_commit "feat: track commitlint config"
+repo_commit "wibble: custom type from yml config"
+assert "Custom type in .commitlintrc.yml is honored → PASS" \
+    0 "PASS" main..HEAD
+
+new_repo
+cat > "$REPO/commitlint.config.js" <<'JS'
+module.exports = {
+  rules: {
+    'type-enum': [2, 'always', ['feat', 'zonk']],
+  },
+};
+JS
+git -C "$REPO" add commitlint.config.js
+repo_commit "feat: track commitlint js config"
+repo_commit "zonk: custom type from js config"
+assert "Custom type in commitlint.config.js is honored → PASS" \
+    0 "PASS" main..HEAD
+
+new_repo
+repo_commit "perf: perf is not in the fallback enum"
+assert "No config → fallback enum rejects perf" \
+    1 "bad type" main..HEAD
+
+echo ""
+
+# --- Group 4: Default range resolution ---
+echo "Group 4: Default range"
+
+new_repo
+git -C "$REPO" update-ref refs/remotes/github/main main
+repo_commit "feat: ahead of github main"
+assert "No args → checks commits ahead of github/main" \
+    0 "github/main..HEAD" # no range args
+
+new_repo
+git -C "$REPO" update-ref refs/remotes/github/main main
+repo_commit "yolo: bad commit ahead of github main"
+assert "No args → refuses bad commit ahead of github/main" \
+    1 "bad type" # no range args
+
+new_repo
+assert "No github/origin base and no args → exit 2" \
+    2 "cannot resolve" # no range args
+
+new_repo
+assert "Garbage range → exit 2" \
+    2 "invalid range" "not-a-ref..HEAD"
+
+echo ""
+
+# --- Summary ---
+echo "=== Results: $passed/$total passed, $failed failed ==="
+
+if [ "$failed" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
GCI-002: local pre-push gate verifying every commit subject in a range is ≤72 chars and starts with an allowed commitlint type (enum parsed from commitlint.config.js, with a safe fallback). Kills the recurring commitlint CI failure — which bit a FOURTH time tonight on PR #250 before this landed. Includes shell tests with negative fixtures (73-char subject refused). This very PR was gated by the script before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a publish validation check that reviews commit subjects before release.
  * Supports conventional commit types configured in the project, with sensible defaults when no configuration is available.
  * Validates commit subject format and enforces a maximum length of 72 characters.
  * Reports invalid commits clearly and returns status codes suitable for automated publishing workflows.

* **Tests**
  * Added coverage for valid, invalid, boundary, configuration, and branch-range scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->