### PR TITLE
fix(test): pin HOOKWISE_STATE_DIR in TestDefaultSnapshotsDir (hw-gzz4)

### DIFF
--- a/internal/analytics/snapshot_test.go
+++ b/internal/analytics/snapshot_test.go
@@ -188,7 +188,11 @@ func TestPruneSnapshots_IgnoresNonSnapshotFiles(t *testing.T) {
 }
 
 // TestDefaultSnapshotsDir verifies the default path is under ~/.hookwise.
+// HOOKWISE_STATE_DIR is pinned empty because test harnesses (task test:go:unit)
+// inject it for isolation, which would redirect the default away from ~/.hookwise.
 func TestDefaultSnapshotsDir(t *testing.T) {
+	t.Setenv("HOOKWISE_STATE_DIR", "")
+
 	got := DefaultSnapshotsDir()
 	assert.True(t, strings.HasSuffix(got, filepath.Join(".hookwise", "snapshots")),
 		"DefaultSnapshotsDir should end in .hookwise/snapshots, got %q", got)


### PR DESCRIPTION
Polecat-filed P1: TestDefaultSnapshotsDir asserted the frozen ~/.hookwise/snapshots literal, failing under the guarded runner which injects HOOKWISE_STATE_DIR=mktemp. Test now pins its own state-dir env (same pattern as PR #227's tuiPIDPath fix); prod default untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