### PR TITLE
docs: rewrite README guards-first per positioning research (hw-g7p5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,39 +8,43 @@
 |_| |_|\___/ \___/|_|\_\  \_/\_/ |_|___/\___|
 ```
 
-**Awareness framework for AI-augmented development.**
+**Guardrails & policy engine for Claude Code.**
 
 [![CI](https://img.shields.io/github/actions/workflow/status/vishnujayvel/hookwise/ci.yml?branch=main)](https://github.com/vishnujayvel/hookwise/actions)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-<img src="screenshots/hero-banner.png" alt="hookwise — peripheral vision for your AI coding workflow" width="700">
+<img src="screenshots/hero-banner.png" alt="hookwise — guardrails and policy engine for Claude Code" width="700">
 
 </div>
 
-## The Problem
+## Stop the command before it runs
 
-AI coding tools are powerful. They're also making developers slower, more burned out, and less aware of what's actually happening in their workflow.
+Your AI agent is one autocomplete away from `rm -rf`, a force push, or a `DROP TABLE`. hookwise puts a declarative policy layer between Claude Code and your shell:
 
-> *"Developers predicted AI would make them 24% faster. They were 19% slower. They still believed they were faster."*
-> — [METR Randomized Controlled Trial](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/), 2025
+```yaml
+# hookwise.yaml
+guards:
+  - match: "Bash"
+    action: block
+    when: 'tool_input.command contains "rm -rf"'
+    reason: "Dangerous command blocked"
+```
 
-The research is clear:
+When Claude tries it, the tool call is denied before execution and Claude sees your reason — no bash scripting, no wrapper processes, no cloud service. One YAML file, evaluated locally on every `PreToolUse` event.
 
-- **19% slower** with AI tools, despite feeling faster ([METR RCT, 246 real GitHub issues](https://arxiv.org/abs/2507.09089))
-- **66% spend more time** fixing "almost-right" AI code ([Stack Overflow 2025, 49K+ devs](https://stackoverflow.blog/2025/12/29/developers-remain-willing-but-reluctant-to-use-ai-the-2025-developer-survey-results-are-here/))
-- **Trust in AI dropped** from 40% to 29% year-over-year ([Stack Overflow 2025](https://stackoverflow.blog/2025/12/29/developers-remain-willing-but-reluctant-to-use-ai-the-2025-developer-survey-results-are-here/))
+<img src="screenshots/guard-demo.gif" alt="Guard blocking a dangerous rm -rf" width="700">
 
-Researchers at UC Berkeley studied this for 8 months and found three forms of AI work intensification: **task expansion** (absorbing other roles), **blurred boundaries** (work becomes ambient), and **increased multitasking** (cognitive overload despite *feeling* productive). Their prescription: *intentional pauses, sequencing, and human grounding* ([HBR, Feb 2026](https://hbr.org/2026/02/ai-doesnt-reduce-work-it-intensifies-it)).
+### Guard semantics
 
-**hookwise gives you all three — as a framework, not willpower.**
+- **Three actions**: `block` (deny the tool call), `confirm` (force Claude Code's permission prompt), `warn` (inject a warning into Claude's context and continue).
+- **Operators**: `contains`, `starts_with`, `ends_with`, `equals`/`==`, and `matches` (regex). Tool matching (`match:`) takes exact names or globs (`mcp__*`).
+- **First-match-wins** — rules read top-to-bottom like a firewall.
+- **Fail-open by design** — if hookwise itself errors, the dispatcher exits 0 and your session keeps working. A safety tool that can break your editor isn't a safety tool.
+- **Local and declarative** — rules live in your repo, review like code, and need no network.
 
-## Why hookwise?
-
-Your AI keeps you productive. hookwise keeps you **mindful**.
-
-It's a config-driven awareness layer for [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) — one YAML file that adds guard rails, metacognition prompts, workflow insights, and an ambient status line to every session. If hookwise errors, it fails open — your AI keeps working.
-
-> *Guard rails should be boring. The exciting part is what you build when you're not worried about what your AI is doing.*
+<div align="center">
+<img src="screenshots/guard-evaluation-flow.png" alt="Guard evaluation flow — hookwise.yaml rules are matched by tool name, then condition, resulting in block, confirm, or warn actions" width="500">
+</div>
 
 ### Without hookwise
 
@@ -57,18 +61,7 @@ if echo "$CMD" | grep -q "rm -rf"; then
 fi
 ```
 
-### With hookwise
-
-```yaml
-# hookwise.yaml — add a rule, remove a rule, done
-guards:
-  - match: "Bash"
-    action: block
-    when: 'tool_input.command contains "rm -rf"'
-    reason: "Dangerous command blocked"
-```
-
-One file. Claude Code reads it, understands it, and can even help you write new rules. No bash scripts to debug.
+With hookwise: add a rule, remove a rule, done. Claude Code reads the YAML, understands it, and can even help you write new rules.
 
 ## How It Compares
 
@@ -77,10 +70,9 @@ One file. Claude Code reads it, understands it, and can even help you write new 
 | Guard rails | Declarative YAML | Manual bash | No |
 | Testing | GuardTester + HookRunner | Manual | N/A |
 | Analytics | SQLite, queryable | DIY | Display-only |
-| Workflow insights | Friction signals, session pulse | No | No |
-| Configuration | One YAML file | Scattered scripts | JSON/TUI |
-| Recipes | 11 built-in, shareable | N/A | N/A |
 | Cost tracking | Budgets + alerts | DIY | Current session only |
+| Configuration | One YAML file | Scattered scripts | JSON/TUI |
+| Recipes | 10 built-in, shareable | N/A | N/A |
 
 ## Quick Start
 
@@ -98,58 +90,68 @@ hookwise doctor
 
 > Prebuilt binaries (darwin/linux × amd64/arm64) are published to [GitHub Releases](https://github.com/vishnujayvel/hookwise/releases). The installer grabs the right one for your platform.
 
+`hookwise init --wire` registers the dispatcher and status line in `.claude/settings.json` for you — idempotently, with a pre-flight safety audit, an automatic backup, and `--dry-run` / `--unwire` escape hatches. A single dispatcher binary understands all 13 hook events; `--wire` registers `PreToolUse` and `PostToolUse` by default, and `--events` adds more. Prefer to edit settings yourself? [Manual setup &rarr;](docs/guide/getting-started.md)
+
+Before it writes anything, `hookwise init` also inventories the hooks you already have (user settings are never modified) and saves the pre-init snapshot to `~/.hookwise/hook-audit.json`.
+
+## Cost Analytics & Budgets
+
+Every session is tracked in a local SQLite database: tool calls, file edits, duration, and per-model token cost computed from your actual Claude Code transcripts.
+
+```bash
+hookwise stats     # today's sessions, cost, tool breakdown, dispatch latency
+```
+
+<img src="screenshots/stats.png" alt="hookwise stats" width="600">
+
+Set a daily budget and pick how hard it bites:
+
+```yaml
+cost_tracking:
+  enabled: true
+  daily_budget: 25.00
+  enforcement: warn      # notify when you cross the line (default)
+  # enforcement: enforce # hard-deny further tool calls until tomorrow
+```
+
+In `enforce` mode the budget is a guard, not a suggestion: once today's spend crosses the limit, `PreToolUse` calls are denied with the reason. `hookwise diff` and `hookwise log` compare analytics snapshots over time.
+
+> Why measure? Developers in a randomized trial predicted AI made them 24% faster — they were 19% slower, and still believed they were faster ([METR RCT, 2025](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/)). Local data closes the perception gap.
+
+## Status Line with Live Feeds
+
+Composable segments for Claude Code's status bar, powered by a [background daemon](docs/features/feeds.md) — the piece no display-only statusline tool has. Mix `cost`, `project`, `calendar`, `weather`, `news`, and `insights`:
+
+```yaml
+status_line: { enabled: true, segments: [cost, project, calendar, weather] }
+```
+
+<img src="screenshots/status-line-insights.gif" alt="hookwise status line — friction tips, pace metrics, and calendar awareness" width="700">
+
+The daemon is a shared singleton: it polls 6 built-in feed producers (plus your custom feeds) on staggered intervals and writes an atomic JSON cache with per-key TTL. Segments read from cache with freshness checks; a stale or unavailable feed silently disappears instead of breaking your prompt (fail-open again). Cost is computed live from the analytics DB at render time. When two or more sessions are active, a fleet badge shows cross-session status (`fleet run:2 done:1`).
+
+Feeds are configured once, in the global `~/.hookwise/config.yaml` — `hookwise doctor` reports feed health against the daemon's *actual* runtime config and warns if a project file carries a `feeds:` block (which the daemon ignores).
+
+<div align="center">
+<img src="screenshots/feed-architecture.png" alt="Feed platform architecture — data sources flow through a background daemon into an atomic cache bus, then to the status line segments" width="600">
+</div>
+
+## Keep the Whole Hook Setup Healthy
+
+**`hookwise audit`** scans your Claude Code settings files and flags hook-safety issues: sprawl, missing binaries, network-dependent hooks on hot paths, and duplicate or overlapping hooks. `--json` emits a schema-versioned report for CI (exits 0 on PASS/WARN, 1 on FAIL); `--fix` interactively removes duplicates; `--project-dir` scans a project's `.claude/` settings instead of your user-level settings.
+
+**`hookwise doctor`** checks your config, state directory, analytics DB, daemon liveness, and per-feed health — measured against the daemon's *effective* runtime config, not just what's on disk. It's honest about disabled subsystems: a feed you turned off reports as `disabled`, and $0 with cost tracking off is "expected", not a malfunction warning.
+
 <div align="center">
 <img src="screenshots/doctor-v1.3.png" alt="hookwise doctor output — all checks passed" width="600">
 </div>
-
-`hookwise doctor` checks your config, state directory, analytics DB, daemon liveness, and per-feed health — measured against the daemon's *effective* runtime config, not just what's on disk. It's honest about disabled subsystems: a feed you turned off reports as `disabled`, and $0 with cost tracking off is "expected", not a malfunction warning.
-
-`hookwise init --wire` registers the dispatcher and status line in `.claude/settings.json` for you — idempotently, with a pre-flight safety audit, an automatic backup, and `--dry-run` / `--unwire` escape hatches. One dispatcher handles all 13 hook events. Prefer to edit settings yourself? [Manual setup &rarr;](docs/guide/getting-started.md)
-
-Before it writes anything, `hookwise init` also inventories the hooks you already have (user settings are never modified) and saves the pre-init snapshot to `~/.hookwise/hook-audit.json`.
 
 ## How It Works
 
 Every hook event passes through a three-phase execution engine. Guards protect, context enriches, side effects observe. If anything errors, it fails open — your AI keeps working.
 
 <div align="center">
-<img src="screenshots/execution-engine.png" alt="Three-phase execution engine — Phase 1: Guards (block/confirm/warn), Phase 2: Context (enrich tool calls), Phase 3: Side Effects (log, coach, analytics). Fail-open: any error exits 0." width="650">
-</div>
-
-## What You Get
-
-**[Guard Rails](docs/features/guards.md)** -- Declarative rules with firewall semantics. `block`, `confirm`, or `warn` with glob patterns and operators like `contains`, `matches`, `starts_with`.
-
-<img src="screenshots/guard-demo.gif" alt="Guard blocking a dangerous rm -rf" width="700">
-
-<div align="center">
-<img src="screenshots/guard-evaluation-flow.png" alt="Guard evaluation flow — hookwise.yaml rules are matched by tool name, then condition, resulting in block, confirm, or warn actions" width="500">
-</div>
-
-**Hook Audit** -- `hookwise audit` scans your Claude Code settings files and flags hook-safety issues: sprawl, missing binaries, network-dependent hooks on hot paths, and duplicate or overlapping hooks. `--json` emits a schema-versioned report for CI (exits 0 on PASS/WARN, 1 on FAIL); `--project-dir` scans a project's `.claude/` settings instead of your user-level settings.
-
-**[Coaching](docs/features/coaching.md)** -- Periodic **metacognition prompts** that break autopilot mode: *"Are you solving the right problem, or the most interesting one?"* Research on AI-assisted programming shows students who plan before coding outperform those who jump straight to debugging ([AIED 2025](https://arxiv.org/abs/2509.03171)) — hookwise makes planning-first the default.
-
-**[Status Line](docs/features/status-line.md)** -- Composable segments powered by a [background daemon](docs/features/feeds.md) with 6 built-in feed producers plus custom feeds. Mix `cost`, `project`, `calendar`, `weather`, `news`, `insights`, and more. Peripheral vision for your development flow — you don't stare at it, but you glance at it.
-
-<img src="screenshots/status-line-insights.gif" alt="hookwise status line — friction tips, pace metrics, and calendar awareness" width="700">
-
-**[Workflow Insights](docs/features/feeds.md)** -- Surfaces friction patterns with actionable tips, pace metrics, and session health. The data your workflow already generates but never shows you.
-
-**[Feed Platform](docs/features/feeds.md)** -- A background daemon polls 6 built-in producers (plus your custom feeds) on staggered intervals and writes to an atomic cache bus with per-key TTL. Status line segments read from cache with `isFresh()` checks. If a feed is unavailable or stale, its segments silently disappear (fail-open). The daemon is a singleton shared by every project, so feeds are configured once, in the global `~/.hookwise/config.yaml` — `hookwise doctor` reports feed health against the daemon's *actual* runtime config and warns if a project file carries a `feeds:` block (which the daemon ignores).
-
-<div align="center">
-<img src="screenshots/feed-architecture.png" alt="Feed platform architecture — data sources flow through a background daemon into an atomic cache bus, then to the status line segments" width="600">
-</div>
-
-**[Analytics](docs/features/analytics.md)** -- SQLite-backed session tracking: tool calls, duration, cost, daily budgets. Close the perception gap between how fast you *feel* and how fast you *are*.
-
-<img src="screenshots/stats.png" alt="hookwise stats" width="600">
-
-**[Interactive TUI](docs/cli.md)** _(optional · experimental)_ -- A full-screen Python/[Textual](https://textual.textualize.io) dashboard with 7 tabs. It ships **separately** from the core binary (the core CLI, guards, analytics, and status line need no Python). Install it from the `tui/` directory (e.g. `uv tool install ./tui`); once `hookwise-tui` is on your PATH, launch it on demand with `hookwise tui`, or set `tui.auto_launch: true` to open it in a separate terminal on session start.
-
-<div align="center">
-<img src="screenshots/tui-insights.png" alt="hookwise TUI — Claude Code usage insights with session metrics, trends, and tool breakdown" width="700">
+<img src="screenshots/execution-engine.png" alt="Three-phase execution engine — Phase 1: Guards (block/confirm/warn), Phase 2: Context (enrich tool calls), Phase 3: Side Effects (log, analytics). Fail-open: any error exits 0." width="650">
 </div>
 
 ## Configuration
@@ -163,15 +165,13 @@ guards:
     action: block
     when: 'tool_input.command contains "rm -rf"'
     reason: "Dangerous command blocked"
-coaching:
-  metacognition: { enabled: true, interval_seconds: 300 }
 analytics: { enabled: true }
 status_line: { enabled: true, segments: [cost, project, calendar] }
 ```
 
-Global config at `~/.hookwise/config.yaml` applies everywhere. Project-level `hookwise.yaml` overrides per workspace — with one exception: the `feeds:` block only takes effect in the global config, because the feed daemon is a shared singleton. A project-level `feeds:` block is ignored, and `hookwise doctor` warns about it.
+Global config at `~/.hookwise/config.yaml` applies everywhere. Project-level `hookwise.yaml` overrides per workspace — with one exception: the `feeds:` block only takes effect in the global config, because the feed daemon is a shared singleton.
 
-## Testing
+## Testing Guards Like Code
 
 ```go
 import hwtesting "github.com/vishnujayvel/hookwise/pkg/hookwise/testing"
@@ -182,15 +182,28 @@ result := tester.Evaluate("Bash", map[string]any{"command": "rm -rf /"})
 assert.Equal(t, "block", result.Action)
 ```
 
-Go test helpers in `pkg/hookwise/testing`. [Details &rarr;](docs/cli.md)
+Go test helpers in `pkg/hookwise/testing`, plus `hookwise test` for YAML-defined guard scenarios. [Details &rarr;](docs/cli.md)
 
 ## Recipes
 
-11 built-in -- [see all](recipes/) or [create your own](docs/guide/creating-a-recipe.md):  `block-dangerous-commands`, `metacognition-prompts`, `commit-without-tests`, and more.
+10 built-in — [see all](recipes/) or [create your own](docs/guide/creating-a-recipe.md): `block-dangerous-commands`, `secret-scanning`, `commit-without-tests`, `cost-tracking`, and more. Ready-made hook configs you can copy into a project and adapt.
+
+## Maturity: What's Solid, What's Early
+
+Honest labels, so you know what you're opting into:
+
+- **Stable** — guards, dispatch engine, cost analytics, status line + feed daemon, `init`/`doctor`/`audit`. This is the core, and it's what the test suite (unit, contract, integration, chaos, mutation) hammers on.
+- **Early / power-user opt-in** — the **interactive TUI**: a full-screen Python/[Textual](https://textual.textualize.io) dashboard with 7 tabs. It ships **separately** from the core binary (the core CLI needs no Python). Install from the `tui/` directory (e.g. `uv tool install ./tui`); auto-launch is **off by default** (`tui.auto_launch: true` to opt in).
+- **Experimental** — **notifications**: today this is a single in-app producer (daily budget-threshold alert) surfaced via `hookwise notifications` and a status-line badge. There are no push/email/Slack channels, and we've deliberately de-scoped delivery — Claude Code ships native push notifications itself (since v2.1.110), so hookwise focuses on deciding *what's worth alerting on*, not on the pipe.
+- **Narrow** — behavioral "coaching" exists only as two opt-in recipes (`builder-trap-detection`, `ai-dependency-tracker`), not as a first-class subsystem.
+
+<div align="center">
+<img src="screenshots/tui-insights.png" alt="hookwise TUI — Claude Code usage insights with session metrics, trends, and tool breakdown" width="700">
+</div>
 
 ## Security
 
-hookwise runs inside your Claude Code session -- security is non-negotiable. The full codebase (~80 source files) is reviewed through a dedicated security pipeline on every release:
+hookwise runs inside your Claude Code session — security is non-negotiable. The full codebase (~80 source files) is reviewed through a dedicated security pipeline on every release:
 
 - **4-domain parallel review** covering core engine, CLI, feed producers, and Python TUI
 - **False-positive filtering** with strict exploitability criteria (confidence >= 8/10)
@@ -205,7 +218,7 @@ Key design choices: parameterized SQL everywhere, safe YAML parsing only, restri
 | Guide | Reference |
 |-------|-----------|
 | [Getting Started](docs/guide/getting-started.md) | [Guards](docs/features/guards.md) |
-| [Creating a Recipe](docs/guide/creating-a-recipe.md) | [Coaching](docs/features/coaching.md) |
+| [Creating a Recipe](docs/guide/creating-a-recipe.md) | [TUI Guide](docs/reference/tui-guide.md) |
 | [Architecture](docs/architecture.md) | [Feeds](docs/features/feeds.md) |
 | [Philosophy](docs/philosophy.md) | [Status Line](docs/features/status-line.md) |
 | [CLI Reference](docs/cli.md) | [Analytics](docs/features/analytics.md) |
@@ -214,4 +227,4 @@ Key design choices: parameterized SQL everywhere, safe YAML parsing only, restri
 
 `git clone`, `go test -race ./...`, `task pr`. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-[MIT](LICENSE) -- Built by [Vishnu](https://github.com/vishnujayvel). *Born from the gap between how fast AI makes you feel — and how fast you actually are.*
+[MIT](LICENSE) — Built by [Vishnu](https://github.com/vishnujayvel). *Guard rails should be boring. The exciting part is what you build when you're not worried about what your AI is doing.*


### PR DESCRIPTION
Factory-authored (bead hw-g7p5, convoy readme-relaunch). Rewrites the README to lead with the guardrails & policy engine story per the 2026-07-11 positioning research: hero = blocked-dangerous-command example + the YAML guard rule; cost analytics + feed-daemon status line as flagship features; honest maturity labels on TUI (early), coaching (narrow), notifications (experimental — Anthropic ships native push since v2.1.110). Every claim cross-checked against the shipped command surface per the bead's V1 accuracy gate. (Published as a single squashed commit: the two mirror commits cherry-pick-conflict against GitHub's squash history; file content is identical to the factory's final state 406e3f8.)

**DO NOT MERGE until Vishnu reviews** — outward-facing marketing copy, human review gate per the bead brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjWqH4FMkdczkSagzXw3dQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Repositioned the product around guardrails and policy enforcement for Claude Code.
  * Clarified command-blocking behavior, rule evaluation, configuration, and fail-open handling.
  * Expanded onboarding guidance for setup, safety audits, backups, dry runs, and removal.
  * Added or refreshed documentation for cost analytics, budgets, live status feeds, health checks, testing, recipes, and security.
  * Updated configuration examples, comparison tables, navigation links, and product messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->