### PR TITLE
test: calendar dead-daemon e2e + chaos matrix coverage (hw-c195)

### DIFF
--- a/cmd/hookwise/cmd_status_line_calendar_e2e_test.go
+++ b/cmd/hookwise/cmd_status_line_calendar_e2e_test.go
@@ -1,0 +1,154 @@
+//go:build integration
+
+// Dead-daemon end-to-end coverage for the calendar status-line segment
+// (scout hw-xthx blind spot #4). A real daemon writes the calendar envelope
+// to disk; after the daemon stops, the segment must keep rendering until the
+// embedded timestamp ages past ttl_seconds, then disappear — even though the
+// cache file's mtime stays fresh. Freshness is content-based
+// (bridge.IsEnvelopeFresh), never mtime-based.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vishnujayvel/hookwise/internal/bridge"
+	"github.com/vishnujayvel/hookwise/internal/core"
+	"github.com/vishnujayvel/hookwise/internal/feeds"
+)
+
+// calendarE2ESocketPath returns a unix socket path under /tmp for a test
+// daemon. macOS /var/folders temp paths (from t.TempDir) can exceed the
+// 104-byte unix socket limit, so sockets get their own short dir.
+func calendarE2ESocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "hw-sock-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "d.sock")
+}
+
+// calendarE2EProducer emits a calendar envelope in the exact shape the real
+// producer writes (schema pinned by feeds.CalendarTestFixture), with an
+// upcoming next_event so the rendered segment is non-empty.
+type calendarE2EProducer struct {
+	eventStart string
+}
+
+func (p *calendarE2EProducer) Name() string { return "calendar" }
+func (p *calendarE2EProducer) Produce(_ context.Context) (interface{}, error) {
+	return feeds.NewEnvelope("calendar", map[string]interface{}{
+		"events": []interface{}{
+			map[string]interface{}{
+				"name":       "Standup",
+				"start":      p.eventStart,
+				"end":        p.eventStart,
+				"all_day":    false,
+				"is_current": false,
+			},
+		},
+		"next_event": map[string]interface{}{
+			"name":  "Standup",
+			"start": p.eventStart,
+		},
+	}), nil
+}
+
+func TestIntegration_CalendarStatusLine_DeadDaemonStaleOmitted(t *testing.T) {
+	tmpDir := t.TempDir()
+	// #228 isolation contract: never touch the real ~/.hookwise.
+	t.Setenv("HOOKWISE_STATE_DIR", tmpDir)
+
+	// runStatusLine reads the feed cache from GetStateDir()/state — point the
+	// daemon's cache writer at the exact directory the status line reads.
+	cacheDir := filepath.Join(core.GetStateDir(), "state")
+	require.Equal(t, filepath.Join(tmpDir, "state"), cacheDir,
+		"HOOKWISE_STATE_DIR override must be in effect before starting the daemon")
+
+	eventStart := time.Now().Add(45 * time.Minute).UTC().Format(time.RFC3339)
+	registry := feeds.NewRegistry()
+	registry.Register(&calendarE2EProducer{eventStart: eventStart})
+
+	// Calendar is a recognised feed and defaults to disabled; without the
+	// explicit enable the daemon skips it and calendar.json is never written.
+	daemon := feeds.NewDaemon(core.DaemonConfig{}, core.FeedsConfig{
+		Calendar: core.CalendarFeedConfig{Enabled: true},
+	}, registry)
+	daemon.SetPIDFile(filepath.Join(tmpDir, "test-daemon.pid"))
+	daemon.SetCacheDir(cacheDir)
+	// DefaultSocketPath is frozen at package init from ~/.hookwise, so
+	// HOOKWISE_STATE_DIR does not move it; isolate explicitly (#228).
+	daemon.SetSocketPath(calendarE2ESocketPath(t))
+	daemon.SetStaggerOffset(10 * time.Millisecond)
+
+	require.NoError(t, daemon.Start())
+	cacheFile := filepath.Join(cacheDir, "calendar.json")
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(cacheFile)
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "daemon should write calendar.json")
+
+	// Daemon is dead from here on — everything below reads its leftovers.
+	require.NoError(t, daemon.Stop())
+
+	// --- Phase 1: fresh envelope renders the segment -----------------------
+	// Presence detector: proves the omission assertion in phase 2 is
+	// meaningful, not a test that would pass on any empty output.
+	collected, err := bridge.CollectFeedCache(cacheDir)
+	require.NoError(t, err)
+	require.Contains(t, collected, "calendar")
+
+	freshSegment := stripANSI(renderBuiltinSegment("calendar", collected, nil))
+	require.NotEmpty(t, freshSegment, "fresh envelope from a dead daemon must still render")
+	assert.Contains(t, freshSegment, "Standup")
+	assert.Contains(t, freshSegment, "\U0001f4c5")
+
+	// The daemon must have injected ttl_seconds into the on-disk data map;
+	// the aging step below derives its offset from this real value.
+	envelope, ok := collected["calendar"].(map[string]interface{})
+	require.True(t, ok)
+	require.True(t, bridge.IsEnvelopeFresh(envelope), "just-written envelope must be fresh")
+	data, ok := envelope["data"].(map[string]interface{})
+	require.True(t, ok)
+	ttl, ok := data["ttl_seconds"].(float64)
+	require.True(t, ok, "daemon must inject ttl_seconds into the cache envelope")
+
+	// --- Phase 2: age the embedded timestamp past TTL ----------------------
+	// Rewrite ONLY the envelope's timestamp; rewriting the file makes its
+	// mtime NOW, i.e. mtime-fresh but content-stale — exactly the divergence
+	// a dead daemon leaves behind. The gate must key on content, not mtime.
+	raw, err := os.ReadFile(cacheFile)
+	require.NoError(t, err)
+	var onDisk map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	agedTS := time.Now().Add(-(time.Duration(ttl)*time.Second + time.Minute))
+	onDisk["timestamp"] = agedTS.UTC().Format(time.RFC3339)
+	aged, err := json.Marshal(onDisk)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(cacheFile, aged, 0o600))
+
+	info, err := os.Stat(cacheFile)
+	require.NoError(t, err)
+	require.Less(t, time.Since(info.ModTime()), time.Minute,
+		"file mtime must be fresh — staleness below must come from the embedded timestamp")
+
+	// --- Phase 3: stale envelope is omitted from the status line -----------
+	collected, err = bridge.CollectFeedCache(cacheDir)
+	require.NoError(t, err)
+	require.Contains(t, collected, "calendar", "stale entry is still collected; the render gate drops it")
+
+	staleEnvelope, ok := collected["calendar"].(map[string]interface{})
+	require.True(t, ok)
+	assert.False(t, bridge.IsEnvelopeFresh(staleEnvelope), "aged envelope must be past TTL")
+
+	staleSegment := renderBuiltinSegment("calendar", collected, nil)
+	assert.Empty(t, staleSegment,
+		"stale calendar envelope must be omitted from the status line (stale = absent)")
+}

