### PR TITLE
test: address CodeRabbit follow-ups from PRs 251+253 (hw-qby9)

### DIFF
--- a/cmd/hookwise/cmd_status_line_calendar_test.go
+++ b/cmd/hookwise/cmd_status_line_calendar_test.go
@@ -144,7 +144,7 @@ func TestCalendarRelativeTime_NonUTCOffsets(t *testing.T) {
 		{
 			name:  "tomorrow label shows the event's own wall clock",
 			now:   time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC),
-			event: time.Date(2026, 6, 17, 9, 0, 0, 0, ist), // 2026-06-16 03:30 UTC, 41.5h out
+			event: time.Date(2026, 6, 17, 9, 0, 0, 0, ist), // 2026-06-17 03:30 UTC, 41.5h out
 			want:  "tomorrow 9:00am",
 		},
 		{

--- a/internal/feeds/producer_calendar_pinned_test.go
+++ b/internal/feeds/producer_calendar_pinned_test.go
@@ -158,6 +158,9 @@ func calendarEvents(t *testing.T, result interface{}) []interface{} {
 func TestCalendarProducer_Pinned_Genuine200EmptyItems_OverwritesGoodCache(t *testing.T) {
 	mock := &pinnedCalendarMock{totalEvents: 1}
 	srv := httptest.NewServer(mock)
+	// Poll 3 closes srv mid-test on purpose; this defer only covers early
+	// require failures (Close is idempotent).
+	defer srv.Close()
 
 	p := newPinnedCalendarProducer(t, srv.URL)
 

--- a/scripts/test-publish-check.sh
+++ b/scripts/test-publish-check.sh
@@ -183,6 +183,12 @@ assert "No args → refuses bad commit ahead of github/main" \
     1 "bad type" # no range args
 
 new_repo
+git -C "$REPO" update-ref refs/remotes/origin/main main
+repo_commit "feat: ahead of origin main"
+assert "No args, no github/main → falls back to origin/main" \
+    0 "origin/main..HEAD" # no range args
+
+new_repo
 assert "No github/origin base and no args → exit 2" \
     2 "cannot resolve" # no range args
 


### PR DESCRIPTION
Factory-authored (bead hw-qby9). Picks up three valid-but-minor CodeRabbit review comments that were merged past on already-green PRs #251 and #253. Test files only, zero production code:

1. **scripts/test-publish-check.sh** — new Group 4 test covering the `origin/main` fallback branch of publish-check's default-range resolution (previously untested).
2. **cmd_status_line_calendar_test.go** — comment-only fix: the "tomorrow label" case said 2026-06-16 03:30 UTC but the time.Date is 2026-06-17 03:30 UTC (asserted 41.5h value was already correct).
3. **producer_calendar_pinned_test.go** — `defer srv.Close()` on the empty-200 httptest server so an early require failure can't leak the goroutine (Close is idempotent; the deliberate mid-test Close still works).

Validation-tier: V1 (test-only). Bead closed by refinery at mirror 7ac930b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for default branch-range fallback behavior when the primary remote reference is unavailable.
  * Improved test reliability by ensuring temporary test resources are cleaned up after failures.
  * Corrected an inline test comment describing calendar time calculations; test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->