--- a/cmd/hookwise/cmd_status_line_feeddata_test.go
+++ b/cmd/hookwise/cmd_status_line_feeddata_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vishnujayvel/hookwise/internal/bridge"
+)
+
+// calendarEnvelopeAt builds a Go-envelope cache entry for the calendar feed
+// with the given embedded timestamp. Freshness is derived from this timestamp
+// (bridge.IsEnvelopeFresh), never from file mtime, so tests age entries by
+// moving the timestamp — mirroring how a dead daemon leaves frozen content.
+func calendarEnvelopeAt(ts time.Time, data map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type":      "calendar",
+		"timestamp": ts.UTC().Format(time.RFC3339),
+		"data":      data,
+	}
+}
+
+// upcomingCalendarData returns calendar feed data with a next_event starting
+// in the future, matching the schema pinned by feeds.CalendarTestFixture.
+func upcomingCalendarData(eventStart time.Time) map[string]interface{} {
+	start := eventStart.UTC().Format(time.RFC3339)
+	return map[string]interface{}{
+		"events": []interface{}{
+			map[string]interface{}{
+				"name":       "Standup",
+				"start":      start,
+				"end":        eventStart.Add(30 * time.Minute).UTC().Format(time.RFC3339),
+				"all_day":    false,
+				"is_current": false,
+			},
+		},
+		"next_event": map[string]interface{}{
+			"name":  "Standup",
+			"start": start,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// feedData: missing / malformed cache entries are treated as absent
+// ---------------------------------------------------------------------------
+
+func TestFeedData_MissingOrMalformedReturnsNil(t *testing.T) {
+	freshData := upcomingCalendarData(time.Now().Add(time.Hour))
+
+	tests := []struct {
+		name  string
+		cache map[string]interface{}
+	}{
+		{"nil cache", nil},
+		{"feed absent", map[string]interface{}{}},
+		{"envelope not a map", map[string]interface{}{"calendar": "not-a-map"}},
+		{"missing timestamp", map[string]interface{}{
+			"calendar": map[string]interface{}{"type": "calendar", "data": freshData},
+		}},
+		{"timestamp not a string", map[string]interface{}{
+			"calendar": map[string]interface{}{"type": "calendar", "timestamp": 12345.0, "data": freshData},
+		}},
+		{"unparseable timestamp", map[string]interface{}{
+			"calendar": map[string]interface{}{"type": "calendar", "timestamp": "not-a-time", "data": freshData},
+		}},
+		{"missing data key", map[string]interface{}{
+			"calendar": map[string]interface{}{
+				"type":      "calendar",
+				"timestamp": time.Now().UTC().Format(time.RFC3339),
+			},
+		}},
+		{"data not a map", map[string]interface{}{
+			"calendar": map[string]interface{}{
+				"type":      "calendar",
+				"timestamp": time.Now().UTC().Format(time.RFC3339),
+				"data":      []interface{}{"wrong shape"},
+			},
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Nil(t, feedData(tc.cache, "calendar"))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// feedData: TTL freshness gate — stale entries are treated as absent
+// ---------------------------------------------------------------------------
+
+func TestFeedData_FreshnessGate(t *testing.T) {
+	now := time.Now()
+
+	withTTL := func(data map[string]interface{}, ttl float64) map[string]interface{} {
+		// ttl_seconds arrives as float64 after a JSON cache round-trip.
+		data["ttl_seconds"] = ttl
+		return data
+	}
+
+	tests := []struct {
+		name     string
+		envelope map[string]interface{}
+		wantData bool
+	}{
+		{
+			name:     "fresh envelope within default TTL",
+			envelope: calendarEnvelopeAt(now, upcomingCalendarData(now.Add(time.Hour))),
+			wantData: true,
+		},
+		{
+			name: "stale envelope past default TTL",
+			envelope: calendarEnvelopeAt(
+				now.Add(-time.Duration(bridge.DefaultTTLSeconds+60)*time.Second),
+				upcomingCalendarData(now.Add(time.Hour)),
+			),
+			wantData: false,
+		},
+		{
+			name: "custom ttl_seconds keeps older entry fresh",
+			envelope: calendarEnvelopeAt(
+				now.Add(-400*time.Second),
+				withTTL(upcomingCalendarData(now.Add(time.Hour)), 600),
+			),
+			wantData: true,
+		},
+		{
+			name: "custom ttl_seconds expires entry before default TTL",
+			envelope: calendarEnvelopeAt(
+				now.Add(-200*time.Second),
+				withTTL(upcomingCalendarData(now.Add(time.Hour)), 120),
+			),
+			wantData: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := map[string]interface{}{"calendar": tc.envelope}
+			data := feedData(cache, "calendar")
+			if tc.wantData {
+				require.NotNil(t, data, "fresh envelope must yield its data map")
+				assert.Contains(t, data, "next_event")
+			} else {
+				assert.Nil(t, data, "stale envelope must be treated as absent")
+			}
+		})
+	}
+}
+
+func TestFeedData_PlaceholderSourceReturnsNil(t *testing.T) {
+	cache := map[string]interface{}{
+		"calendar": calendarEnvelopeAt(time.Now(), map[string]interface{}{
+			"source":     "placeholder",
+			"next_event": map[string]interface{}{"name": "Standup"},
+		}),
+	}
+	assert.Nil(t, feedData(cache, "calendar"), "placeholder data must be treated as absent")
+}
+
+// ---------------------------------------------------------------------------
+// renderCalendarSegment: fresh/stale/missing cache
+// ---------------------------------------------------------------------------
+
+func TestRenderCalendarSegment_FreshCacheRenders(t *testing.T) {
+	// Presence detector: proves the assertions below can distinguish
+	// rendered-vs-omitted, so the stale/missing empty results are meaningful.
+	cache := map[string]interface{}{
+		"calendar": calendarEnvelopeAt(time.Now(), upcomingCalendarData(time.Now().Add(45*time.Minute))),
+	}
+
+	got := stripANSI(renderCalendarSegment(cache))
+	require.NotEmpty(t, got, "fresh calendar envelope must render a segment")
+	assert.Contains(t, got, "\U0001f4c5")
+	assert.Contains(t, got, "Standup")
+	assert.Contains(t, got, "in ", "relative time must be computed from the absolute start")
+}
+
+func TestRenderCalendarSegment_StaleCacheOmitted(t *testing.T) {
+	// Same payload as the fresh case — only the embedded timestamp differs.
+	// A dead daemon leaves exactly this shape behind: valid event data with
+	// an aging timestamp. Past TTL the segment must vanish, not linger.
+	cache := map[string]interface{}{
+		"calendar": calendarEnvelopeAt(
+			time.Now().Add(-time.Duration(bridge.DefaultTTLSeconds+60)*time.Second),
+			upcomingCalendarData(time.Now().Add(45*time.Minute)),
+		),
+	}
+
+	assert.Empty(t, renderCalendarSegment(cache), "stale calendar envelope must render nothing")
+}
+
+func TestRenderCalendarSegment_MissingCacheOmitted(t *testing.T) {
+	assert.Empty(t, renderCalendarSegment(nil), "nil cache must render nothing")
+	assert.Empty(t, renderCalendarSegment(map[string]interface{}{}), "absent feed must render nothing")
+}
+
+func TestRenderCalendarSegment_NextEventVariants(t *testing.T) {
+	fresh := func(nextEvent interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"calendar": calendarEnvelopeAt(time.Now(), map[string]interface{}{
+				"next_event": nextEvent,
+			}),
+		}
+	}
+
+	t.Run("static time fallback when start missing", func(t *testing.T) {
+		got := stripANSI(renderCalendarSegment(fresh(map[string]interface{}{
+			"name": "1:1",
+			"time": "3pm",
+		})))
+		assert.Contains(t, got, "1:1 3pm")
+	})
+
+	t.Run("name-only map renders name", func(t *testing.T) {
+		got := stripANSI(renderCalendarSegment(fresh(map[string]interface{}{
+			"name": "Focus block",
+		})))
+		assert.Contains(t, got, "Focus block")
+	})
+
+	t.Run("empty map omitted", func(t *testing.T) {
+		assert.Empty(t, renderCalendarSegment(fresh(map[string]interface{}{})))
+	})
+
+	t.Run("empty string omitted", func(t *testing.T) {
+		assert.Empty(t, renderCalendarSegment(fresh("")))
+	})
+
+	t.Run("unexpected type omitted", func(t *testing.T) {
+		assert.Empty(t, renderCalendarSegment(fresh(42.0)))
+	})
+}

--- a/internal/chaos/calendar_chaos_test.go
+++ b/internal/chaos/calendar_chaos_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+
+// Calendar entries in the chaos matrix (scout hw-xthx blind spot #4).
+// The calendar feed had zero chaos coverage while weather/pulse were
+// exercised; these tests mirror the existing corrupt-cache and
+// producer-panic patterns for calendar, and add the dead-daemon staleness
+// transition (embedded timestamp past TTL while file mtime stays fresh).
+package chaos
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishnujayvel/hookwise/internal/bridge"
+	"github.com/vishnujayvel/hookwise/internal/core"
+	"github.com/vishnujayvel/hookwise/internal/feeds"
+)
+
+// calendarFeedData returns calendar data in the schema pinned by
+// feeds.CalendarTestFixture, with an upcoming next_event.
+func calendarFeedData(eventStart time.Time) map[string]interface{} {
+	start := eventStart.UTC().Format(time.RFC3339)
+	return map[string]interface{}{
+		"events": []interface{}{
+			map[string]interface{}{
+				"name":       "Standup",
+				"start":      start,
+				"end":        eventStart.Add(30 * time.Minute).UTC().Format(time.RFC3339),
+				"all_day":    false,
+				"is_current": false,
+			},
+		},
+		"next_event": map[string]interface{}{
+			"name":  "Standup",
+			"start": start,
+		},
+	}
+}
+
+// TestChaos_CalendarCorruptCacheSkipped verifies that CollectFeedCache
+// returns a valid calendar entry while skipping corrupt sibling files —
+// the calendar mirror of TestChaos_CorruptCacheSkipped.
+func TestChaos_CalendarCorruptCacheSkipped(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "feed-cache")
+	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
+
+	validData := map[string]interface{}{
+		"type":      "calendar",
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"data":      calendarFeedData(time.Now().Add(time.Hour)),
+	}
+	validJSON, err := json.MarshalIndent(validData, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "calendar.json"), validJSON, 0o600))
+
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "corrupt1.json"), []byte("{{{invalid"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "corrupt2.json"), []byte(""), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "corrupt3.json"), []byte{0xFF, 0xFE, 0x00, 0x01}, 0o600))
+
+	collected, err := bridge.CollectFeedCache(cacheDir)
+	require.NoError(t, err, "CollectFeedCache should not error on corrupt siblings")
+	require.Contains(t, collected, "calendar", "valid calendar entry should be collected")
+
+	calEntry, ok := collected["calendar"].(map[string]interface{})
+	require.True(t, ok, "calendar entry should be a map")
+	assert.Equal(t, "calendar", calEntry["type"])
+	assert.True(t, bridge.IsEnvelopeFresh(calEntry), "just-written calendar entry should be fresh")
+
+	for _, name := range []string{"corrupt1", "corrupt2", "corrupt3"} {
+		assert.NotContains(t, collected, name, "%s should be skipped", name)
+	}
+}
+
+// TestChaos_CalendarProducerPanicRecovery verifies that a panicking calendar
+// producer cannot crash the daemon or block sibling feeds, and leaves no
+// calendar cache file behind — the calendar mirror of
+// TestChaos_ProducerPanicRecovery.
+func TestChaos_CalendarProducerPanicRecovery(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", tmpDir)
+
+	cacheDir := filepath.Join(tmpDir, "feed-cache")
+	pidFile := filepath.Join(tmpDir, "test-daemon.pid")
+
+	registry := feeds.NewRegistry()
+	registry.Register(&panicProducer{name: "calendar", panicMsg: "calendar chaos panic"})
+	registry.Register(&goodProducer{
+		name: "survivor",
+		data: map[string]interface{}{"alive": true},
+	})
+
+	// Calendar is a recognised feed and defaults to disabled; enable it so the
+	// daemon actually polls the panicking producer instead of skipping it.
+	daemon := feeds.NewDaemon(core.DaemonConfig{}, core.FeedsConfig{
+		Calendar: core.CalendarFeedConfig{Enabled: true},
+	}, registry)
+	daemon.SetPIDFile(pidFile)
+	daemon.SetCacheDir(cacheDir)
+	// Isolate the unix socket: DefaultSocketPath is frozen at init and ignores
+	// HOOKWISE_STATE_DIR (#228).
+	daemon.SetSocketPath(shortSocketPath(t))
+	daemon.SetStaggerOffset(0)
+
+	require.NoError(t, daemon.Start())
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filepath.Join(cacheDir, "survivor.json"))
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "survivor.json was not written before timeout")
+	require.NoError(t, daemon.Stop())
+
+	assert.FileExists(t, filepath.Join(cacheDir, "survivor.json"),
+		"sibling feed should still write cache despite panicking calendar producer")
+
+	_, err := os.Stat(filepath.Join(cacheDir, "calendar.json"))
+	assert.True(t, os.IsNotExist(err), "panicking calendar producer should not have written a cache file")
+}
+
+// TestChaos_CalendarDeadDaemonStaleTransition verifies the fresh→stale
+// transition for a calendar envelope left behind by a stopped daemon: the
+// entry stays fresh right after the daemon dies, and flips stale once its
+// embedded timestamp ages past the daemon-injected ttl_seconds — even though
+// the cache file's mtime is current. Consumers keying on IsEnvelopeFresh
+// (the Go status line) drop the segment; nothing may key on mtime.
+func TestChaos_CalendarDeadDaemonStaleTransition(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOOKWISE_STATE_DIR", tmpDir)
+
+	cacheDir := filepath.Join(tmpDir, "feed-cache")
+	pidFile := filepath.Join(tmpDir, "test-daemon.pid")
+
+	registry := feeds.NewRegistry()
+	registry.Register(&goodProducer{
+		name: "calendar",
+		data: calendarFeedData(time.Now().Add(time.Hour)),
+	})
+
+	daemon := feeds.NewDaemon(core.DaemonConfig{}, core.FeedsConfig{
+		Calendar: core.CalendarFeedConfig{Enabled: true},
+	}, registry)
+	daemon.SetPIDFile(pidFile)
+	daemon.SetCacheDir(cacheDir)
+	daemon.SetSocketPath(shortSocketPath(t))
+	daemon.SetStaggerOffset(0)
+
+	cacheFile := filepath.Join(cacheDir, "calendar.json")
+	require.NoError(t, daemon.Start())
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(cacheFile)
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "calendar.json was not written before timeout")
+	require.NoError(t, daemon.Stop())
+
+	// Right after the daemon dies the leftover envelope is still fresh.
+	collected, err := bridge.CollectFeedCache(cacheDir)
+	require.NoError(t, err)
+	envelope, ok := collected["calendar"].(map[string]interface{})
+	require.True(t, ok, "calendar entry should be a map")
+	require.True(t, bridge.IsEnvelopeFresh(envelope), "envelope must be fresh immediately after daemon stop")
+
+	data, ok := envelope["data"].(map[string]interface{})
+	require.True(t, ok)
+	ttl, ok := data["ttl_seconds"].(float64)
+	require.True(t, ok, "daemon must inject ttl_seconds into the calendar envelope")
+
+	// Age the embedded timestamp past TTL. Rewriting the file sets its mtime
+	// to NOW: mtime-fresh, content-stale — the dead-daemon divergence.
+	raw, err := os.ReadFile(cacheFile)
+	require.NoError(t, err)
+	var onDisk map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	agedTS := time.Now().Add(-(time.Duration(ttl)*time.Second + time.Minute))
+	onDisk["timestamp"] = agedTS.UTC().Format(time.RFC3339)
+	aged, err := json.Marshal(onDisk)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(cacheFile, aged, 0o600))
+
+	info, err := os.Stat(cacheFile)
+	require.NoError(t, err)
+	require.Less(t, time.Since(info.ModTime()), time.Minute,
+		"file mtime must be fresh — staleness must come from the embedded timestamp")
+
+	collected, err = bridge.CollectFeedCache(cacheDir)
+	require.NoError(t, err)
+	staleEnvelope, ok := collected["calendar"].(map[string]interface{})
+	require.True(t, ok)
+	assert.False(t, bridge.IsEnvelopeFresh(staleEnvelope),
+		"envelope aged past ttl_seconds must be stale despite a fresh file mtime")
+}


### PR DESCRIPTION
Blind spot #4 from the calendar-staleness scout (hw-xthx): calendar had zero integration/chaos coverage and the status-line calendar render path had no direct tests. Adds: dead-daemon e2e (daemon stopped, cache aged past TTL via embedded timestamp, status line must omit the segment; fresh control case proves detection), calendar in the chaos matrix mirroring weather/pulse, and direct feedData/renderCalendarSegment tests for fresh/stale/missing. Integration-tagged (nightly tier per #228 convention) with full state-dir isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for calendar status-line rendering, including upcoming event display and relative timing.
  * Added validation that stale or missing calendar data is omitted from output.
  * Added resilience checks for malformed cache files and producer failures.
  * Verified cached calendar data becomes stale after the daemon stops, even when files appear recently modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->